### PR TITLE
Add a configuration for readthedocs.org

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,11 @@
 # Configuration for readthedocs.org.
+# See https://docs.readthedocs.io/en/latest/config-file/v2.html
 
 version: 2
 
-build:
-  tools:
-    # readthedocs.org uses Python 3.7 by default; fablib has to use
-    # Python 3.9 or greater.
-    python: "3.9"
+python:
+  # readthedocs.org uses Python 3.7 by default; fablib has to use
+  # Python 3.9 or greater.
+  version: "3.9"
+  install:
+    - requirements: requirements.txt    

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+# Configuration for readthedocs.org.
+
+version: 2
+
+build:
+  tools:
+    # readthedocs.org uses Python 3.7 by default; fablib has to use
+    # Python 3.9 or greater.
+    python: "3.9"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,8 @@
 
 version: 2
 
+# readthedocs.org uses Python 3.7 by default; fablib has to use Python
+# 3.9 or greater.  This incantation seems to work.
 build:
   os: ubuntu-20.04
   tools:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,8 @@ build:
   tools:
     python: "3.9"
 
+# Tell RTD location of our Sphinx configuration.  Seems to work
+# without this too, although default is docs/conf.py.
 sphinx:
   configuration: docs/source/conf.py
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,7 @@
 
 version: 2
 
-python:
-  # readthedocs.org uses Python 3.7 by default; fablib has to use
-  # Python 3.9 or greater.
-  version: "3.9"
-  install:
-    - requirements: requirements.txt    
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,5 +11,4 @@ build:
 python:
   install:
     - requirements: docs/requirements.txt
-    - method: pip
-      path: .
+    - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,3 +7,9 @@ build:
   os: ubuntu-20.04
   tools:
     python: "3.9"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,9 @@ build:
   tools:
     python: "3.9"
 
+sphinx:
+  configuration: docs/source/conf.py
+
 python:
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,8 @@ build:
 sphinx:
   configuration: docs/source/conf.py
 
+# To be able to build API documentation, we need to install both docs
+# requirements and package requirements, it seems.
 python:
   install:
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+furo


### PR DESCRIPTION
Addresses #87.

Normally building Sphinx docs on readthedocs.org should work out of the box, without any changes to the source repository.  But we can't use RTD's defaults to build fablib docs, because:

 - fablib needs Python >= 3.9; RTD'd default is Python 3.7.
 - fablib docs use furo theme, and we need to tell RTD to install furo theme.

The defaults are overridden in `.readthedocs.yaml`.  The current results are at https://fabric-fablib.readthedocs.io/en/latest/ (docs built on RTD) and at https://readthedocs.org/projects/fabric-fablib/ (project overview and admin settings).

Some notes:

 - For now, I'm the sole admin of the RTD project; I suppose we should add others (@paul-ruth, @kthare10, and @ibaldin?) once things are proven to be working as desired or whenever folks are ready.
 - I have (temporarily) made RTD's "default branch" this PR branch, instead of the `main` branch.  This is just for conveniently experimenting.  (This setting is under admin > advanced settings > default branch).  I'll switch the default branch to `main` once this PR is merged.
 - I have enabled "build pull requests for this project" at RTD (this setting is also at ), which should send commit statuses to GitHub.  I am guessing that we will get PR statuses once the configuration from this PR is merged.  We probably will have to find out exactly how that works by trial and error. Let us see.
 - I am not sure how to build and host docs for older versions of fablib with RTD -- since RTD needs the configuration file that we're only adding now, and older release tags obviously don't have the said configuration.