### PR TITLE
Run code formatting checks with `black --check`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,23 @@
+# Run some code checks with GitHub Actions.
+
+name: Code checks
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v3
+
+      # See https://black.readthedocs.io/en/stable/integrations/github_actions.html
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "."
+          version: "~= 22.0"


### PR DESCRIPTION
Addresses #95.  Consists of two changes:

- Adds a GitHub Actions workflow to run `black --check` against the sources.  Any new code that is displeases [black](https://black.readthedocs.io/en/stable/index.html) will be rejected.
- Formats all code using black's defaults.