### PR TITLE
Format docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Overhaul API docs (PR
   [#217](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/217),
   issue [#215](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/215))
+- Update/reformat API docstrings (PR
+  [#220](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/220))
 
 ### Added
 

--- a/docs/source/component.rst
+++ b/docs/source/component.rst
@@ -6,4 +6,4 @@ Component
 
 .. autoclass:: fabrictestbed_extensions.fablib.component.Component
    :members:
-   :special-members:
+   :special-members: __init__, __str__

--- a/docs/source/fablib.rst
+++ b/docs/source/fablib.rst
@@ -6,4 +6,4 @@ FablibManager
 
 .. autoclass:: fabrictestbed_extensions.fablib.fablib.FablibManager
    :members:
-   :special-members:
+   :special-members: __init__, __str__

--- a/docs/source/facility_port.rst
+++ b/docs/source/facility_port.rst
@@ -6,4 +6,4 @@ FacilityPort
 
 .. autoclass:: fabrictestbed_extensions.fablib.facility_port.FacilityPort
    :members:
-   :special-members:
+   :special-members: __init__, __str__

--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -6,4 +6,4 @@ Interface
 
 .. autoclass:: fabrictestbed_extensions.fablib.interface.Interface
    :members:
-   :special-members:
+   :special-members: __init__, __str__

--- a/docs/source/network_service.rst
+++ b/docs/source/network_service.rst
@@ -6,4 +6,4 @@ NetworkService
 
 .. autoclass:: fabrictestbed_extensions.fablib.network_service.NetworkService
    :members:
-   :special-members:
+   :special-members: __init__, __str__

--- a/docs/source/node.rst
+++ b/docs/source/node.rst
@@ -6,4 +6,4 @@ Node
 
 .. autoclass:: fabrictestbed_extensions.fablib.node.Node
    :members:
-   :special-members:
+   :special-members: __init__, __str__

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -6,4 +6,4 @@ Resources
 
 .. autoclass:: fabrictestbed_extensions.fablib.resources.Resources
    :members:
-   :special-members:
+   :special-members: __init__, __str__

--- a/docs/source/slice.rst
+++ b/docs/source/slice.rst
@@ -6,4 +6,4 @@ Slice
 
 .. autoclass:: fabrictestbed_extensions.fablib.slice.Slice
    :members:
-   :special-members:
+   :special-members: __init__, __str__

--- a/fabrictestbed_extensions/fablib/facility_port.py
+++ b/fabrictestbed_extensions/fablib/facility_port.py
@@ -45,9 +45,11 @@ class FacilityPort:
 
     def __init__(self, slice: Slice, fim_interface: FimInterface):
         """
-        Constructor. Sets the fablib slice and FIM node based on arguments.
+        Sets the fablib slice and FIM node based on arguments.
+
         :param slice: the fablib slice to have this node on
         :type slice: Slice
+
         :param node: the FIM node that this Node represents
         :type node: Node
         """
@@ -57,8 +59,9 @@ class FacilityPort:
 
     def __str__(self):
         """
-        Creates a tabulated string describing the properties of the node.
-        Intended for printing node information.
+        Creates a tabulated string describing the properties of the
+        node.  Intended for printing node information.
+
         :return: Tabulated string of node information
         :rtype: String
         """
@@ -157,6 +160,7 @@ class FacilityPort:
     def get_slice(self) -> Slice:
         """
         Gets the fablib slice associated with this node.
+
         :return: the fablib slice on this node
         :rtype: Slice
         """
@@ -165,16 +169,22 @@ class FacilityPort:
     def get_interfaces(self) -> List[Interface]:
         """
         Gets a particular interface associated with a FABRIC node.
-        Accepts either the interface name or a network_name. If a network name
-        is used this method will return the interface on the node that is
-        connected to the network specified.
-        If a name and network_name are both used, the interface name will
+
+        Accepts either the interface name or a network_name.  If a
+        network name is used this method will return the interface on
+        the node that is connected to the network specified.  If a
+        name and network_name are both used, the interface name will
         take precedence.
+
         :param name: interface name to search for
         :type name: str
+
         :param network_name: network name to search for
+
         :type name: str
+
         :raise Exception: if interface is not found
+
         :return: an interface on the node
         :rtype: Interface
         """

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -236,8 +236,10 @@ class NetworkService:
         mirror_direction: str = "both",
     ) -> NetworkService:
         """
-        Instantiate a new PortMirror service
-        mirror_direction can be "rx", "tx" or "both" (non-case-sensitive)
+        Instantiate a new PortMirror service.
+
+        ``mirror_direction`` can be ``"rx"``, ``"tx"`` or ``"both"``
+        (non-case-sensitive)
         """
         # decode the direction
         if not isinstance(mirror_interface_name, str):

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2053,6 +2053,7 @@ class Node:
     def test_ssh(self) -> bool:
         """
         Test whether SSH is functional on the node.
+
         :return: true if SSH is working, false otherwise
         :rtype: bool
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1992,8 +1992,9 @@ class Node:
 
     def get_management_os_interface(self) -> str or None:
         """
-        Gets the name of the management interface used by the node's operating
-        system.
+        Gets the name of the management interface used by the node's
+        operating system.
+
         :return: interface name
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -179,7 +179,7 @@ class Node:
     def get_node(slice: Slice = None, node=None):
         """
         Returns a new fablib node using existing FABRIC resources.
-        
+
         :note: Not intended for API call.
 
         :param slice: the fablib slice storing the existing node

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -841,6 +841,7 @@ class Node:
     def get_interfaces(self) -> List[Interface] or None:
         """
         Gets a list of the interfaces associated with the FABRIC node.
+
         :return: a list of interfaces on the node
         :rtype: List[Interface]
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -534,31 +534,37 @@ class Node:
         pretty_names=True,
     ):
         """
-        Lists all the networks attached to  the nodes with their attributes.
+        Lists all the networks attached to the nodes with their
+        attributes.
 
-        There are several output options: "text", "pandas", and "json" that determine the format of the
-        output that is returned and (optionally) displayed/printed.
+        There are several output options: "text", "pandas", and "json"
+        that determine the format of the output that is returned and
+        (optionally) displayed/printed.
 
-        output:  'text': string formatted with tabular
-                  'pandas': pandas dataframe
-                  'json': string in json format
+        output: 'text': string formatted with tabular 'pandas': pandas
+        dataframe 'json': string in json format
 
         fields: json output will include all available fields/columns.
 
         Example: fields=['Name','Type']
 
-        filter_function:  A lambda function to filter data by field values.
+        filter_function: A lambda function to filter data by field
+        values.
 
         Example: filter_function=lambda s: s['Type'] == 'FABNetv4'
 
         :param output: output format
         :type output: str
+
         :param fields: list of fields (table columns) to show
         :type fields: List[str]
+
         :param quiet: True to specify printing/display
         :type quiet: bool
+
         :param filter_function: lambda function
         :type filter_function: lambda
+
         :return: table in format specified by output parameter
         :rtype: Object
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -691,11 +691,16 @@ class Node:
 
     def set_image(self, image: str, username: str = None, image_type: str = "qcow2"):
         """
-        Sets the image information of this fablib node on the FABRIC node.
+        Sets the image information of this fablib node on the FABRIC
+        node.
+
         :param image: the image reference to set
         :type image: String
-        :param username: the username of this fablib node. Currently unused.
+
+        :param username: the username of this fablib node.  Currently
+            unused.
         :type username: String
+
         :param image_type: the image type to set
         :type image_type: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1546,18 +1546,27 @@ class Node:
         retry_interval: int = 10,
     ):
         """
-        Creates a thread that calls node.upload_file().  Results from the thread can be
-        retrieved with by calling thread.result()
+        Creates a thread that calls ``node.upload_file()``.
+
+        Results from the thread can be retrieved with by calling
+        ``thread.result()``.
+
         :param local_file_path: the path to the file to upload
         :type local_file_path: str
-        :param remote_file_path: the destination path of the file on the node
+
+        :param remote_file_path: the destination path of the file on
+            the node
         :type remote_file_path: str
+
         :param retry: how many times to retry SCP upon failure
         :type retry: int
+
         :param retry_interval: how often to retry SCP on failure
         :type retry_interval: int
-        :return: a thread that called node.execute()
+
+        :return: a thread that called ``node.execute()``
         :rtype: Thread
+
         :raise Exception: if management IP is invalid
         """
         return (

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -300,27 +300,36 @@ class Node:
         """
         Show a table containing the current node attributes.
 
-        There are several output options: "text", "pandas", and "json" that determine the format of the
-        output that is returned and (optionally) displayed/printed.
+        There are several output options: ``"text"``, ``"pandas"``,
+        and ``"json"`` that determine the format of the output that is
+        returned and (optionally) displayed/printed.
 
-        output:  'text': string formatted with tabular
-                  'pandas': pandas dataframe
-                  'json': string in json format
+        :param output: output format.  Options are:
 
-        fields: json output will include all available fields.
+                - ``"text"``: string formatted with tabular
 
-        Example: fields=['Name','State']
+                - ``"pandas"``: pandas dataframe
 
-        :param output: output format
+                - ``"json"``: string in json format
+
         :type output: str
-        :param fields: list of fields to show
+
+        :param fields: List of fields to show.  JSON output will
+            include all available fields.
         :type fields: List[str]
+
         :param quiet: True to specify printing/display
         :type quiet: bool
+
         :param colors: True to specify state colors for pandas output
         :type colors: bool
+
         :return: table in format specified by output parameter
         :rtype: Object
+
+        Here's an example of ``fields``::
+
+            fields=['Name','State']
         """
 
         data = self.toDict()

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1900,16 +1900,25 @@ class Node:
     ):
         """
         Upload a directory to remote location on the node.
-        Makes a gzipped tarball of a directory and uploades it to a node. Then
-        unzips and tars the directory at the remote_directory_path
-        :param local_directory_path: the path to the directory to upload
+
+        Makes a gzipped tarball of a directory and uploads it to a
+        node.  Then unzips and untars the directory at the
+        ``remote_directory_path``.
+
+        :param local_directory_path: the path to the directory to
+            upload
         :type local_directory_path: str
-        :param remote_directory_path: the destination path of the directory on the node
+
+        :param remote_directory_path: the destination path of the
+            directory on the node
         :type remote_directory_path: str
+
         :param retry: how many times to retry SCP upon failure
         :type retry: int
+
         :param retry_interval: how often to retry SCP on failure
         :type retry_interval: int
+
         :raise Exception: if management IP is invalid
         """
         import os

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -683,6 +683,7 @@ class Node:
     def get_slice(self) -> Slice:
         """
         Gets the fablib slice associated with this node.
+
         :return: the fablib slice on this node
         :rtype: Slice
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2178,8 +2178,10 @@ class Node:
     ):
         """
         Delete a route on the node.
+
         :param subnet: The destination subnet
-        :type subnet:  IPv4Network or IPv6Network
+        :type subnet: IPv4Network or IPv6Network
+
         :param gateway: The next hop gateway.
         :type gateway: IPv4Address or IPv6Address
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -907,6 +907,7 @@ class Node:
     def get_username(self) -> str:
         """
         Gets the username on this fablib node.
+
         :return: the username on this node
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -942,8 +942,10 @@ class Node:
     def get_private_key_file(self) -> str:
         """
         Gets the private key file path on the fablib slice.
-        Important! Slice key management is underdevelopment and this
+
+        Important!  Slice key management is underdevelopment and this
         functionality will likely change going forward.
+
         :return: the private key path
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -954,8 +954,10 @@ class Node:
     def get_private_key_passphrase(self) -> str:
         """
         Gets the private key passphrase on the FABLIB slice.
-        Important! Slice key management is underdevelopment and this
+
+        Important!  Slice key management is underdevelopment and this
         functionality will likely change going forward.
+
         :return: the private key passphrase
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -908,8 +908,10 @@ class Node:
     def get_public_key(self) -> str:
         """
         Gets the public key on fablib node.
-        Important! Slice key management is underdevelopment and this
+
+        Important!  Slice key management is underdevelopment and this
         functionality will likely change going forward.
+
         :return: the public key on the node
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1581,14 +1581,20 @@ class Node:
     ):
         """
         Upload a local file to a remote location on the node.
+
         :param local_file_path: the path to the file to upload
         :type local_file_path: str
-        :param remote_file_path: the destination path of the file on the node
+
+        :param remote_file_path: the destination path of the file on
+            the node
         :type remote_file_path: str
+
         :param retry: how many times to retry SCP upon failure
         :type retry: int
+
         :param retry_interval: how often to retry SCP on failure
         :type retry_interval: int
+
         :raise Exception: if management IP is invalid
         """
         logging.debug(

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2329,8 +2329,10 @@ class Node:
     def un_manage_interface(self, interface: Interface):
         """
         Mark an interface unmanaged by Network Manager;
-        This is needed to be run on rocky* images to avoid the
-        network configuration from being overwritten by NetworkManager
+
+        This is needed to be run on rocky* images to avoid the network
+        configuration from being overwritten by NetworkManager
+
         :param interface: the FABlib interface.
         :type interface: Interface
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -726,8 +726,9 @@ class Node:
 
     def set_site(self, site):
         """
-        Sets the hostname of this fablib node on the FABRIC node.
-        :param host_name: the hostname. example: host_name='renc-w2.fabric-testbed.net'
+        Sets the site of this fablib node on FABRIC.
+
+        :param site: the site
         :type host_name: String
         """
         # example: host_name='renc-w2.fabric-testbed.net'

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2990,13 +2990,15 @@ class Node:
         """
         Perform operation action on a VM; an action which is triggered by CF via the Aggregate
 
-        @param operation operation to be performed
-        @param vcpu_cpu_map virtual cpu to host cpu map
-        @param node_set list of numa nodes
-        @param keys list of ssh keys
-        @raises Exception in case of failure
+        :param operation: operation to be performed
+        :param vcpu_cpu: map virtual cpu to host cpu map
+        :param node_set: list of numa nodes
+        :param keys list: of ssh keys
 
-        @return State of POA or Dictionary containing the info, in case of INFO POAs
+        :raise Exception: in case of failure
+
+        :return: State of POA or Dictionary containing the info, in
+                 case of INFO POAs
         """
         retry = 20
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -804,6 +804,7 @@ class Node:
     def get_reservation_id(self) -> str or None:
         """
         Gets the reservation ID on the FABRIC node.
+
         :return: reservation ID on the node
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -377,38 +377,43 @@ class Node:
         """
         Lists all the components in the node with their attributes.
 
-        There are several output options: "text", "pandas", and "json"
-        that determine the format of the output that is returned and
-        (optionally) displayed/printed.
+        There are several output options: ``"text"``, ``"pandas"``,
+        and ``"json"`` that determine the format of the output that is
+        returned and (optionally) displayed/printed.
 
-        fields: json output will include all available fields/columns.
+        :param output: output format.  Output can be one of:
 
-        Example: fields=['Name','Model']
+                - ``"text"``: string formatted with tabular
 
-        filter_function: A lambda function to filter data by field
-        values.
+                - ``"pandas"``: pandas dataframe
 
-        Example: filter_function=lambda s: s['Model'] == 'NIC_Basic'
-
-        :param output: output format. Output can be one of:
-
-            - ``"text"``: string formatted with tabular
-            - ``"pandas"``: pandas dataframe
-            - ``"json"``: string in json format
+                - ``"json"``: string in json format
 
         :type output: str
 
-        :param fields: list of fields (table columns) to show
+        :param fields: list of fields (table columns) to show.  JSON
+            output will include all available fields/columns.
         :type fields: List[str]
 
         :param quiet: True to specify printing/display
         :type quiet: bool
 
-        :param filter_function: lambda function
+        :param filter_function: A lambda function to filter data by
+            field values.
+
         :type filter_function: lambda
 
         :return: table in format specified by output parameter
         :rtype: Object
+
+
+        Here's an example of ``fields``::
+
+            fields=['Name','Model']
+
+        Here's an example of ``filter_function``::
+
+            filter_function=lambda s: s['Model'] == 'NIC_Basic'
         """
 
         components = []

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -928,8 +928,10 @@ class Node:
     def get_private_key(self) -> str:
         """
         Gets the private key on the fablib node.
-        Important! Slice key management is underdevelopment and this
+
+        Important!  Slice key management is underdevelopment and this
         functionality will likely change going forward.
+
         :return: the private key on the node
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -122,8 +122,10 @@ class Node:
 
     def get_sliver(self) -> OrchestratorSliver:
         """
-        Not intended as API call
-        Gets the node SM sliver
+        Gets the node SM sliver.
+
+        :note: Not intended as API call.
+
         :return: SM sliver for the node
         :rtype: Sliver
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -164,12 +164,16 @@ class Node:
     @staticmethod
     def get_node(slice: Slice = None, node=None):
         """
-        Not intended for API call.
         Returns a new fablib node using existing FABRIC resources.
+        
+        :note: Not intended for API call.
+
         :param slice: the fablib slice storing the existing node
         :type slice: Slice
+
         :param node: the FIM node stored in this fablib node
         :type node: Node
+
         :return: a new fablib node storing resources
         :rtype: Node
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3143,10 +3143,12 @@ class Node:
 
     def pin_cpu(self, component_name: str, cpu_range_to_pin: str = None):
         """
-        Pin the cpus for the VM to the numa node associated with the component
+        Pin the cpus for the VM to the numa node associated with the
+        component.
 
-        @param component_name: Component Name
-        @param cpu_range_to_pin: range of the cpus to pin; example: 0-1 or 0
+        :param component_name: Component Name
+        :param cpu_range_to_pin: range of the cpus to pin; example:
+            0-1 or 0
         """
         try:
             allocated_cpu_list = list(range(0, self.get_cores()))

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2571,6 +2571,7 @@ class Node:
     def ping_test(self, dst_ip: str) -> bool:
         """
         Test a ping from the node to a destination IP
+
         :param dst_ip: destination IP String.
         :type dst_ip: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3058,7 +3058,7 @@ class Node:
         """
         Get CPU Information for the Node and the host on which the VM is running
 
-        @return cpu info dict
+        :return: cpu info dict
         """
         """
         Host INFO looks like:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3106,7 +3106,7 @@ class Node:
         """
         Get Numa Information for the Node and the host on which the VM is running
 
-        @return numa info dict
+        :return: numa info dict
         """
         """
         Host INFO looks like:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1901,7 +1901,7 @@ class Node:
         :param retry_interval: how often to retry SCP on failure
         :type retry_interval: int
 
-        :return: a thread that called node.download_file()
+        :return: a thread that called ``node.upload_directory()``
         :rtype: Thread
 
         :raise Exception: if management IP is invalid

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -377,29 +377,34 @@ class Node:
         """
         Lists all the components in the node with their attributes.
 
-        There are several output options: "text", "pandas", and "json" that determine the format of the
-        output that is returned and (optionally) displayed/printed.
+        There are several output options: "text", "pandas", and "json"
+        that determine the format of the output that is returned and
+        (optionally) displayed/printed.
 
-        output:  'text': string formatted with tabular
-                  'pandas': pandas dataframe
-                  'json': string in json format
+        output: 'text': string formatted with tabular 'pandas': pandas
+        dataframe 'json': string in json format
 
         fields: json output will include all available fields/columns.
 
         Example: fields=['Name','Model']
 
-        filter_function:  A lambda function to filter data by field values.
+        filter_function: A lambda function to filter data by field
+        values.
 
         Example: filter_function=lambda s: s['Model'] == 'NIC_Basic'
 
         :param output: output format
         :type output: str
+
         :param fields: list of fields (table columns) to show
         :type fields: List[str]
+
         :param quiet: True to specify printing/display
         :type quiet: bool
+
         :param filter_function: lambda function
         :type filter_function: lambda
+
         :return: table in format specified by output parameter
         :rtype: Object
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -136,16 +136,23 @@ class Node:
         slice: Slice = None, name: str = None, site: str = None, avoid: List[str] = []
     ):
         """
-        Not intended for API call. See: Slice.add_node()
-        Creates a new FABRIC node and returns a fablib node with the new node.
+        Not intended for API call.  See: Slice.add_node()
+
+        Creates a new FABRIC node and returns a fablib node with the
+        new node.
+
         :param slice: the fablib slice to build the new node on
         :type slice: Slice
+
         :param name: the name of the new node
         :type name: str
+
         :param site: the name of the site to build the node on
         :type site: str
+
         :param avoid: a list of node names to avoid
         :type avoid: List[str]
+
         :return: a new fablib node
         :rtype: Node
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2097,8 +2097,10 @@ class Node:
     ):
         """
         Add a route on the node.
+
         :param subnet: The destination subnet
-        :type subnet:  IPv4Network or IPv6Network
+        :type subnet: IPv4Network or IPv6Network
+
         :param gateway: The next hop gateway.
         :type gateway: IPv4Address or IPv6Address
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2201,10 +2201,13 @@ class Node:
     ):
         """
         Add an IP to an interface on the node.
+
         :param addr: IP address
-        :type addr:  IPv4Address or IPv6Address
+        :type addr: IPv4Address or IPv6Address
+
         :param subnet: subnet.
         :type subnet: IPv4Network or IPv6Network
+
         :param interface: the FABlib interface.
         :type interface: Interface
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -786,6 +786,7 @@ class Node:
     def get_management_ip(self) -> str or None:
         """
         Gets the management IP on the FABRIC node.
+
         :return: management IP
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -820,6 +820,7 @@ class Node:
     def get_reservation_state(self) -> str or None:
         """
         Gets the reservation state on the FABRIC node.
+
         :return: the reservation state on the node
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2335,8 +2335,10 @@ class Node:
     ):
         """
         Bring down a link on an interface on the node.
+
         :param subnet: subnet.
         :type subnet: IPv4Network or IPv6Network
+
         :param interface: the FABlib interface.
         :type interface: Interface
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2282,8 +2282,10 @@ class Node:
     def ip_link_up(self, subnet: Union[IPv4Network, IPv6Network], interface: Interface):
         """
         Bring up a link on an interface on the node.
