### PR TITLE
Release 1.5.2 preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [1.5.2] - 2023-08-02
+
 ### Fixed
 
 - Address a crash when querying NUMA properties. (Issue

--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -1,3 +1,3 @@
 # Please update version number here when making a release: flit, the
 # build backend we use, picks up the version from here.
-__version__ = "1.5.2b1"
+__version__ = "1.5.2"


### PR DESCRIPTION
Will tag `rel1.5.2` and publish the packages on PyPI once this is merged.