### PR TITLE
configure_nvme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fablib now uses pyproject.toml for specifying packaging metadata instead of setup.py and friends (issue [#74](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/74)).
+- Make configure_nvme() more generic (PR [#126](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/126)).
 
 ### Fixed
 

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -505,41 +505,62 @@ class Component:
         output = []
         try:
             device_pci_id = self.get_pci_addr()[0]
-            stdout,stderr = self.node.execute('basename `sudo ls -l /sys/block/nvme*|grep "'+str(device_pci_id)+'"|awk \'{print $9}\'`',quiet=True)
-            if (stderr != ''):
-                output.append('Cannot find NVME device name for PCI ID : '+device_pci_id)
+            stdout, stderr = self.node.execute(
+                'basename `sudo ls -l /sys/block/nvme*|grep "'
+                + str(device_pci_id)
+                + "\"|awk '{print $9}'`",
+                quiet=True,
+            )
+            if stderr != "":
+                output.append(
+                    "Cannot find NVME device name for PCI ID : " + device_pci_id
+                )
                 raise Exception
             device_name = stdout.strip()
-            block_device_name = "/dev/"+device_name
-            output.append(self.node.execute("sudo fdisk -l "+block_device_name))
-            output.append(
-                self.node.execute("sudo parted -s "+block_device_name+" mklabel gpt")
-            )
-            output.append(
-                self.node.execute("sudo parted -s "+block_device_name+" print" )
-            )
-            output.append(
-                self.node.execute("sudo parted -s "+block_device_name+" print unit MB print free")
-            )
-            output.append(
-                self.node.execute("sudo parted -s --align optimal "+block_device_name+" mkpart primary ext4 0% 100%")
-            )
-            output.append(self.node.execute("lsblk "+block_device_name))
-            output.append(
-                self.node.execute("sudo mkfs.ext4 "+block_device_name+"p1")
-            )
-            # This is to use a unique mountpoint when it is not provided by the user
-            if (mount_point == ""):
-                mount_point = "/mnt/"+device_name
+            block_device_name = "/dev/" + device_name
+            output.append(self.node.execute("sudo fdisk -l " + block_device_name))
             output.append(
                 self.node.execute(
-                    "sudo mkdir -p "+mount_point+" && sudo mount "+block_device_name+"p1 "+mount_point)
+                    "sudo parted -s " + block_device_name + " mklabel gpt"
+                )
             )
-            output.append(self.node.execute("df -h "+mount_point))
+            output.append(
+                self.node.execute("sudo parted -s " + block_device_name + " print")
+            )
+            output.append(
+                self.node.execute(
+                    "sudo parted -s " + block_device_name + " print unit MB print free"
+                )
+            )
+            output.append(
+                self.node.execute(
+                    "sudo parted -s --align optimal "
+                    + block_device_name
+                    + " mkpart primary ext4 0% 100%"
+                )
+            )
+            output.append(self.node.execute("lsblk " + block_device_name))
+            output.append(
+                self.node.execute("sudo mkfs.ext4 " + block_device_name + "p1")
+            )
+            # This is to use a unique mountpoint when it is not provided by the user
+            if mount_point == "":
+                mount_point = "/mnt/" + device_name
+            output.append(
+                self.node.execute(
+                    "sudo mkdir -p "
+                    + mount_point
+                    + " && sudo mount "
+                    + block_device_name
+                    + "p1 "
+                    + mount_point
+                )
+            )
+            output.append(self.node.execute("df -h " + mount_point))
         except Exception as e:
             print(f"config_nvme Fail: {self.get_name()}")
-            #traceback.print_exc()
-            raise Exception(str(output)+str(e))
+            # traceback.print_exc()
+            raise Exception(str(output) + str(e))
 
         return output
 

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -506,57 +506,52 @@ class Component:
         try:
             device_pci_id = self.get_pci_addr()[0]
             stdout, stderr = self.node.execute(
-                'basename `sudo ls -l /sys/block/nvme*|grep "'
-                + str(device_pci_id)
-                + "\"|awk '{print $9}'`",
+                f'basename `sudo ls -l /sys/block/nvme*|grep "'
+                f"{device_pci_id}\"|awk '{{print $9}}'`",
                 quiet=True,
             )
             if stderr != "":
                 output.append(
-                    "Cannot find NVME device name for PCI ID : " + device_pci_id
+                    f"Cannot find NVME device name for PCI ID : {device_pci_id}"
                 )
                 raise Exception
             device_name = stdout.strip()
-            block_device_name = "/dev/" + device_name
-            output.append(self.node.execute("sudo fdisk -l " + block_device_name))
+            block_device_name = f"/dev/{device_name}"
+            output.append(self.node.execute(f"sudo fdisk -l {block_device_name}"))
             output.append(
-                self.node.execute(
-                    "sudo parted -s " + block_device_name + " mklabel gpt"
-                )
+                self.node.execute(f"sudo parted -s {block_device_name} mklabel gpt")
             )
             output.append(
-                self.node.execute("sudo parted -s " + block_device_name + " print")
+                self.node.execute(f"sudo parted -s {block_device_name} print")
             )
             output.append(
                 self.node.execute(
-                    "sudo parted -s " + block_device_name + " print unit MB print free"
+                    f"sudo parted -s {block_device_name} print unit MB print free"
                 )
             )
             output.append(
                 self.node.execute(
-                    "sudo parted -s --align optimal "
-                    + block_device_name
-                    + " mkpart primary ext4 0% 100%"
+                    f"sudo parted -s --align optimal "
+                    f"{block_device_name} "
+                    f"mkpart primary ext4 0% 100%"
                 )
             )
-            output.append(self.node.execute("lsblk " + block_device_name))
-            output.append(
-                self.node.execute("sudo mkfs.ext4 " + block_device_name + "p1")
-            )
+            output.append(self.node.execute(f"lsblk {block_device_name}"))
+            output.append(self.node.execute(f"sudo mkfs.ext4 {block_device_name}p1"))
             # This is to use a unique mountpoint when it is not provided by the user
             if mount_point == "":
-                mount_point = "/mnt/" + device_name
+                mount_point = f"/mnt/{device_name}"
             output.append(
                 self.node.execute(
-                    "sudo mkdir -p "
-                    + mount_point
-                    + " && sudo mount "
-                    + block_device_name
-                    + "p1 "
-                    + mount_point
+                    f"sudo mkdir -p "
+                    f"{mount_point}"
+                    f" && sudo mount "
+                    f"{block_device_name}"
+                    f"p1 "
+                    f"{mount_point}"
                 )
             )
-            output.append(self.node.execute("df -h " + mount_point))
+            output.append(self.node.execute(f"df -h {mount_point}"))
         except Exception as e:
             print(f"config_nvme Fail: {self.get_name()}")
             # traceback.print_exc()

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -493,51 +493,53 @@ class Component:
         """
         return self.get_fim_component().type
 
-    def configure_nvme(self, mount_point="/mnt/nvme_mount"):
+    def configure_nvme(self, mount_point=""):
         """
         Configure the NVMe drive.
 
         Note this works but may be reorganized.
 
-        :param mount_point: The mount point in the filesystem. Default = /mnt/nvme_mount
+        :param mount_point: The mount point in the filesystem. Default = "" later reassigned to /mnt/{linux device name}
         :type mount_point: String
         """
         output = []
         try:
-            output.append(self.node.execute("sudo fdisk -l /dev/nvme*"), quiet=True)
+            device_pci_id = self.get_pci_addr()[0]
+            stdout,stderr = self.node.execute('basename `sudo ls -l /sys/block/nvme*|grep "'+str(device_pci_id)+'"|awk \'{print $9}\'`',quiet=True)
+            if (stderr != ''):
+                output.append('Cannot find NVME device name for PCI ID : '+device_pci_id)
+                raise Exception
+            device_name = stdout.strip()
+            block_device_name = "/dev/"+device_name
+            output.append(self.node.execute("sudo fdisk -l "+block_device_name))
             output.append(
-                self.node.execute("sudo parted -s /dev/nvme0n1 mklabel gpt"), quiet=True
+                self.node.execute("sudo parted -s "+block_device_name+" mklabel gpt")
             )
             output.append(
-                self.node.execute("sudo parted -s /dev/nvme0n1 print"), quiet=True
+                self.node.execute("sudo parted -s "+block_device_name+" print" )
             )
+            output.append(
+                self.node.execute("sudo parted -s "+block_device_name+" print unit MB print free")
+            )
+            output.append(
+                self.node.execute("sudo parted -s --align optimal "+block_device_name+" mkpart primary ext4 0% 100%")
+            )
+            output.append(self.node.execute("lsblk "+block_device_name))
+            output.append(
+                self.node.execute("sudo mkfs.ext4 "+block_device_name+"p1")
+            )
+            # This is to use a unique mountpoint when it is not provided by the user
+            if (mount_point == ""):
+                mount_point = "/mnt/"+device_name
             output.append(
                 self.node.execute(
-                    "sudo parted -s /dev/nvme0n1 print unit MB print free"
-                ),
-                quiet=True,
+                    "sudo mkdir -p "+mount_point+" && sudo mount "+block_device_name+"p1 "+mount_point)
             )
-            output.append(
-                self.node.execute(
-                    "sudo parted -s --align optimal /dev/nvme0n1 mkpart primary ext4 0% 960197MB"
-                ),
-                quiet=True,
-            )
-            output.append(self.node.execute("lsblk /dev/nvme0n1"), quiet=True)
-            output.append(
-                self.node.execute("sudo mkfs.ext4 /dev/nvme0n1p1"), quiet=True
-            )
-            output.append(
-                self.node.execute(
-                    f"sudo mkdir {mount_point} && sudo mount /dev/nvme0n1p1 {mount_point}"
-                ),
-                quiet=True,
-            )
-            output.append(self.node.execute(f"df -h {mount_point}"), quiet=True)
+            output.append(self.node.execute("df -h "+mount_point))
         except Exception as e:
             print(f"config_nvme Fail: {self.get_name()}")
-            # traceback.print_exc()
-            raise Exception(str(output))
+            #traceback.print_exc()
+            raise Exception(str(output)+str(e))
 
         return output
 

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -555,7 +555,7 @@ class Component:
         except Exception as e:
             print(f"config_nvme Fail: {self.get_name()}")
             # traceback.print_exc()
-            raise Exception(str(output) + str(e))
+            raise Exception(str(output))
 
         return output
 


### PR DESCRIPTION
Fix configure_nvme routine to make it generic
mount_point is now defaulted to "" and later reassigned to /mnt/{linux device name} just in case the user is using multiple NVMEs and does not provide a mount_point.