### PR TITLE
Remove build from `install_requires`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build
 on:
   push:
     branches:
-      - main
+      - "main"
   pull_request:
 
 permissions:
@@ -29,6 +29,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install build
+
       - name: Build the package
         run: |
           python -m build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+# Build the package
+
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: 'pip'  # cache pip dependencies
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build the package
+        run: |
+          python -m build
+
+      # See https://github.com/actions/upload-artifact
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: dist/
+          if-no-files-found: error

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ name: Code checks
 on:
   push:
     branches:
-      - main
+      - "main"
   pull_request:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,9 @@ name: Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - "main"
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-build
 ipycytoscape
 ipywidgets
 ipyleaflet

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,4 @@ setup(
     ],
     python_requires=">=3.9",
     install_requires=requirements,
-    setup_requires=requirements,
 )


### PR DESCRIPTION
Issue is #113, which is a smaller part of #58. This PR makes three small changes:

-  [build](https://pypi.org/project/build/) is only required to build source and wheel packages, so removes it from `requirements.txt`. FABlib users should not have to install build.
- Per [setuptools docs](https://setuptools.pypa.io/en/latest/references/keywords.html), `setup_requires` is a deprecated/discouraged keyword, so removes that from `setup.py`.  It doesn't seem to do much when building packages.
- Adds a GitHub Actions "build" workflow which should ensure that FABlib remains buildable.