### PR TITLE
Check that Changelog has been updated

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,6 +38,7 @@ jobs:
 
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
+        if: github.event_name != "pull_request"
         run: |
           git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md
           if [ $? -eq 0 ]; then

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,11 +41,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           # `git diff --exit-code` exits with 1 if there were
-          # differences and 0 means no differences.
-          if (git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md); then
-              echo "Seems that you've updated CHANGELOG.md. Nice!"
-          else
-              # If we're here, it means that there is no difference.
-              echo "Please update CHANGELOG.md."
-              exit 1
-          fi
+          # differences and 0 means no differences. Here we negate
+          # that, because we want to fail if changelog has not been
+          # updated.
+          ! git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,4 @@ jobs:
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
         run: |
-          git remote -v
-          git ls-remote --heads
-          echo "GITHUB_BASE_REF: ${GITHUB_BASE_REF}"
           ! git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,4 +39,5 @@ jobs:
         run: |
           git remote -v
           git ls-remote --heads
-          ! git diff --exit-code "${GITHUB_BASE_REF}" -- CHANGELOG.md
+          echo "GITHUB_BASE_REF: ${GITHUB_BASE_REF}"
+          ! git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Check that Changelog has been updated
         run: |
           git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md
-          if [ $? -eq 0 ] then
+          if [ $? -eq 0 ]; then
               echo "Please update CHANGELOG.md"
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,3 +33,8 @@ jobs:
       - name: Run "black --check"
         run: |
           python -m black --check --verbose .
+
+      # Remind PR authors to update CHANGELOG.md
+      - name: Check that Changelog has been updated
+        run: |
+          ! git diff --exit-code "origin/${BASE_REF}" -- CHANGELOG.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,4 +39,7 @@ jobs:
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
         run: |
-          ! git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md
+          git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md
+          if [ $? -eq 0 ] then
+              echo "Please update CHANGELOG.md"
+          fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,5 +37,6 @@ jobs:
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
         run: |
+          git remote -v
           git ls-remote --heads
           ! git diff --exit-code "${GITHUB_BASE_REF}" -- CHANGELOG.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,8 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out sources
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # since we need to diff against origin/main.
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # since we need to diff against origin/main.
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,4 +37,4 @@ jobs:
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
         run: |
-          ! git diff --exit-code "origin/${BASE_REF}" -- CHANGELOG.md
+          ! git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,8 +40,12 @@ jobs:
       - name: Check that Changelog has been updated
         if: github.event_name == 'pull_request'
         run: |
-          git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md
-          if [ $? -eq 0 ]; then
-              echo "Please update CHANGELOG.md"
+          # `git diff --exit-code` exits with 1 if there were
+          # differences and 0 means no differences.
+          if (git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md); then
+              echo "Seems that you've updated CHANGELOG.md. Nice!"
+          else
+              # If we're here, it means that there is no difference.
+              echo "Please update CHANGELOG.md."
               exit 1
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,4 +37,5 @@ jobs:
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
         run: |
-          ! git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md
+          git remo
+          ! git diff --exit-code "${GITHUB_BASE_REF}" -- CHANGELOG.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,5 +37,5 @@ jobs:
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
         run: |
-          git remo
+          git ls-remote --heads
           ! git diff --exit-code "${GITHUB_BASE_REF}" -- CHANGELOG.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -42,4 +42,5 @@ jobs:
           git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md
           if [ $? -eq 0 ]; then
               echo "Please update CHANGELOG.md"
+              exit 1
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
-        if: github.event_name != "pull_request"
+        if: github.event_name != 'pull_request'
         run: |
           git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md
           if [ $? -eq 0 ]; then

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'pull_request'
         run: |
           git diff --exit-code "origin/${GITHUB_BASE_REF}" -- CHANGELOG.md
           if [ $? -eq 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added 
+### Added
 
 - Support new GPU models has been added (PR [#122](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/122)).
 
@@ -29,21 +29,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.3] - 2022-12-01
 
- 
+
 ### Added
 - FABLIB:  Show and list functionallity for all resource object types.
- 
+
 ### Changed
- 
+
 - FABLIB:  Now leaves network manager for management iface but does not manage other ifaces
 
 ### Fixed
 
 - FABLIB: node.upload_directory now uses correct temporary file names
 
- 
- 
- 
+
+
+
 ## [1.3.2] - 2022-10-25
-  
+
 Older changes are not included in change log.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-FABRIC testbed extensions changelog
+This is the changelog file for FABRIC testbed extensions.  All notable
+changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-FABRIC testbed extensions changlog
+FABRIC testbed extensions changelog
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@ FABRIC testbed extensions changelog
 
 ### Added 
 
-- Support new GPU models has been added.
+- Support new GPU models has been added (PR [#122](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/122)).
 
 ### Changed
 
-- Fablib now uses pyproject.toml for specifying packaging metadata instead of setup.py and friends (issue #74).
+- Fablib now uses pyproject.toml for specifying packaging metadata instead of setup.py and friends (issue [#74](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/74)).
 
 ### Fixed
 
-- Fablib will now fail early when required configuration is missing  (issue #69).
+- Fablib will now fail early when required configuration is missing (issue [#69](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/69)).
 
 ## [1.3.4] - 2023-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 FABRIC testbed extensions changlog
 
+## [Unreleased]
+
+### Added 
+
+- Support new GPU models has been added.
+
+### Changed
+
+- Fablib now uses pyproject.toml for specifying packaging metadata instead of setup.py and friends (issue #74).
+
+### Fixed
+
+- Fablib will now fail early when required configuration is missing  (issue #69).
+
 ## [1.3.4] - 2023-01-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -55,9 +55,18 @@ If you want to interact with FABRIC from Jupyter installed on your
 computer, see: [Install the FABRIC Python API][fablib-install].
 
 
-## Testing FABlib
+## Contributing to FABlib
 
-Run tests with [pytest]:
+Contributions to FABlib are made with GitHub Pull Requests. When you
+submit a pull request, some tests will run against it:
+
+- Code formatting will be checked using [black].  Be sure that your
+  code is formatted with black, using its defaults.
+- CHANGELOG.md will be checked for updates.
+- Packages will be built.
+- Unit tests will be run.
+
+You can run tests in your environment, like so, using [pytest]:
 
 ```console
 $ pip install -e .[test]
@@ -129,4 +138,4 @@ For details about publishing to PyPI, see flit documentation about
 
 [build]: https://pypi.org/project/build/
 [pytest]: https://pypi.org/project/pytest/
-
+[black]: https://pypi.org/project/black/


### PR DESCRIPTION
Adds a step in "code checks" GitHub Actions workflow that checks that CHANGELOG.md has been updated.

We often forget to update CHANGELOG.md when submitting a PR.  It would be nice to be reminded about that.

Changes: 
- A step has been added in "code checks" workflow, which will run essentially run `git diff --exit-code "origin/main" -- CHANGELOG.md` when a PR is made.  It will fail if changelog has not been updated.  Failing outright probably is bit of an extreme step for small pull requests, but it is better than entirely forgetting to keep the changelog up-to-date.
- README has been updated, with some hints about the above and contribution process in general.
- CHANGELOG.md itself has been updated, capturing some recent unreleased changes.