+
         :param subnet: subnet.
         :type subnet: IPv4Network or IPv6Network
+
         :param interface: the FABlib interface.
         :type interface: Interface
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -381,9 +381,6 @@ class Node:
         that determine the format of the output that is returned and
         (optionally) displayed/printed.
 
-        output: 'text': string formatted with tabular 'pandas': pandas
-        dataframe 'json': string in json format
-
         fields: json output will include all available fields/columns.
 
         Example: fields=['Name','Model']
@@ -393,7 +390,12 @@ class Node:
 
         Example: filter_function=lambda s: s['Model'] == 'NIC_Basic'
 
-        :param output: output format
+        :param output: output format. Output can be one of:
+
+            - ``"text"``: string formatted with tabular
+            - ``"pandas"``: pandas dataframe
+            - ``"json"``: string in json format
+
         :type output: str
 
         :param fields: list of fields (table columns) to show

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -745,6 +745,7 @@ class Node:
     def get_image_type(self) -> str or None:
         """
         Gets the image type on the FABRIC node.
+
         :return: the image type on the node
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2532,9 +2532,12 @@ class Node:
     def get_storage(self, name: str) -> Component:
         """
         Gets a particular storage associated with this node.
+
         :param name: the name of the storage
         :type name: String
+
         :raise Exception: if storage not found by name
