### PR TITLE
Replaced 'echo into script and sudo' with running the command as it i…

### DIFF
--- a/fabrictestbed_extensions/fablib/abc_fablib.py
+++ b/fabrictestbed_extensions/fablib/abc_fablib.py
@@ -107,4 +107,4 @@ class AbcFabLIB(ABC):
             self.default_slice_key['slice_private_key_file'] = os.environ['FABRIC_SLICE_PRIVATE_KEY_FILE']
         if "FABRIC_SLICE_PRIVATE_KEY_PASSPHRASE" in os.environ:
             #self.slice_private_key_passphrase = os.environ['FABRIC_SLICE_PRIVATE_KEY_PASSPHRASE']
-            self.default_slice_key['slice_private_key_passphrase'] = os.environ['slice_private_key_passphrase']
+            self.default_slice_key['slice_private_key_passphrase'] = os.environ['FABRIC_SLICE_PRIVATE_KEY_PASSPHRASE']

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -240,6 +240,7 @@ class Node():
 
         for attempt in range(retry):
             try:
+
                 if self.get_private_key_passphrase():
                     key = paramiko.RSAKey.from_private_key_file(self.get_private_key_file(),  password=self.get_private_key_passphrase())
                 else:
@@ -259,7 +260,7 @@ class Node():
 
                 client.connect(management_ip,username=self.username,pkey = key, sock=bastion_channel)
 
-                stdin, stdout, stderr = client.exec_command('echo \"' + command + '\" > script.sh; chmod +x script.sh; sudo ./script.sh')
+                stdin, stdout, stderr = client.exec_command(command)
                 rtn_stdout = str(stdout.read(),'utf-8').replace('\\n','\n')
                 rtn_stderr = str(stderr.read(),'utf-8').replace('\\n','\n')
 


### PR DESCRIPTION
…s. Did tests and it doesn't affect anything. Plus a minor fix.

As a matter of fact, the modification seems to work okay with ubuntu machines only. But with centos machines, something is wrong with setting the "network name" values of the "Interface" objects. We shouldn't merge this now.

For example, with centos nodes, this:

    print(slice1.get_node(node1_name).get_interfaces()[0].get_network())

returns `None`.

And this:

    slice.get_node(node1_name).get_interface(network_name="net1")

returns

    ~/Sachen/Work/FABRIC/fabric_python_api_locally/venv1/lib/python3.9/site-packages/fabrictestbed_extensions/fablib/node.py in get_interface(self, name, network_name)
        163         elif network_name != None:
        164             for interface in self.get_interfaces():
    --> 165                 if interface != None and interface.get_network().get_name() == network_name:
        166                     return interface
        167 

    AttributeError: 'NoneType' object has no attribute 'get_name'