### PR TITLE
Address warnings when running sphinx-build

### DIFF
--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1062,9 +1062,9 @@ class FablibManager:
         :param filter_function: lambda function
         :type filter_function: lambda
         :return: table in format specified by output parameter
-        :param update
-        :param pretty_names
-        :param force_refresh
+        :param update:
+        :param pretty_names:
+        :param force_refresh:
         :rtype: Object
         """
         return self.get_resources(
@@ -1755,11 +1755,12 @@ class FablibManager:
         """
         Get the available resources.
 
-        Optionally update the available resources by querying the FABRIC
-        services. Otherwise, this method returns the existing information.
+        Optionally update the available resources by querying the
+        FABRIC services.  Otherwise, this method returns the existing
+        information.
 
         :param update:
-        :param force_refresh
+        :param force_refresh:
         :return: Available Resources object
         """
         from fabrictestbed_extensions.fablib.resources import Resources
@@ -1937,8 +1938,9 @@ class FablibManager:
 
         :param excludes: A list of slice states to exclude from the output list
         :type excludes: List[SliceState]
-        :param slice_name
-        :param slice_id
+        :param slice_name:
+        :param slice_id:
+
         :return: a list of slices
         :rtype: List[Slice]
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1145,34 +1145,48 @@ class Node:
         """
         Runs a command on the FABRIC node.
 
-        The function uses paramiko to ssh to the FABRIC node and execute an arbitrary shell command.
-
+        The function uses paramiko to ssh to the FABRIC node and
+        execute an arbitrary shell command.
 
         :param command: the command to run
         :type command: str
+
         :param retry: the number of times to retry SSH upon failure
         :type retry: int
-        :param retry_interval: the number of seconds to wait before retrying SSH upon failure
+
+        :param retry_interval: the number of seconds to wait before
+            retrying SSH upon failure
         :type retry_interval: int
+
         :param username: username
         :type username: str
+
         :param private_key_file: path to private key file
         :type private_key_file: str
+
         :param private_key_passphrase: pass phrase
         :type private_key_passphrase: str
-        :param output_file: path to a file where the stdout/stderr will be written. None for no file output
+
+        :param output_file: path to a file where the stdout/stderr
+            will be written.  None for no file output
         :type output_file: List[str]
+
         :param output: print stdout and stderr to the screen
         :type output: bool
-        :param read_timeout: the number of seconds to wait before retrying to
-        read from stdout and stderr
+
+        :param read_timeout: the number of seconds to wait before
+            retrying to read from stdout and stderr
         :type read_timeout: int
-        :param timeout: the number of seconds to wait before terminating the
-        command using the linux timeout command. Specifying a timeout
-        encapsulates the command with the timeout command for you
+
+        :param timeout: the number of seconds to wait before
+            terminating the command using the linux timeout command.
+            Specifying a timeout encapsulates the command with the
+            timeout command for you
         :type timeout: int
-        :return: a tuple of  (stdout[Sting],stderr[String])
+
+        :return: a tuple of (stdout[Sting],stderr[String])
         :rtype: Tuple
+
         :raise Exception: if management IP is invalid
         """
         import logging

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1041,24 +1041,38 @@ class Slice:
 
         :param name: Name of the new node
         :type name: String
-        :param site: (Optional) Name of the site to deploy the node on.
-            Default to a random site.
+
+        :param site: (Optional) Name of the site to deploy the node
+            on.  Default to a random site.
         :type site: String
-        :param cores: (Optional) Number of cores in the node. Default: 2 cores
+
+        :param cores: (Optional) Number of cores in the node.
+            Default: 2 cores
         :type cores: int
-        :param ram: (Optional) Amount of ram in the node. Default: 8 GB
+
+        :param ram: (Optional) Amount of ram in the node.  Default: 8
+            GB
         :type ram: int
-        :param disk: (Optional) Amount of disk space n the node. Default: 10 GB
+
+        :param disk: (Optional) Amount of disk space n the node.
+            Default: 10 GB
         :type disk: int
-        :param image: (Optional) The image to uese for the node. Default: default_rocky_8
+
+        :param image: (Optional) The image to uese for the node.
+            Default: default_rocky_8
         :type image: String
-        :param instance_type
-        :param host: (Optional) The physical host to deploy the node. Each site
-            has worker nodes numbered 1, 2, 3, etc. Host names follow the pattern
-            in this example of STAR worker number 1: "star-w1.fabric-testbed.net".
-            Default: unset
+
+        :param instance_type:
+        :type instance_type: String
+
+        :param host: (Optional) The physical host to deploy the node.
+            Each site has worker nodes numbered 1, 2, 3, etc.  Host
+            names follow the pattern in this example of STAR worker
+            number 1: "star-w1.fabric-testbed.net".  Default: unset
         :type host: String
-        :param avoid: (Optional) A list of sites to avoid is allowing random site.
+
+        :param avoid: (Optional) A list of sites to avoid is allowing
+            random site.
         :type avoid: List[String]
 
         :return: a new node

--- a/tox.ini
+++ b/tox.ini
@@ -27,4 +27,4 @@ deps =
      furo
 
 commands =
-    sphinx-build -b html {toxinidir}/docs/source/ {toxinidir}/docs/build/html
+    sphinx-build -W -b html {toxinidir}/docs/source/ {toxinidir}/docs/build/html


### PR DESCRIPTION
Issue is #86.  Changes:

- Fixes some warnings that Sphinx reports when generating API docs.
- Run `sphinx-build` with a `-W` argument such that `tox -e docs` will treat warnings as errors.

Will follow up with some fixes for #219. I wanted to keep this PR small in scope, so that the other stuff can be separately addressed.