+
         :return: the storage on the FABRIC node
         :rtype: Component
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -781,6 +781,7 @@ class Node:
     def get_site(self) -> str or None:
         """
         Gets the sitename on the FABRIC node.
+
         :return: the sitename on the node
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2234,10 +2234,13 @@ class Node:
     ):
         """
         Delete an IP to an interface on the node.
+
         :param addr: IP address
-        :type addr:  IPv4Address or IPv6Address
+        :type addr: IPv4Address or IPv6Address
+
         :param subnet: subnet.
         :type subnet: IPv4Network or IPv6Network
+
         :param interface: the FABlib interface.
         :type interface: Interface
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -64,9 +64,11 @@ class Node:
 
     def __init__(self, slice: Slice, node: FimNode):
         """
-        Constructor. Sets the fablib slice and FIM node based on arguments.
+        Sets the fablib slice and FIM node based on arguments.
+
         :param slice: the fablib slice to have this node on
         :type slice: Slice
+
         :param node: the FIM node that this Node represents
         :type node: Node
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -918,8 +918,10 @@ class Node:
     def get_public_key_file(self) -> str:
         """
         Gets the public key file path on the fablib node.
-        Important! Slice key management is underdevelopment and this
+
+        Important!  Slice key management is underdevelopment and this
         functionality will likely change going forward.
