### PR TITLE
Skip changelog check when PR has "no changelog" label

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
-        if: github.event_name == 'pull_request' && !contains(github.event.label.name, 'no changelog')
+        if: github.event_name == "pull_request" && !contains(github.event.pull_request.labels.*.name, "no changelog")
         run: |
           # `git diff --exit-code` exits with 1 if there were
           # differences and 0 means no differences. Here we negate

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
-        if: github.event_name == "pull_request" && !contains(github.event.pull_request.labels.*.name, "no changelog")
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no changelog')
         run: |
           # `git diff --exit-code` exits with 1 if there were
           # differences and 0 means no differences. Here we negate

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !contains(github.event.label.name, 'no changelog')
         run: |
           # `git diff --exit-code` exits with 1 if there were
           # differences and 0 means no differences. Here we negate


### PR DESCRIPTION
Issue is #129.

I've added a new label "no changelog" to this repository, and the "code checks" workflow should skip checking for changelog updates when that label is present on a PR. Demonstration that this works as intended is right here on this PR.