### PR TITLE
166.public ip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/

--- a/docs/source/fablib.rst
+++ b/docs/source/fablib.rst
@@ -496,6 +496,8 @@
 
   .. automethod:: get_reservation_state
 
+  .. automethod:: get_public_ips
+
 .. automodule:: resources
 
 ``Resources``

--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -1,3 +1,3 @@
 # Please update version number here when making a release: flit, the
 # build backend we use, picks up the version from here.
-__version__ = "1.4.3"
+__version__ = "1.4.4rc0"

--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -1,3 +1,3 @@
 # Please update version number here when making a release: flit, the
 # build backend we use, picks up the version from here.
-__version__ = "1.4.4rc0"
+__version__ = "1.4.4rc1"

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -804,7 +804,7 @@ class NetworkService:
             elif self.get_fim_network_service().labels.ipv6 is not None:
                 result = []
                 for x in self.get_fim_network_service().labels.ipv6:
-                    result.append(IPv4Address(x))
+                    result.append(IPv6Address(x))
                 return result
         return None
 

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import logging
 
 from tabulate import tabulate
-from typing import List
+from typing import List, Union
 
 from typing import TYPE_CHECKING
 
@@ -789,7 +789,7 @@ class NetworkService:
             logging.warning(f"Failed to get_available_ips: {e}")
             return None
 
-    def get_public_ips(self) -> List[IPv4Address] or List[IPv6Address] or None:
+    def get_public_ips(self) -> Union[List[IPv4Address] or List[IPv6Address] or None]:
         """
         Get list of public IPs assigned to the FabNetv*Ext service
         :return: List of Public IPs

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -789,6 +789,25 @@ class NetworkService:
             logging.warning(f"Failed to get_available_ips: {e}")
             return None
 
+    def get_public_ips(self) -> List[IPv4Address] or List[IPv6Address] or None:
+        """
+        Get list of public IPs assigned to the FabNetv*Ext service
+        :return: List of Public IPs
+        :rtype: List[IPv4Address] or List[IPv6Address] or None
+        """
+        if self.get_fim_network_service().labels is not None:
+            if self.get_fim_network_service().labels.ipv4 is not None:
+                result = []
+                for x in self.get_fim_network_service().labels.ipv4:
+                    result.append(IPv4Address(x))
+                return result
+            elif self.get_fim_network_service().labels.ipv6 is not None:
+                result = []
+                for x in self.get_fim_network_service().labels.ipv6:
+                    result.append(IPv4Address(x))
+                return result
+        return None
+
     def get_subnet(self) -> IPv4Network or IPv6Network or None:
         """
         Gets the assigned subnet for a FABnet L3 IPv6 or IPv4 network


### PR DESCRIPTION
- Added support to return the list of IPs with external access back to the user. This hides the labels from fablib user and they can directly use the lis to configure interfaces.