+
         :return: the public key path
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -705,7 +705,9 @@ class Node:
     def set_host(self, host_name: str = None):
         """
         Sets the hostname of this fablib node on the FABRIC node.
-        :param host_name: the hostname. example: host_name='renc-w2.fabric-testbed.net'
+
+        :param host_name: the hostname.  example:
+            host_name='renc-w2.fabric-testbed.net'
         :type host_name: String
         """
         # example: host_name='renc-w2.fabric-testbed.net'

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -454,31 +454,41 @@ class Node:
         """
         Lists all the interfaces in the node with their attributes.
 
-        There are several output options: "text", "pandas", and "json" that determine the format of the
-        output that is returned and (optionally) displayed/printed.
+        There are several output options: ``"text"``, ``"pandas"``,
+        and ``"json"`` that determine the format of the output that is
+        returned and (optionally) displayed/printed.
 
-        output:  'text': string formatted with tabular
-                  'pandas': pandas dataframe
-                  'json': string in json format
+        :param output: Output format.  Options are:
 
-        fields: json output will include all available fields/columns.
+                - ``"text"``: string formatted with tabular
 
-        Example: fields=['Name','MAC']
+                - ``"pandas"``: pandas dataframe
 
-        filter_function:  A lambda function to filter data by field values.
+                - ``"json"``: string in json format
 
-        Example: filter_function=lambda s: s['Node'] == 'Node1'
-
-        :param output: output format
         :type output: str
-        :param fields: list of fields (table columns) to show
+
+        :param fields: List of fields (table columns) to show.  JSON
+            output will include all available fields/columns.
         :type fields: List[str]
+
         :param quiet: True to specify printing/display
         :type quiet: bool
-        :param filter_function: lambda function
+
+        :param filter_function: A lambda function to filter data by
+            field values.
         :type filter_function: lambda
+
         :return: table in format specified by output parameter
         :rtype: Object
+
+        Example of ``fields``::
+
+            fields=['Name','MAC']
+
+        Example of ``filter_function``::
+
+            filter_function=lambda s: s['Node'] == 'Node1'
         """
 
         if str(self.get_reservation_state()) != "Active":

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1864,19 +1864,29 @@ class Node:
         retry: int = 3,
         retry_interval: int = 10,
     ):
