### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains implementation of a Python API for
 intereacting with [FABRIC][fabric] testbed, colloquially known as
 "FABlib".
 
-## Installing the Python package
+## Installing fabrictestbed-extensions
 
 Install released versions of FABlib from PyPI:
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ presented with many examples on FABlib usage when you log in there.
 The [notebook sources][fabric-jupyter-examples] can be found on GitHub
 as well.
 
-FABlib API documentation can be found [here][fablib-api-rtd], since
-version 1.4.  Older API docs are [here][fablib-api-old].
+Since FABlib 1.4, API docs can be found [here][fablib-api-rtd].  Older
+API docs are [here][fablib-api-old].
 
 If you want to interact with FABRIC from Jupyter installed on your
 computer, see [Install the FABRIC Python API][fablib-install].

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # fabrictestbed-extensions
-[![Requirements Status](https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements.svg?branch=main)](https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements/?branch=main)
+
+[![requirements-badge](Requirements Status)][requirements]
 
 [![PyPI](https://img.shields.io/pypi/v/fabrictestbed-extensions?style=plastic)](https://pypi.org/project/fabrictestbed-extensions/)
 
@@ -21,3 +22,9 @@ git clone https://github.com/fabric-testbed/fabrictestbed-extensions.git
 cd fabrictestbed-extensions
 pip install --user .
 ```
+
+<!-- Badges -->
+
+[requirements]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements/?branch=main
+[requirements-badge]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements.svg?branch=main
+

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note that installing FABlib using either methods will also install a
 number of dependencies, so you might want to install FABlib in a
 virtual environment.  Your favorite tool for managing virtual
 environments ([venv], [virtualenv], or [virtualenvwrapper]) should
-work, although FABRIC team tends to use virtualenvwrapper.
+work, although FABRIC team tends to favor virtualenvwrapper.
 
 
 ## Using FABlib

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![requirements-badge]][requirements]
 
-[![PyPI](https://img.shields.io/pypi/v/fabrictestbed-extensions?style=plastic)](https://pypi.org/project/fabrictestbed-extensions/)
+[![pypi-badge]][pypy]
 
 Extensions for the FABRIC API/CLI.  
 
@@ -27,4 +27,7 @@ pip install --user .
 
 [requirements]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements/?branch=main
 [requirements-badge]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements.svg?branch=main (Requirements Status)
+
+[pypy]: https://pypi.org/project/fabrictestbed-extensions/
+[pypi-badge]: https://img.shields.io/pypi/v/fabrictestbed-extensions?style=plastic (PyPI)
 

--- a/README.md
+++ b/README.md
@@ -8,18 +8,17 @@ intereacting with [FABRIC][fabric] testbed, colloquially known as
 
 ## Installing FABlib
 
-Install released versions of FABlib from PyPI:
+You can install released versions of FABlib from PyPI:
 
 ```console
 $ pip install fabrictestbed-extensions
 ```
 
-If you want a more "bleeding edge" version of FABlib, install it from
+If you need the current development version of FABlib, install it from
 the git repository:
 
-
 ```console
-$ pip install git+https://github.com/fabric-testbed/fabrictestbed-extensions.git
+$ pip install git+https://github.com/fabric-testbed/fabrictestbed-extensions@main
 ```
 
 Note that installing FABlib using either methods will also install a

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ $ pip install git+https://github.com/fabric-testbed/fabrictestbed-extensions@mai
 
 Note that installing FABlib using either methods will also install a
 number of dependencies, so you might want to install FABlib in a
-virtual environment.  Your favorite tool for managing virtual
+virtual environment. Your favorite tool for managing virtual
 environments ([venv], [virtualenv], or [virtualenvwrapper]) should
-work, although FABRIC team tends to favor virtualenvwrapper.
+work. FABRIC team tends to favor virtualenvwrapper.
 
 
 ## Using FABlib
@@ -43,16 +43,16 @@ except Exception as e:
 ```
 
 Your first encounter with FABlib however might be through FABRIC
-project's [JupyterHub][fabric-jupyter] instance.  You will be
-presented with many examples on FABlib usage when you log in there.
-The [notebook sources][fabric-jupyter-examples] can be found on GitHub
-as well.
+project's [JupyterHub][fabric-jupyter] instance. You will be presented
+with many examples on FABlib usage when you log in there. The
+[notebook sources][fabric-jupyter-examples] can be found on GitHub as
+well.
 
-Since FABlib 1.4, API docs can be found [here][fablib-api-rtd].  Older
+Since FABlib 1.4, API docs can be found [here][fablib-api-rtd]. Older
 API docs are [here][fablib-api-old].
 
 If you want to interact with FABRIC from Jupyter installed on your
-computer, see [Install the FABRIC Python API][fablib-install].
+computer, see: [Install the FABRIC Python API][fablib-install].
 
 
 ## Building Python packages

--- a/README.md
+++ b/README.md
@@ -30,10 +30,23 @@ work, although FABRIC team tends to use virtualenvwrapper.
 
 ## Using FABlib
 
-Your first encounter with FABlib might be through FABRIC project's
-[JupyterHub][fabric-jupyter] instance.  You will be presented with
-many examples on FABlib usage when you log in there.  The [notebook
-sources][fabric-jupyter-examples] can be found on GitHub as well.
+Once installed, you can use FABlib in your Python projects:
+
+```python
+from fabrictestbed_extensions.fablib.fablib import FablibManager as fablib_manager
+
+try:
+    fablib = fablib_manager()
+    fablib.show_config()
+except Exception as e:
+    print(f"Exception: {e}")
+```
+
+Your first encounter with FABlib however might be through FABRIC
+project's [JupyterHub][fabric-jupyter] instance.  You will be
+presented with many examples on FABlib usage when you log in there.
+The [notebook sources][fabric-jupyter-examples] can be found on GitHub
+as well.
 
 FABlib API documentation can be found [here][fablib-api-rtd], since
 version 1.4.  Older API docs are [here][fablib-api-old].

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ virtual environment.  Use your favorite: [venv], [virtualenv], or
 [virtualenvwrapper].
 
 
-<!-- Badges -->
+<!-- URLs -->
 
 [requirements]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements/?branch=main
 [requirements-badge]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements.svg?branch=main (Requirements Status)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ virtual environment.  Use your favorite: [venv], [virtualenv], or
 [virtualenvwrapper].
 
 
+## Using fabrictestbed-extensions
+
+Your first encounter with FABlib might be through FABRIC project's
+[JupyterHub][fabric-jupyter] instance.  You will be presented with
+many examples on FABlib usage when you log in there.  The [notebook
+sources][[fabric-jupyter-examples]] can be found on GitHub as well.
+
+FABlib API documentation can be found [here][fablib-api-rtd], since
+version 1.4.  Older API docs are [here][fablib-api-old].
+
+If you want to interact with FABRIC from Jupyter installed on your
+computer, see [Install the FABRIC Python API][fablib-install].
+
+
 ## Building the Python package
 
 Do not do `python setup.py sdist bdist_wheel`. Instead, do:
@@ -56,3 +70,11 @@ $ twine upload dist/*
 [venv]: https://docs.python.org/3/library/venv.html
 [virtualenv]: https://virtualenv.pypa.io/en/latest/
 [virtualenvwrapper]: https://virtualenvwrapper.readthedocs.io/en/latest/
+
+[fabric-jupyter] https://jupyter.fabric-testbed.net/
+[fabric-jupyter-examples]: https://github.com/fabric-testbed/jupyter-examples
+[fabrlib-install]: https://learn.fabric-testbed.net/knowledge-base/install-the-python-api/
+
+[fablib-api-rtd]: https://fabric-fablib.readthedocs.io/en/latest/
+[fablib-api-old]: https://learn.fabric-testbed.net/docs/fablib/fablib.html
+

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ the git repository:
 $ pip install git+https://github.com/fabric-testbed/fabrictestbed-extensions.git
 ```
 
+Note that installing FABlib using either methods will also install a
+number of dependencies, so you might want to install FABlib in a
+virtual environment.  Use your favorite: [venv], [virtualenv], or
+[virtualenvwrapper].
+
 
 <!-- Badges -->
 
@@ -47,3 +52,7 @@ $ pip install git+https://github.com/fabric-testbed/fabrictestbed-extensions.git
 [pypi-badge]: https://img.shields.io/pypi/v/fabrictestbed-extensions?style=plastic (PyPI)
 
 [fabric]: https://fabric-testbed.net/
+
+[venv]: https://docs.python.org/3/library/venv.html
+[virtualenv]: https://virtualenv.pypa.io/en/latest/
+[virtualenvwrapper]: https://virtualenvwrapper.readthedocs.io/en/latest/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ virtual environment.  Use your favorite: [venv], [virtualenv], or
 Your first encounter with FABlib might be through FABRIC project's
 [JupyterHub][fabric-jupyter] instance.  You will be presented with
 many examples on FABlib usage when you log in there.  The [notebook
-sources][[fabric-jupyter-examples]] can be found on GitHub as well.
+sources][fabric-jupyter-examples] can be found on GitHub as well.
 
 FABlib API documentation can be found [here][fablib-api-rtd], since
 version 1.4.  Older API docs are [here][fablib-api-old].
@@ -71,7 +71,7 @@ $ twine upload dist/*
 [virtualenv]: https://virtualenv.pypa.io/en/latest/
 [virtualenvwrapper]: https://virtualenvwrapper.readthedocs.io/en/latest/
 
-[fabric-jupyter] https://jupyter.fabric-testbed.net/
+[fabric-jupyter]: https://jupyter.fabric-testbed.net/
 [fabric-jupyter-examples]: https://github.com/fabric-testbed/jupyter-examples
 [fabrlib-install]: https://learn.fabric-testbed.net/knowledge-base/install-the-python-api/
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ twine upload dist/*
 
 [fabric-jupyter]: https://jupyter.fabric-testbed.net/
 [fabric-jupyter-examples]: https://github.com/fabric-testbed/jupyter-examples
-[fabrlib-install]: https://learn.fabric-testbed.net/knowledge-base/install-the-python-api/
+[fablib-install]: https://learn.fabric-testbed.net/knowledge-base/install-the-python-api/
 
 [fablib-api-rtd]: https://fabric-fablib.readthedocs.io/en/latest/
 [fablib-api-old]: https://learn.fabric-testbed.net/docs/fablib/fablib.html

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ $ pip install git+https://github.com/fabric-testbed/fabrictestbed-extensions@mai
 
 Note that installing FABlib using either methods will also install a
 number of dependencies, so you might want to install FABlib in a
-virtual environment.  Use your favorite: [venv], [virtualenv], or
-[virtualenvwrapper].
+virtual environment.  Your favorite tool for managing virtual
+environments ([venv], [virtualenv], or [virtualenvwrapper]) should
+work, although FABRIC team tends to uuse virtualenvwrapper.
 
 
 ## Using FABlib

--- a/README.md
+++ b/README.md
@@ -2,16 +2,23 @@
 
 [![requirements-badge]][requirements] [![pypi-badge]][pypy]
 
-Extensions for the FABRIC API/CLI.  
+This repository contains implementation of a Python API for
+intereacting with [FABRIC][fabric] testbed, colloquially known as
+"FABlib".
 
 ## Build instructions
-(Do not do `python setup.py sdist bdist_wheel`)
+
+Do not do `python setup.py sdist bdist_wheel`. Instead, do:
+
+```console
+$ pip install build
+$ python -m build
 ```
-python -m build
-```
-Following that upload to PyPi using
-```
-twine upload dist/*
+
+Following that upload to PyPi using:
+
+```console
+$ twine upload dist/*
 ```
 
 ## Install Instructions
@@ -29,3 +36,4 @@ pip install --user .
 [pypy]: https://pypi.org/project/fabrictestbed-extensions/
 [pypi-badge]: https://img.shields.io/pypi/v/fabrictestbed-extensions?style=plastic (PyPI)
 
+[fabric]: https://fabric-testbed.net/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # fabrictestbed-extensions
 
-[![requirements-badge]][requirements]
-
-[![pypi-badge]][pypy]
+[![requirements-badge]][requirements] [![pypi-badge]][pypy]
 
 Extensions for the FABRIC API/CLI.  
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![requirements-badge]][requirements] [![pypi-badge]][pypy]
 
 This repository contains implementation of a Python API for
-intereacting with [FABRIC][fabric] testbed, colloquially known as
+intereacting with [FABRIC][fabric] testbed, otherwise known as
 "FABlib".
 
 ## Installing FABlib

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you want to interact with FABRIC from Jupyter installed on your
 computer, see [Install the FABRIC Python API][fablib-install].
 
 
-## Building the Python package
+## Building Python packages
 
 Do not do `python setup.py sdist bdist_wheel`. Instead, do:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note that installing FABlib using either methods will also install a
 number of dependencies, so you might want to install FABlib in a
 virtual environment.  Your favorite tool for managing virtual
 environments ([venv], [virtualenv], or [virtualenvwrapper]) should
-work, although FABRIC team tends to uuse virtualenvwrapper.
+work, although FABRIC team tends to use virtualenvwrapper.
 
 
 ## Using FABlib

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains implementation of a Python API for
 intereacting with [FABRIC][fabric] testbed, colloquially known as
 "FABlib".
 
-## Installing fabrictestbed-extensions
+## Installing FABlib
 
 Install released versions of FABlib from PyPI:
 
@@ -28,7 +28,7 @@ virtual environment.  Use your favorite: [venv], [virtualenv], or
 [virtualenvwrapper].
 
 
-## Using fabrictestbed-extensions
+## Using FABlib
 
 Your first encounter with FABlib might be through FABRIC project's
 [JupyterHub][fabric-jupyter] instance.  You will be presented with

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains implementation of a Python API for
 intereacting with [FABRIC][fabric] testbed, colloquially known as
 "FABlib".
 
-## Build instructions
+## Building the Python package
 
 Do not do `python setup.py sdist bdist_wheel`. Instead, do:
 
@@ -15,18 +15,28 @@ $ pip install build
 $ python -m build
 ```
 
-Following that upload to PyPi using:
+Following that, upload to PyPi using:
 
 ```console
 $ twine upload dist/*
 ```
 
-## Install Instructions
+## Installing the Python package
+
+Install released versions of FABlib from PyPI:
+
+```console
+$ pip install fabrictestbed-extensions
 ```
-git clone https://github.com/fabric-testbed/fabrictestbed-extensions.git 
-cd fabrictestbed-extensions
-pip install --user .
+
+If you want a more "bleeding edge" version of FABlib, install it from
+the git repository:
+
+
+```console
+$ pip install git+https://github.com/fabric-testbed/fabrictestbed-extensions.git
 ```
+
 
 <!-- Badges -->
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fabrictestbed-extensions
 
-[![requirements-badge](Requirements Status)][requirements]
+[![requirements-badge]][requirements]
 
 [![PyPI](https://img.shields.io/pypi/v/fabrictestbed-extensions?style=plastic)](https://pypi.org/project/fabrictestbed-extensions/)
 
@@ -26,5 +26,5 @@ pip install --user .
 <!-- Badges -->
 
 [requirements]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements/?branch=main
-[requirements-badge]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements.svg?branch=main
+[requirements-badge]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements.svg?branch=main (Requirements Status)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fabrictestbed-extensions
 
-[![requirements-badge]][requirements] [![pypi-badge]][pypy] [![api-docs-badge]][api-docs]
+[![pypi-badge]][pypy] [![api-docs-badge]][api-docs]
 
 This repository contains implementation of a Python API for
 intereacting with [FABRIC][fabric] testbed, otherwise known as
@@ -71,9 +71,6 @@ $ twine upload dist/*
 ```
 
 <!-- URLs -->
-
-[requirements]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements/?branch=main
-[requirements-badge]: https://requires.io/github/fabric-testbed/fabrictestbed-extensions/requirements.svg?branch=main (Requirements Status)
 
 [pypy]: https://pypi.org/project/fabrictestbed-extensions/
 [pypi-badge]: https://img.shields.io/pypi/v/fabrictestbed-extensions?style=plastic (PyPI)

--- a/README.md
+++ b/README.md
@@ -6,21 +6,6 @@ This repository contains implementation of a Python API for
 intereacting with [FABRIC][fabric] testbed, colloquially known as
 "FABlib".
 
-## Building the Python package
-
-Do not do `python setup.py sdist bdist_wheel`. Instead, do:
-
-```console
-$ pip install build
-$ python -m build
-```
-
-Following that, upload to PyPi using:
-
-```console
-$ twine upload dist/*
-```
-
 ## Installing the Python package
 
 Install released versions of FABlib from PyPI:
@@ -42,6 +27,21 @@ number of dependencies, so you might want to install FABlib in a
 virtual environment.  Use your favorite: [venv], [virtualenv], or
 [virtualenvwrapper].
 
+
+## Building the Python package
+
+Do not do `python setup.py sdist bdist_wheel`. Instead, do:
+
+```console
+$ pip install build
+$ python -m build
+```
+
+Following that, upload to PyPi using:
+
+```console
+$ twine upload dist/*
+```
 
 <!-- URLs -->
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fabrictestbed-extensions
 
-[![requirements-badge]][requirements] [![pypi-badge]][pypy]
+[![requirements-badge]][requirements] [![pypi-badge]][pypy] [![api-docs-badge]][api-docs]
 
 This repository contains implementation of a Python API for
 intereacting with [FABRIC][fabric] testbed, otherwise known as
@@ -78,6 +78,9 @@ $ twine upload dist/*
 [pypy]: https://pypi.org/project/fabrictestbed-extensions/
 [pypi-badge]: https://img.shields.io/pypi/v/fabrictestbed-extensions?style=plastic (PyPI)
 
+[api-docs]: https://fabric-fablib.readthedocs.io/en/latest/?badge=latest
+[api-docs-badge]: https://readthedocs.org/projects/fabric-fablib/badge/?version=latest (Documentation Status)
+
 [fabric]: https://fabric-testbed.net/
 
 [venv]: https://docs.python.org/3/library/venv.html
@@ -90,4 +93,3 @@ $ twine upload dist/*
 
 [fablib-api-rtd]: https://fabric-fablib.readthedocs.io/en/latest/
 [fablib-api-old]: https://learn.fabric-testbed.net/docs/fablib/fablib.html
-


### PR DESCRIPTION
Addresses #68 and #98.

For convenience, the rendered markdown is at https://github.com/fabric-testbed/fabrictestbed-extensions/tree/68.update-readme#readme.