### PR TITLE
Add support for SSH config file in Fabric RC

### DIFF
--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -471,6 +471,13 @@ class fablib:
     def is_jupyter_notebook() -> bool:
         return fablib.get_default_fablib_manager().is_jupyter_notebook()
 
+    @staticmethod
+    def get_ssh_config_file() -> str:
+        """
+        Gets the location of the ssh config file specified in the fabric rc.
+        """
+        return fablib.get_default_fablib_manager().get_ssh_config_file()
+
 
 class FablibManager:
     FABRIC_BASTION_USERNAME = "FABRIC_BASTION_USERNAME"
@@ -482,6 +489,7 @@ class FablibManager:
     FABRIC_SLICE_PUBLIC_KEY_FILE = "FABRIC_SLICE_PUBLIC_KEY_FILE"
     FABRIC_SLICE_PRIVATE_KEY_FILE = "FABRIC_SLICE_PRIVATE_KEY_FILE"
     FABRIC_SLICE_PRIVATE_KEY_PASSPHRASE = "FABRIC_SLICE_PRIVATE_KEY_PASSPHRASE"
+    FABRIC_SSH_CONFIG_FILE = "FABRIC_SSH_CONFIG_FILE"
     FABRIC_LOG_FILE = 'FABRIC_LOG_FILE'
     FABRIC_LOG_LEVEL = 'FABRIC_LOG_LEVEL'
     FABRIC_AVOID = 'FABRIC_AVOID'
@@ -666,6 +674,9 @@ class FablibManager:
         if self.FABRIC_SLICE_PRIVATE_KEY_PASSPHRASE in fabric_rc_dict:
             self.default_slice_key['slice_private_key_passphrase'] = fabric_rc_dict[
                 self.FABRIC_SLICE_PRIVATE_KEY_PASSPHRASE]
+        
+        if self.FABRIC_SSH_CONFIG_FILE in fabric_rc_dict:
+            self.ssh_config_file = fabric_rc_dict[self.FABRIC_SSH_CONFIG_FILE]
 
         if self.FABRIC_LOG_FILE in fabric_rc_dict:
             self.set_log_file(fabric_rc_dict[self.FABRIC_LOG_FILE])
@@ -1314,6 +1325,12 @@ class FablibManager:
         else:
             raise Exception(f"Failed to get slice list: {slices}")
         return return_slices
+
+    def get_ssh_config_file(self):
+        """
+        Gets the location of the ssh config file specified in the fabric rc.
+        """
+        return self.ssh_config_file
 
     # def tabulate_slices(self, slices):
     #     table = []

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -797,13 +797,30 @@ class Node:
             logging.error(e, exc_info=True)
             raise Exception(f"Component not found: {name}")
 
+    def get_ssh_config_file(self) -> str:
+        """
+        Gets the SSH config file specified in the fabric rc
+        :return: The path to the SSH config file
+        :rtype: str
+        """
+        return self.get_fablib_manager().get_ssh_config_file()
+
     def get_ssh_command(self) -> str:
         """
         Gets a SSH command used to access this node node from a terminal.
         :return: the SSH command to access this node
         :rtype: str
         """
-        return 'ssh -i {} -F /path/to/your/ssh/config/file {}@{}'.format(self.get_private_key_file(),
+        try:
+            ssh_config_file_path = self.get_ssh_config_file()
+            if not ssh_config_file_path:
+                ssh_config_file_path = "/path/to/your/ssh/config/file"
+        except Exception as e:
+            logging.debug("SSH config file not found in rc, printing default message")
+            ssh_config_file_path = "/path/to/your/ssh/config/file"
+        
+        return 'ssh -i {} -F {} {}@{}'.format(self.get_private_key_file(),
+                                           ssh_config_file_path,
                                            self.get_username(),
                                            self.get_management_ip())
 


### PR DESCRIPTION
Currently the Node.get_ssh_command() doesn't autocomplete the ssh config file to be used (-F option).
I have extended the Fabric RC with a new variable "FABRIC_SSH_CONFIG_FILE" which should be filled out with the fabric specific ssh config file. If not specified if left empty the default action is to keep the message "/path/to/your/ssh/config/file".

An example of the ssh config file could be redirecting all traffic through the bastion host and the config file could look like this:

UserKnownHostsFile /dev/null
StrictHostKeyChecking no
ServerAliveInterval 120 

Host bastion-?.fabric-testbed.net
  User <bastion_username>
  ForwardAgent yes
  Hostname %h
  IdentityFile <bastion_key_file>
  IdentitiesOnly yes

Host * !bastion-?.fabric-testbed.net
  ProxyJump <bastion_username>@bastion-1.fabric-testbed.net:22
  IdentityFile <sliver_key_file>