-        """ "
-        Creates a thread that calls node.upload_directory. Results from the thread can be
-        retrieved with by calling thread.result()
-        :param local_directory_path: the path to the directory to upload
+        """
+        Creates a thread that calls ``Node.upload_directory()``.
+
+        Results from the thread can be retrieved with by calling
+        ``thread.result()``.
+
+        :param local_directory_path: the path to the directory to
+            upload
         :type local_directory_path: str
-        :param remote_directory_path: the destination path of the directory on the node
+
+        :param remote_directory_path: the destination path of the
+            directory on the node
         :type remote_directory_path: str
+
         :param retry: how many times to retry SCP upon failure
         :type retry: int
+
         :param retry_interval: how often to retry SCP on failure
         :type retry_interval: int
+
         :return: a thread that called node.download_file()
         :rtype: Thread
+
         :raise Exception: if management IP is invalid
         """
         return (

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1045,7 +1045,8 @@ class Node:
 
     def get_ssh_command(self) -> str:
         """
-        Gets an SSH command used to access this node node from a terminal.
+        Gets an SSH command used to access this node from a terminal.
+
         :return: the SSH command to access this node
         :rtype: str
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -856,16 +856,21 @@ class Node:
     ) -> Interface or None:
         """
         Gets a particular interface associated with a FABRIC node.
-        Accepts either the interface name or a network_name. If a network name
-        is used this method will return the interface on the node that is
-        connected to the network specified.
-        If a name and network_name are both used, the interface name will
+        Accepts either the interface name or a network_name.  If a
+        network name is used this method will return the interface on
+        the node that is connected to the network specified.  If a
+        name and network_name are both used, the interface name will
         take precedence.
+
         :param name: interface name to search for
         :type name: str
+
         :param network_name: network name to search for
+
         :type name: str
+
         :raise Exception: if interface is not found
+
         :return: an interface on the node
         :rtype: Interface
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -537,36 +537,41 @@ class Node:
         Lists all the networks attached to the nodes with their
         attributes.
 
-        There are several output options: "text", "pandas", and "json"
-        that determine the format of the output that is returned and
-        (optionally) displayed/printed.
+        There are several output options: ``"text"``, ``"pandas"``,
+        and ``"json"`` that determine the format of the output that is
+        returned and (optionally) displayed/printed.
 
-        output: 'text': string formatted with tabular 'pandas': pandas
-        dataframe 'json': string in json format
+        :param output: Output format.  Options are:
 
-        fields: json output will include all available fields/columns.
+                - ``"text"``: string formatted with tabular
 
-        Example: fields=['Name','Type']
+                - ``"pandas"``: pandas dataframe
 
-        filter_function: A lambda function to filter data by field
-        values.
+                - ``"json"``: string in JSON format
 
-        Example: filter_function=lambda s: s['Type'] == 'FABNetv4'
-
-        :param output: output format
         :type output: str
 
-        :param fields: list of fields (table columns) to show
+        :param fields: List of fields (table columns) to show.  JSON
+            output will include all available fields/columns.
         :type fields: List[str]
 
         :param quiet: True to specify printing/display
         :type quiet: bool
 
-        :param filter_function: lambda function
+        :param filter_function: A lambda function to filter data by
+            field values.
         :type filter_function: lambda
 
         :return: table in format specified by output parameter
         :rtype: Object
+
+        Example of ``fields``::
+
+            fields=['Name','Type']
+
+        Example of ``filter_function``::
+
+            filter_function=lambda s: s['Type'] == 'FABNetv4'
         """
 
         interfaces = self.get_interfaces()

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -653,6 +653,7 @@ class Node:
     def set_instance_type(self, instance_type: str):
         """
         Sets the instance type of this fablib node on the FABRIC node.
+
         :param instance_type: the name of the instance type to set
         :type instance_type: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -99,8 +99,11 @@ class Node:
 
     def __str__(self):
         """
