### PR TITLE
205 interface re config

### DIFF
--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -1,3 +1,3 @@
 # Please update version number here when making a release: flit, the
 # build backend we use, picks up the version from here.
-__version__ = "1.5.1"
+__version__ = "1.5.2b1"

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -472,6 +472,17 @@ class Interface:
         self.get_node().ip_link_down(None, self)
         self.get_node().ip_link_up(None, self)
 
+    def un_manage_interface(self):
+        """
+        Mark an interface unmanaged by Network Manager;
+        This is needed to be run on rocky* images to avoid the
+        network configuration from being overwritten by NetworkManager
+        """
+        if self.get_network() is None:
+            return
+
+        self.get_node().un_manage_interface(None, self)
+
     def set_vlan(self, vlan: Any = None):
         """
         Set the VLAN on the FABRIC request.
@@ -873,6 +884,7 @@ class Interface:
             subnet = self.get_network().get_subnet()
             addr = fablib_data.get(self.ADDR)
             if addr and subnet:
+                self.un_manage_interface()
                 self.ip_link_up()
                 self.ip_addr_add(addr=addr, subnet=ipaddress.ip_network(subnet))
         else:

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -481,7 +481,7 @@ class Interface:
         if self.get_network() is None:
             return
 
-        self.get_node().un_manage_interface(None, self)
+        self.get_node().un_manage_interface(self)
 
     def set_vlan(self, vlan: Any = None):
         """

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -862,7 +862,7 @@ class Interface:
         else:
             mode = self.MANUAL
 
-        if mode == self.AUTO and addr is not None:
+        if mode == self.AUTO and addr is None:
             fablib_data[self.ADDR] = str(self.get_network().allocate_ip())
             # addr = fablib_data[self.ADDR]
             # print(f"auto allocated addr: {addr}")

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2166,6 +2166,26 @@ class Node:
             logging.warning(f"Failed to del addr: {e}")
             raise e
 
+    def un_manage_interface(self, interface: Interface):
+        """
+        Mark an interface unmanaged by Network Manager;
+        This is needed to be run on rocky* images to avoid the
+        network configuration from being overwritten by NetworkManager
+        :param interface: the FABlib interface.
+        :type interface: Interface
+        """
+
+        if interface is None:
+            return
+
+        try:
+            self.execute(
+                f"sudo nmcli dev set {interface.get_physical_os_interface()} managed no",
+                quiet=True,
+            )
+        except Exception as e:
+            logging.warning(f"Failed to mark interface as unmanaged: {e}")
+
     def ip_link_up(self, subnet: Union[IPv4Network, IPv6Network], interface: Interface):
         """
         Bring up a link on an interface on the node.

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2180,7 +2180,7 @@ class Node:
 
         try:
             self.execute(
-                f"sudo nmcli dev set {interface.get_physical_os_interface()} managed no",
+                f"sudo nmcli dev set {interface.get_physical_os_interface_name()} managed no",
                 quiet=True,
             )
         except Exception as e:
@@ -2221,7 +2221,7 @@ class Node:
 
         try:
             self.execute(
-                f"{ip_command} link set dev {interface.get_physical_os_interface()} up",
+                f"{ip_command} link set dev {interface.get_physical_os_interface_name()} up",
                 quiet=True,
             )
         except Exception as e:


### PR DESCRIPTION
- `Interface::config` made idempotent
   - Allocate IP address only if IP can not be found in `fablib_data` 
   - Mark the interface as `unamanged` via nmcli (Prevent NetworkManager from overwriting the config)
   - Bring up the interface
   - Set the IP Address
- Added an integration test