### PR TITLE
Fix typo: "IPv46ddress" should be "IPv6Address"

### DIFF
--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1671,7 +1671,7 @@ class Slice:
                         not type(net.get_subnet())
                         in [ipaddress.IPv4Network, ipaddress.IPv6Network]
                         or not type(net.get_gateway())
-                        in [ipaddress.IPv4Address, ipaddress.IPv46ddress]
+                        in [ipaddress.IPv4Address, ipaddress.IPv6ddress]
                         or net.get_available_ips() == None
                     ):
                         logging.warning(

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1671,7 +1671,7 @@ class Slice:
                         not type(net.get_subnet())
                         in [ipaddress.IPv4Network, ipaddress.IPv6Network]
                         or not type(net.get_gateway())
-                        in [ipaddress.IPv4Address, ipaddress.IPv6ddress]
+                        in [ipaddress.IPv4Address, ipaddress.IPv6Address]
                         or net.get_available_ips() == None
                     ):
                         logging.warning(


### PR DESCRIPTION
While running mypy against fablib, I noticed these messages: 

```
fabrictestbed_extensions/fablib/interface.py:785: error: Module "ipaddress" is not valid as a type  [valid-type]
fabrictestbed_extensions/fablib/slice.py:849: error: Module "ipaddress" is not valid as a type  [valid-type]
fabrictestbed_extensions/fablib/slice.py:850: error: Module "ipaddress" is not valid as a type  [valid-type]
```

which led me to this:

https://github.com/fabric-testbed/fabrictestbed-extensions/blob/93214307dce67b4830990fee0ae1010bd38899e0/fabrictestbed_extensions/fablib/slice.py#L1674

It probably escaped attention because it is in a less used code path, and also because Python ¯\\\_(ツ)\_/¯

I have been trying various checkers (ruff, flake8, mypy) against fablib, and interestingly none of them caught this directly.  This is a minor fix, but I also wanted to use the opportunity to make the case that _maybe_ at least _some_ checking could be helpful...