-        Creates a tabulated string describing the properties of the node.
+        Creates a tabulated string describing the properties of the
+        node.
+
         Intended for printing node information.
+
         :return: Tabulated string of node information
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -687,6 +687,7 @@ class Node:
     def get_name(self) -> str or None:
         """
         Gets the name of the FABRIC node.
+
         :return: the name of the node
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -715,6 +715,7 @@ class Node:
     def get_ram(self) -> int or None:
         """
         Gets the amount of RAM on the FABRIC node.
+
         :return: the amount of RAM on the node
         :rtype: int
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -663,11 +663,12 @@ class Node:
 
     def set_username(self, username: str = None):
         """
-        Not intended as an API call.
         Sets this fablib node's username
-        Optional username parameter. The username likely should be picked
-        to match the image type.
-        :param username: username
+
+        :note: Not intended as an API call.
+
+        :param username: Optional username parameter.  The username
+            likely should be picked to match the image type.
         """
         if username is not None:
             self.username = username

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -633,10 +633,13 @@ class Node:
     def set_capacities(self, cores: int = 2, ram: int = 2, disk: int = 10):
         """
         Sets the capacities of the FABRIC node.
+
         :param cores: the number of cores to set on this node
         :type cores: int
+
         :param ram: the amount of RAM to set on this node
         :type ram: int
+
         :param disk: the amount of disk space to set on this node
         :type disk: int
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -190,9 +190,9 @@ class Node:
 
     def toJson(self):
         """
