### PR TITLE
Completing the support for A30/A40 so site listing should be possible

### DIFF
--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -952,6 +952,8 @@ class Node:
         - NVME_P4510: NVMe Storage Device
         - GPU_TeslaT4: Tesla T4 GPU
         - GPU_RTX6000: RTX6000 GPU
+        - GPU_A30: A30 GPU
+        - GPU_A40: A40 GPU
         :param model: the name of the component model to add
         :type model: String
         :param name: the name of the new component

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -70,6 +70,12 @@ class Resources:
         "rtx6000_available": "RTX6000 Available",
         "rtx6000_capacity": "RTX6000 Capacity",
         "rtx6000_allocated": "RTX6000 Allocated",
+        "a30_available": "A30 Available",
+        "a30_capacity": "A30 Capacity",
+        "a30_allocated": "A30 Allocated",
+        "a40_available": "A40 Available",
+        "a40_capacity": "A40 Capacity",
+        "a40_allocated": "A40 Allocated",
     }
 
     def __init__(self, fablib_manager):
@@ -113,6 +119,8 @@ class Resources:
                     f"{self.get_component_available(site_name,'NVME-P4510')}/{self.get_component_capacity(site_name,'NVME-P4510')}",
                     f"{self.get_component_available(site_name,'GPU-Tesla T4')}/{self.get_component_capacity(site_name,'GPU-Tesla T4')}",
                     f"{self.get_component_available(site_name,'GPU-RTX6000')}/{self.get_component_capacity(site_name,'GPU-RTX6000')}",
+                    f"{self.get_component_available(site_name, 'GPU-A30')}/{self.get_component_capacity(site_name, 'GPU-A30')}",
+                    f"{self.get_component_available(site_name, 'GPU-A40')}/{self.get_component_capacity(site_name, 'GPU-A40')}",
                 ]
             )
 
@@ -133,6 +141,8 @@ class Resources:
                 "P4510 (NVMe 1TB)",
                 "Tesla T4 (GPU)",
                 "RTX6000 (GPU)",
+                "A30 (GPU)",
+                "A40 (GPU)"
             ],
         )
 
@@ -608,6 +618,14 @@ class Resources:
             "rtx6000_capacity": self.get_component_capacity(site_name, "GPU-RTX6000"),
             "rtx6000_allocated": self.get_component_capacity(site_name, "GPU-RTX6000")
             - self.get_component_available(site_name, "GPU-RTX6000"),
+            "a30_available": self.get_component_available(site_name, "GPU-A30"),
+            "a30_capacity": self.get_component_capacity(site_name, "GPU-A30"),
+            "a30_allocated": self.get_component_capacity(site_name, "GPU-A30")
+                                 - self.get_component_available(site_name, "GPU-A30"),
+            "a40_available": self.get_component_available(site_name, "GPU-A40"),
+            "a40_capacity": self.get_component_capacity(site_name, "GPU-A40"),
+            "a40_allocated": self.get_component_capacity(site_name, "GPU-A40")
+                                 - self.get_component_available(site_name, "GPU-A40"),
         }
 
     def site_to_dictXXX(self, site):
@@ -745,6 +763,32 @@ class Resources:
                 "pretty_name": "RTX6000 Allocated",
                 "value": self.get_component_capacity(site_name, "GPU-RTX6000")
                 - self.get_component_available(site_name, "GPU-RTX6000"),
+            },
+            "a30_available": {
+                "pretty_name": "A30 Available",
+                "value": self.get_component_available(site_name, "GPU-A30"),
+            },
+            "a30_capacity": {
+                "pretty_name": "A30 Capacity",
+                "value": self.get_component_capacity(site_name, "GPU-A30"),
+            },
+            "A30_allocated": {
+                "pretty_name": "A30 Allocated",
+                "value": self.get_component_capacity(site_name, "GPU-A30")
+                         - self.get_component_available(site_name, "GPU-A30"),
+            },
+            "A40_available": {
+                "pretty_name": "A40 Available",
+                "value": self.get_component_available(site_name, "GPU-A40"),
+            },
+            "a40_capacity": {
+                "pretty_name": "A40 Capacity",
+                "value": self.get_component_capacity(site_name, "GPU-A40"),
+            },
+            "a40_allocated": {
+                "pretty_name": "A40 Allocated",
+                "value": self.get_component_capacity(site_name, "GPU-A40")
+                         - self.get_component_available(site_name, "GPU-A40"),
             },
         }
 

--- a/fabrictestbed_extensions/tests/component_tests.py
+++ b/fabrictestbed_extensions/tests/component_tests.py
@@ -55,6 +55,8 @@ class ComponentTest(AbcTest):
     COMPONENT_MODELS = {
         "GPU_Tesla_T4": ComponentModelType.GPU_Tesla_T4,
         "GPU_RTX6000": ComponentModelType.GPU_RTX6000,
+        "GPU_A30": ComponentModelType.GPU_A30,
+        "GPU_A40": ComponentModelType.GPU_A40,
         "SharedNIC_ConnectX_6": ComponentModelType.SharedNIC_ConnectX_6,
         "SmartNIC_ConnectX_6": ComponentModelType.SmartNIC_ConnectX_6,
         "SmartNIC_ConnectX_5": ComponentModelType.SmartNIC_ConnectX_5,


### PR DESCRIPTION
This addresses #170 

It is untested though - I need some help to figure out how best to test this. I want A30 and A40 GPUs to be listable in site resources and also so it is possible to search sites for these same way it is possible to search for RTX6000 and Teslas.