### PR TITLE
Fail early when connection with bastion host fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PR [#187](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/187))
 - Remove unused `AbcFabLIB` class (Issue
   [#117](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/117))
-
+- Fail early when connection with bastion host fails (Issue
+  [#151](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/151))
 
 ## [1.4.4] - 2023-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
 - Address a crash when querying NUMA properties. (Issue
   [#191](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/191),
   PR [#192](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/192))
+
+### Changed
+
+- Update list of OS images (PR
+  [#202](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/202))
+- List Facility Ports updated to include additional parameters (Issue
+  [#210](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/210))
+- Fail early when connection with bastion host fails (Issue
+  [#151](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/151))
+
+### Added
+
 - Add/update integration tests (Issues
   [#184](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/184),
   [#186](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/186),
   PR [#187](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/187))
-- Remove unused `AbcFabLIB` class (Issue
-  [#117](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/117))
-- Update list of OS images (PR
-  [#202](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/202))
-- Make Network Interface Config Idempotant (Issue[#205](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/205))
+- Make Network Interface Config Idempotant
+  (Issue [#205](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/205))
 - Methods added to retrieve SSH keys for bastion and sliver (PR
   [#207](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/207))
-- Fail early when connection with bastion host fails (Issue
-  [#151](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/151))
-- List Facility Ports updated to include additional parameters (Issue
-  [#210](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/210))
 
+### Removed
+  
+- Remove unused `AbcFabLIB` class (Issue
+  [#117](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/117))
 
 
 ## [1.4.4] - 2023-05-21

--- a/docs/source/fablib.rst
+++ b/docs/source/fablib.rst
@@ -61,6 +61,8 @@
 
    .. automethod:: get_bastion_private_ipv6_addr
 
+   .. automethod:: probe_bastion_host                   
+
    .. automethod:: get_slice_manager
 
    .. automethod:: new_slice

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1656,10 +1656,10 @@ class FablibManager:
             bastion_client = paramiko.SSHClient()
             bastion_client.set_missing_host_key_policy(paramiko.AutoAddPolicy)
 
-            bastion_host = self.fablib_manager.get_bastion_public_addr()
-            bastion_username = self.fablib_manager.get_bastion_username()
-            bastion_key_path = self.fablib_manager.get_bastion_key_filename()
-            bastion_key_passphrase = self.fablib_manager.get_bastion_key_passphrase()
+            bastion_host = self.get_bastion_public_addr()
+            bastion_username = self.get_bastion_username()
+            bastion_key_path = self.get_bastion_key_filename()
+            bastion_key_passphrase = self.get_bastion_key_passphrase()
 
             logging.info(
                 f"Probing bastion host {bastion_host} with "

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -33,6 +33,7 @@ from ipaddress import IPv4Network, IPv6Network
 from typing import TYPE_CHECKING, Dict, List
 
 import pandas as pd
+import paramiko
 from fabrictestbed.util.constants import Constants
 from IPython import get_ipython
 from IPython.core.display_functions import display
@@ -1665,10 +1666,10 @@ class FablibManager:
         paramiko.SSHException, not paramiko.AuthenticationException.
         """
 
-        try:
-            bastion_client = paramiko.SSHClient()
-            bastion_client.set_missing_host_key_policy(paramiko.AutoAddPolicy)
+        bastion_client = paramiko.SSHClient()
+        bastion_client.set_missing_host_key_policy(paramiko.AutoAddPolicy)
 
+        try:
             bastion_host = self.get_bastion_public_addr()
             bastion_username = self.get_bastion_username()
             bastion_key_path = self.get_bastion_key_filename()

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1694,19 +1694,11 @@ class FablibManager:
                 logging.info(f"Connection with {bastion_host} appears to be working")
                 return True
 
-        except paramiko.AuthenticationException as e:
-            # Report error and give up.
-            logging.error(f"Bastion auth error: {e}")
-            raise e
-
-        except paramiko.SSHException as e:
-            # Unsure how to handle this. Same as above maybe?
-            logging.error(f"Bastion SSH error: {e}")
-            raise e
-
-        except Exception as e:
-            # Could this be a transient error? Should we keep
-            # re-trying in that case?
+        # In theory paramiko can raise several types of exceptions,
+        # but in practice it has not been that precise.  Let us treat
+        # all exceptions as un-recoverable for now, and refine the
+        # behavior based on some real-world testing.
+        except (paramiko.SSHException, Exception) as e:
             logging.error(f"Bastion connection error: {e}")
             raise e
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1601,8 +1601,8 @@ class FablibManager:
         :return: FABRIC Bastion key filename
         :rtype: String
         """
-        return self.bastion_passphrase        
-    
+        return self.bastion_passphrase
+
     def get_bastion_public_addr(self) -> str:
         """
         Gets the FABRIC Bastion host address.

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1594,6 +1594,15 @@ class FablibManager:
         """
         return self.bastion_key_filename
 
+    def get_bastion_key_passphrase(self) -> str:
+        """
+        Gets the passphrase for FABRIC Bastion key.
+
+        :return: FABRIC Bastion key filename
+        :rtype: String
+        """
+        return self.bastion_passphrase        
+    
     def get_bastion_public_addr(self) -> str:
         """
         Gets the FABRIC Bastion host address.

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -608,6 +608,7 @@ class FablibManager:
         data_dir: str = None,
         output: str = None,
         execute_thread_pool_size: int = 64,
+        offline: bool = False,
     ):
         """
         Constructor. Builds FablibManager.  Tries to get configuration from:
@@ -789,7 +790,9 @@ class FablibManager:
         self.resources = None
         self.links = None
         self.facility_ports = None
-        self.build_slice_manager()
+
+        if not offline:
+            self.build_slice_manager()
 
     def _validate_configuration(self):
         """

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1602,15 +1602,6 @@ class FablibManager:
         """
         return self.bastion_key_filename
 
-    def get_bastion_key_passphrase(self) -> str:
-        """
-        Gets the passphrase for FABRIC Bastion key.
-
-        :return: FABRIC Bastion key filename
-        :rtype: String
-        """
-        return self.bastion_passphrase
-
     def get_bastion_key(self) -> str:
         """
         Reads the FABRIC Bastion private key file and returns the key.
@@ -1673,7 +1664,7 @@ class FablibManager:
             bastion_host = self.get_bastion_public_addr()
             bastion_username = self.get_bastion_username()
             bastion_key_path = self.get_bastion_key_filename()
-            bastion_key_passphrase = self.get_bastion_key_passphrase()
+            bastion_key_passphrase = self.bastion_passphrase
 
             logging.info(
                 f"Probing bastion host {bastion_host} with "

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1636,7 +1636,7 @@ class FablibManager:
         """
         return self.bastion_private_ipv6_addr
 
-    def _probe_bastion_host(self) -> bool:
+    def probe_bastion_host(self) -> bool:
         """
         See if bastion will admit us with our configuration.
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1649,8 +1649,8 @@ class FablibManager:
         use it with too many repeated authentication failures.  We
         want to avoid that.
 
-        Returns True if connection attempt succeeds.  Raises an error
-        in the event of failure.
+        Returns ``True`` if connection attempt succeeds.  Raises an
+        error in the event of failure.
         """
 
         bastion_client = paramiko.SSHClient()

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1651,10 +1651,6 @@ class FablibManager:
 
         Returns True if connection attempt succeeds.  Raises an error
         in the event of failure.
-
-        It seems that error reporting is not quite accurate.  When a
-        connection is attempted using the wrong ssh key, we get a
-        paramiko.SSHException, not paramiko.AuthenticationException.
         """
 
         bastion_client = paramiko.SSHClient()

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1519,8 +1519,8 @@ class Slice:
         See if bastion will admit us with our configuration.
 
         Bastion hosts are configured to block hosts that attempts to
-        use it with too many authentication failures.  We want to
-        avoid that.
+        use it with too many repeated authentication failures.  We
+        want to avoid that.
 
         Returns True if connection attempt succeeds.  Raises an error
         in the event of failure.

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1513,13 +1513,16 @@ class Slice:
             time.sleep(interval)
             self.update()
 
-    def _probe_bastion_host(self):
+    def _probe_bastion_host(self) -> bool:
         """
         See if bastion will admit us with our configuration.
 
         Bastion hosts are configured to block hosts that attempts to
         use it with too many authentication failures.  We want to
         avoid that.
+
+        Returns True if connection attempt succeeds.  Raises an error
+        in the event of failure.
         """
 
         try:

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1475,7 +1475,7 @@ class Slice:
         timeout_start = time.time()
         slice = self.sm_slice
 
-        self._probe_bastion()
+        self._probe_bastion_host()        
 
         # Wait for the slice to be stable ok
         self.wait(timeout=timeout, interval=interval, progress=progress)
@@ -1509,7 +1509,7 @@ class Slice:
             time.sleep(interval)
             self.update()
 
-    def _probe_bastion(self):
+    def _probe_bastion_host(self):
         """
         See if bastion will admit us with our configuration.
 

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1525,11 +1525,12 @@ class Slice:
             bastion_host = self.fablib_manager.get_bastion_public_addr()
             bastion_username = self.fablib_manager.get_bastion_username()
             bastion_key_path = self.fablib_manager.get_bastion_key_filename()
-            bastion_key_passphrase = None
+            bastion_key_passphrase = self.fablib_manager.get_bastion_key_passphrase()
 
             logging.info(
                 f"Probing bastion host {bastion_host} with "
-                f"username: {bastion_username}, key: {bastion_key_path}"
+                f"username: {bastion_username}, key: {bastion_key_path}, "
+                f"key passphrase: {'hidden' if bastion_key_passphrase else None}"
             )
 
             result = bastion_client.connect(

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1527,7 +1527,7 @@ class Slice:
             bastion_key_path = self.fablib_manager.get_bastion_key_filename()
             bastion_key_passphrase = None
 
-            logging.debug(
+            logging.info(
                 f"Probing bastion host {bastion_host} with "
                 f"username: {bastion_username}, key: {bastion_key}"
             )
@@ -1540,7 +1540,7 @@ class Slice:
                 look_for_keys=False,
             )
 
-            logging.debug(f"Bastion connection attempt result: {result}")
+            logging.info(f"Bastion connection attempt result: {result}")
 
             if result is None:
                 return False

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1475,7 +1475,11 @@ class Slice:
         timeout_start = time.time()
         slice = self.sm_slice
 
-        self._probe_bastion_host()        
+        try:
+            self._probe_bastion_host()        
+        except Exception as e:
+            print(f"Error when connecting to bastion host: {e}", file=stderr)
+            return False
 
         # Wait for the slice to be stable ok
         self.wait(timeout=timeout, interval=interval, progress=progress)

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1480,9 +1480,9 @@ class Slice:
             self.get_fablib_manager().probe_bastion_host()
         except Exception as e:
             print(f"Error when connecting to bastion host: {e}", file=sys.stderr)
-            # TODO: How to propagate this error?  If we can continue
-            # functioning without bastion, we can return False here;
-            # if we can't, we should perhaps raise an error?
+            # How to propagate this error?  If we can continue
+            # functioning without bastion, we can return False here.
+            # If we can't, we should raise an error?
             #
             # Seems that post_boot_config(), which is invoked after
             # wait_ssh(), needs bastion, so re-throwing the error

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1524,6 +1524,10 @@ class Slice:
 
         Returns True if connection attempt succeeds.  Raises an error
         in the event of failure.
+
+        It seems that error reporting is not quite accurate.  When a
+        connection is attempted using the wrong ssh key, we get a
+        paramiko.SSHException, not paramiko.AuthenticationException.
         """
 
         try:

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import ipaddress
 import json
 import logging
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
@@ -1476,9 +1477,9 @@ class Slice:
         slice = self.sm_slice
 
         try:
-            self._probe_bastion_host()        
+            self._probe_bastion_host()
         except Exception as e:
-            print(f"Error when connecting to bastion host: {e}", file=stderr)
+            print(f"Error when connecting to bastion host: {e}", file=sys.stderr)
             return False
 
         # Wait for the slice to be stable ok

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1521,69 +1521,6 @@ class Slice:
             time.sleep(interval)
             self.update()
 
-    def _probe_bastion_host(self) -> bool:
-        """
-        See if bastion will admit us with our configuration.
-
-        Bastion hosts are configured to block hosts that attempts to
-        use it with too many repeated authentication failures.  We
-        want to avoid that.
-
-        Returns True if connection attempt succeeds.  Raises an error
-        in the event of failure.
-
-        It seems that error reporting is not quite accurate.  When a
-        connection is attempted using the wrong ssh key, we get a
-        paramiko.SSHException, not paramiko.AuthenticationException.
-        """
-
-        try:
-            bastion_client = paramiko.SSHClient()
-            bastion_client.set_missing_host_key_policy(paramiko.AutoAddPolicy)
-
-            bastion_host = self.fablib_manager.get_bastion_public_addr()
-            bastion_username = self.fablib_manager.get_bastion_username()
-            bastion_key_path = self.fablib_manager.get_bastion_key_filename()
-            bastion_key_passphrase = self.fablib_manager.get_bastion_key_passphrase()
-
-            logging.info(
-                f"Probing bastion host {bastion_host} with "
-                f"username: {bastion_username}, key: {bastion_key_path}, "
-                f"key passphrase: {'hidden' if bastion_key_passphrase else None}"
-            )
-
-            result = bastion_client.connect(
-                hostname=bastion_host,
-                username=bastion_username,
-                key_filename=bastion_key_path,
-                passphrase=bastion_key_passphrase,
-                look_for_keys=False,
-            )
-
-            # Things should be fine if we are here.
-            if result is None:
-                logging.info(f"Connection with {bastion_host} appears to be working")
-                return True
-
-        except paramiko.AuthenticationException as e:
-            # Report error and give up.
-            logging.error(f"Bastion auth error: {e}")
-            raise e
-
-        except paramiko.SSHException as e:
-            # Unsure how to handle this. Same as above maybe?
-            logging.error(f"Bastion SSH error: {e}")
-            raise e
-
-        except Exception as e:
-            # Could this be a transient error? Should we keep
-            # re-trying in that case?
-            logging.error(f"Bastion connection error: {e}")
-            raise e
-
-        finally:
-            bastion_client.close()
-
     def test_ssh(self) -> bool:
         """
         Tests all nodes in the slices are accessible via ssh.

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1480,7 +1480,14 @@ class Slice:
             self._probe_bastion_host()
         except Exception as e:
             print(f"Error when connecting to bastion host: {e}", file=sys.stderr)
-            return False
+            # TODO: How to propagate this error?  If we can continue
+            # functioning without bastion, we can return False here;
+            # if we can't, we should perhaps raise an error?
+            #
+            # Seems that post_boot_config(), which is invoked after
+            # wait_ssh(), needs bastion, so re-throwing the error
+            # might be the right thing to do.
+            raise e
 
         # Wait for the slice to be stable ok
         self.wait(timeout=timeout, interval=interval, progress=progress)

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1522,18 +1522,18 @@ class Slice:
             bastion_client = paramiko.SSHClient()
             bastion_client.set_missing_host_key_policy(paramiko.AutoAddPolicy)
 
-            bastion_host = self.fablib_manager.get_bastion_host()
-            username = self.fablib_manager.get_bastion_username()
+            bastion_host = self.fablib_manager.get_bastion_public_addr()
+            bastion_username = self.fablib_manager.get_bastion_username()
             bastion_key_path = self.fablib_manager.get_bastion_key_filename()
             bastion_key_passphrase = None
 
             logging.info(
                 f"Probing bastion host {bastion_host} with "
-                f"username: {bastion_username}, key: {bastion_key}"
+                f"username: {bastion_username}, key: {bastion_key_path}"
             )
 
             result = bastion_client.connect(
-                hostname=bastion_hostname,
+                hostname=bastion_host,
                 username=bastion_username,
                 key_filename=bastion_key_path,
                 passphrase=bastion_key_passphrase,
@@ -1543,24 +1543,24 @@ class Slice:
             logging.info(f"Bastion connection attempt result: {result}")
 
             if result is None:
-                return False
+                raise Exception(f"Connection with {bastion_host} failed")
 
         except paramiko.AuthenticationException as e:
             # Report error and give up.
-            logger.error(f"Bastion auth error: {e}")
+            logging.error(f"Bastion auth error: {e}")
             raise e
             # return False
 
         except paramiko.SSHException as e:
             # Unsure how to handle this. Same as above maybe?
-            logger.error(f"Bastion SSH error: {e}")
+            logging.error(f"Bastion SSH error: {e}")
             raise e
             # return False
 
         except Exception as e:
             # Could this be a transient error? Should we keep
             # re-trying in that case?
-            logger.error(f"Some other error: {e}")
+            logging.error(f"Bastion connection error: {e}")
             raise e
             # return False
 

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1500,13 +1500,14 @@ class Slice:
             self.get_fablib_manager().probe_bastion_host()
         except Exception as e:
             print(f"Error when connecting to bastion host: {e}", file=sys.stderr)
-            # How to propagate this error?  If we can continue
-            # functioning without bastion, we can return False here.
-            # If we can't, we should raise an error?
+            # There are two choices here when it comes to propagating
+            # this error: (1) if we can continue functioning without
+            # bastion, we can return False here; (2) if we can't, we
+            # should re-raise the exception.
             #
-            # Seems that post_boot_config(), which is invoked after
-            # wait_ssh(), needs bastion, so re-throwing the error
-            # might be the right thing to do.
+            # It appears that post_boot_config(), which is invoked
+            # after wait_ssh(), needs bastion, so re-throwing the
+            # error might be the right thing to do.
             raise e
 
         # Wait for the slice to be stable ok

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1477,7 +1477,7 @@ class Slice:
         slice = self.sm_slice
 
         try:
-            self._probe_bastion_host()
+            self.get_fablib_manager().probe_bastion_host()
         except Exception as e:
             print(f"Error when connecting to bastion host: {e}", file=sys.stderr)
             # TODO: How to propagate this error?  If we can continue

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1540,34 +1540,29 @@ class Slice:
                 look_for_keys=False,
             )
 
-            logging.info(f"Bastion connection attempt result: {result}")
-
+            # Things should be fine if we are here.
             if result is None:
-                raise Exception(f"Connection with {bastion_host} failed")
+                logging.info(f"Connection with {bastion_host} appears to be working")
+                return True
 
         except paramiko.AuthenticationException as e:
             # Report error and give up.
             logging.error(f"Bastion auth error: {e}")
             raise e
-            # return False
 
         except paramiko.SSHException as e:
             # Unsure how to handle this. Same as above maybe?
             logging.error(f"Bastion SSH error: {e}")
             raise e
-            # return False
 
         except Exception as e:
             # Could this be a transient error? Should we keep
             # re-trying in that case?
             logging.error(f"Bastion connection error: {e}")
             raise e
-            # return False
 
         finally:
             bastion_client.close()
-
-        return True
 
     def test_ssh(self) -> bool:
         """

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -33,7 +33,6 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 import pandas as pd
-import paramiko
 from IPython.core.display_functions import display
 
 from fabrictestbed_extensions.fablib.facility_port import FacilityPort

--- a/tests/integration/test_bastion_ssh.py
+++ b/tests/integration/test_bastion_ssh.py
@@ -1,6 +1,10 @@
+import tempfile
 import unittest
 
+import paramiko
+
 from fabrictestbed_extensions.fablib.fablib import FablibManager
+
 
 class BastionHostTests(unittest.TestCase):
     """
@@ -17,3 +21,37 @@ class BastionHostTests(unittest.TestCase):
         fm = FablibManager(offline=True)
         result = fm.probe_bastion_host()
         self.assertTrue(result)
+
+    def test_probe_bastion_host_no_username(self):
+        """
+        Test bastion with an empty username.
+        """
+        fm = FablibManager(offline=True, bastion_username="")
+        self.assertRaises(
+            paramiko.ssh_exception.AuthenticationException, fm.probe_bastion_host
+        )
+
+    def test_probe_bastion_host_empty_key(self):
+        """
+        Test bastion with an empty key.
+        """
+        keyfile = tempfile.NamedTemporaryFile()
+
+        fm = FablibManager(offline=True, bastion_key_filename=keyfile.name)
+        self.assertRaises(
+            paramiko.ssh_exception.AuthenticationException, fm.probe_bastion_host
+        )
+
+    def test_probe_bastion_host_bad_key(self):
+        """
+        Test bastion with a key we just generated.
+        """
+        keyfile = tempfile.NamedTemporaryFile()
+
+        rsa_key = paramiko.RSAKey.generate(bits=2048)
+        rsa_key.write_private_key_file(keyfile.name)
+
+        fm = FablibManager(offline=True, bastion_key_filename=keyfile.name)
+        self.assertRaises(
+            paramiko.ssh_exception.AuthenticationException, fm.probe_bastion_host
+        )

--- a/tests/integration/test_bastion_ssh.py
+++ b/tests/integration/test_bastion_ssh.py
@@ -1,0 +1,19 @@
+import unittest
+
+from fabrictestbed_extensions.fablib.fablib import FablibManager
+
+class BastionHostTests(unittest.TestCase):
+    """
+    Test that bastion setup works.
+
+    Fablib needs bastion host name, username, ssh key, and the
+    (optional) key passphrase to function correctly.
+    """
+
+    def test_probe_bastion_host(self):
+        """
+        This should pass when fablib set up is correct.
+        """
+        fm = FablibManager(offline=True)
+        result = fm.probe_bastion_host()
+        self.assertTrue(result)

--- a/tests/integration/test_bastion_ssh.py
+++ b/tests/integration/test_bastion_ssh.py
@@ -19,8 +19,7 @@ class BastionHostTests(unittest.TestCase):
         This should pass when fablib set up is correct.
         """
         fm = FablibManager(offline=True)
-        result = fm.probe_bastion_host()
-        self.assertTrue(result)
+        self.assertTrue(fm.probe_bastion_host())
 
     def test_probe_bastion_host_no_username(self):
         """


### PR DESCRIPTION
Issue is #151.  

Currently `Slice.submit()` (and possibly `Slice.modify()` too) will spin on `wait_ssh()`, with repeated attempts every 20 seconds for for 1800 seconds.  With this change, when connection with bastion host fails, we fail early and report the failure.