-        Returns the node attributes as a json string
+        Returns the node attributes as a JSON string
 
-        :return: slice attributes as json string
+        :return: slice attributes as JSON string
         :rtype: str
         """
         return json.dumps(self.toDict(), indent=4)

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1149,8 +1149,10 @@ class Node:
     def validIPAddress(self, IP: str) -> str:
         """
         Checks if the IP string is a valid IP address.
+
         :param IP: the IP string to check
         :type IP: String
+
         :return: the type of IP address the IP string is, or 'Invalid'
         :rtype: String
         """

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -871,14 +871,19 @@ class Slice:
         mirror_direction: str = "both",
     ) -> NetworkService:
         """
-        Adds a special PortMirror service - it receives data from the dataplane
-        switch interface specified by `mirror_interface` into an interface
-        specified by `receive_interface`
+        Adds a special PortMirror service.
+
+        It receives data from the dataplane switch interface specified
+        by ``mirror_interface`` into an interface specified by
+        ``receive_interface``.
+
         :param name: Name of the service
-        :param mirror_interface_name: Name of the interface on the dataplane switch to mirror
-        :param receive_interface: Interface in the topology belonging to a SmartNIC component
-        :param mirror_direction: String 'rx', 'tx' or 'both' defaulting to 'both'
-        which receives the data
+        :param mirror_interface_name: Name of the interface on the
+            dataplane switch to mirror
+        :param receive_interface: Interface in the topology belonging
+            to a SmartNIC component
+        :param mirror_direction: String 'rx', 'tx' or 'both'
+            defaulting to 'both' which receives the data
         """
         self.nodes = None
         self.interfaces = None


### PR DESCRIPTION
Issue is #219.  Makes API docs' formatting a little nicer.

Consider `node` module's docs [before](https://fabric-fablib.readthedocs.io/en/rel1.4.4/fablib.html#node) and [after,](https://fabric-fablib--220.org.readthedocs.build/en/220/node.html) for comparison.  

For an even more specific example, consider `Node.add_component()` [before](https://fabric-fablib.readthedocs.io/en/rel1.4.4/fablib.html#node.Node.add_component) and [after.](https://fabric-fablib--220.org.readthedocs.build/en/220/node.html#fabrictestbed_extensions.fablib.node.Node.add_component)