### PR TITLE
Addressing the occasional EOFError exception from Paramiko on reboot

### DIFF
--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -25,6 +25,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 import json
+import jinja2
 
 if TYPE_CHECKING:
     from fabrictestbed_extensions.fablib.slice import Slice

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -34,6 +34,7 @@ from typing import List, Dict
 
 from typing import TYPE_CHECKING
 
+from IPython.core.display_functions import display
 from fabrictestbed.util.constants import Constants
 from fabrictestbed_extensions import __version__ as fablib_version
 import pandas as pd

--- a/fabrictestbed_extensions/fablib/facility_port.py
+++ b/fabrictestbed_extensions/fablib/facility_port.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from tabulate import tabulate
 import json
+import jinja2
 
 from fabrictestbed.slice_editor import Labels, Capacities
 from fabrictestbed_extensions.fablib.interface import Interface

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -30,6 +30,7 @@ from fabrictestbed.slice_editor import Flags
 from tabulate import tabulate
 from ipaddress import IPv4Address
 import json
+import jinja2
 
 import logging
 

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -50,6 +50,7 @@ from fabric_cf.orchestrator.orchestrator_proxy import Status
 from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network
 import ipaddress
 import json
+import jinja2
 
 
 class NetworkService:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -31,6 +31,7 @@ import time
 import paramiko
 import logging
 
+from IPython.core.display_functions import display
 from fabrictestbed_extensions.fablib.network_service import NetworkService
 from tabulate import tabulate
 import select

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1292,9 +1292,13 @@ class Node:
                 else:
                     # Credit to Stack Overflow user tintin's post here: https://stackoverflow.com/a/32758464
                     stdout_chunks = []
-                    stdout_chunks.append(
-                        stdout.channel.recv(len(stdout.channel.in_buffer))
-                    )
+                    try:
+                        stdout_chunks.append(
+                            stdout.channel.recv(len(stdout.channel.in_buffer))
+                        )
+                    except EOFError:
+                        logging.warning('A Paramiko EOFError has occurred, '
+                                        'if this is part of a reboot sequence, it can be ignored')
                     stderr_chunks = []
 
                     while (
@@ -1377,7 +1381,7 @@ class Node:
 
             except Exception as e:
                 logging.warning(
-                    f"Exception in upload_file() (attempt #{attempt} of {retry}): {e}"
+                    f"Exception in node.execute() (attempt #{attempt} of {retry}): {e}"
                 )
 
                 if attempt + 1 == retry:
@@ -1636,7 +1640,7 @@ class Node:
         elif self.validIPAddress(management_ip) == "IPv6":
             src_addr = ("0:0:0:0:0:0:0:0", 22)
         else:
-            raise Exception(f"upload_file: Management IP Invalid: {management_ip}")
+            raise Exception(f"download_file: Management IP Invalid: {management_ip}")
         dest_addr = (management_ip, 22)
 
         for attempt in range(int(retry)):


### PR DESCRIPTION
- Also fixing error messages from other exceptions (cut-and-paste artifacts).
- Also fixing import error for display in node.py
- Similar in component.py
- Similar in fablib.py
- Similar for facility_port.py
- Similar for interface.py
- Similar for network_service.py