### PR TITLE
Check that commits are signed

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           fetch-depth: 0 # since we need to diff against origin/main.
 
+      # https://github.com/marketplace/actions/check-signed-commits-in-pr
       - name: Check that commits are signed
         uses: 1Password/check-signed-commits-action@v1
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           fetch-depth: 0 # since we need to diff against origin/main.
 
+      - name: Check that commits are signed
+        uses: 1Password/check-signed-commits-action@v1
+
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
@@ -35,9 +38,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install black
-
-      - name: Check that commits are signed
-        uses: 1Password/check-signed-commits-action@v1
 
       - name: Run "black --check"
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,6 +10,9 @@ on:
 
 permissions:
   contents: read
+  # Allow 1Password/check-signed-commits-action to leave comments on
+  # pull requests.
+  pull-requests: write
 
 jobs:
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,6 +33,9 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install black
 
+      - name: Check that commits are signed
+        uses: 1Password/check-signed-commits-action@v1
+
       - name: Run "black --check"
         run: |
           python -m black --check --verbose .


### PR DESCRIPTION
Issue is #138.

An example of how this works is in PR #141.  When the check fails, it also leaves a comment on the PR with some helpful hints (see [example](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/141#issuecomment-1492570797) on the same PR).  The comment contains an advertisement for 1Password, but I guess we can live with that?