### PR TITLE
Getter optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Some optimizations in `list_sites()`, `show_site()`, `get_random_site()`
+  (PR [#230](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/230))
+
 ### Fixed
 - Update default username for `defaul_centos9_stream` image (Issue [#227](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/227))
 

--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -1,3 +1,3 @@
 # Please update version number here when making a release: flit, the
 # build backend we use, picks up the version from here.
-__version__ = "1.5.4b1"
+__version__ = "1.5.4"

--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -1,3 +1,3 @@
 # Please update version number here when making a release: flit, the
 # build backend we use, picks up the version from here.
-__version__ = "1.5.4b0"
+__version__ = "1.5.4b1"

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1034,6 +1034,7 @@ class FablibManager:
         update: bool = True,
         pretty_names: bool = True,
         force_refresh: bool = False,
+        latlon: bool = True,
     ) -> object:
         """
         Lists all the sites and their attributes.
@@ -1065,6 +1066,7 @@ class FablibManager:
         :param update:
         :param pretty_names:
         :param force_refresh:
+        :param latlon: convert address to latlon, makes online call to openstreetmaps.org
         :rtype: Object
         """
         return self.get_resources(
@@ -1075,6 +1077,7 @@ class FablibManager:
             quiet=quiet,
             filter_function=filter_function,
             pretty_names=pretty_names,
+            latlon=latlon
         )
 
     def list_links(
@@ -1221,6 +1224,7 @@ class FablibManager:
         fields: list[str] = None,
         quiet: bool = False,
         pretty_names=True,
+        latlon=True,
     ):
         """
         Show a table with all the properties of a specific site
@@ -1244,6 +1248,8 @@ class FablibManager:
         :type fields: List[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
+        :param latlon: convert address to lat/lon
+        :type latlon: bool
         :return: table in format specified by output parameter
         :rtype: Object
         """
@@ -1254,6 +1260,7 @@ class FablibManager:
                 output=output,
                 quiet=quiet,
                 pretty_names=pretty_names,
+                latlon=latlon
             )
         )
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1077,7 +1077,7 @@ class FablibManager:
             quiet=quiet,
             filter_function=filter_function,
             pretty_names=pretty_names,
-            latlon=latlon
+            latlon=latlon,
         )
 
     def list_links(
@@ -1260,7 +1260,7 @@ class FablibManager:
                 output=output,
                 quiet=quiet,
                 pretty_names=pretty_names,
-                latlon=latlon
+                latlon=latlon,
             )
         )
 
@@ -1376,7 +1376,7 @@ class FablibManager:
             filter_function=combined_filter_function,
             update=update,
             # if filter function is not specified, no need for latlon
-            latlon=True if filter_function else False
+            latlon=True if filter_function else False,
         )
 
         sites = list(map(lambda x: x["name"], site_list))

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1336,7 +1336,6 @@ class FablibManager:
         filter_function=None,
         update: bool = True,
         unique: bool = True,
-        latlon: bool = False,
     ) -> List[str]:
         """
         Get a list of random sites names. Each site will be included at most once.
@@ -1376,7 +1375,8 @@ class FablibManager:
             quiet=True,
             filter_function=combined_filter_function,
             update=update,
-            latlon=latlon,
+            # if filter function is not specified, no need for latlon
+            latlon=True if filter_function else False
         )
 
         sites = list(map(lambda x: x["name"], site_list))

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -82,14 +82,14 @@ class fablib:
         return fablib.get_default_fablib_manager().get_site_names()
 
     @staticmethod
-    def list_sites() -> object:
+    def list_sites(latlon: bool = True) -> object:
         """
         Get a string used to print a tabular list of sites with state
 
         :return: tabulated string of site state
         :rtype: str
         """
-        return fablib.get_default_fablib_manager().list_sites()
+        return fablib.get_default_fablib_manager().list_sites(latlon=latlon)
 
     @staticmethod
     def list_links() -> object:
@@ -1336,6 +1336,7 @@ class FablibManager:
         filter_function=None,
         update: bool = True,
         unique: bool = True,
+        latlon: bool = False,
     ) -> List[str]:
         """
         Get a list of random sites names. Each site will be included at most once.
@@ -1344,6 +1345,9 @@ class FablibManager:
         :type count: int
         :param avoid: list of site names to avoid chosing
         :type site_name: List[String]
+        :param unique:
+        :param latlon: convert address to latlon if needed for the filter, False by default
+        :type latlon: bool
         :return: list of random site names.
         :rtype: List[Sting]
         """
@@ -1372,6 +1376,7 @@ class FablibManager:
             quiet=True,
             filter_function=combined_filter_function,
             update=update,
+            latlon=latlon,
         )
 
         sites = list(map(lambda x: x["name"], site_list))

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -30,7 +30,8 @@ from typing import List, Tuple
 
 from fabrictestbed.slice_editor import AdvertisedTopology, Capacities
 from fabrictestbed.slice_manager import Status
-from fim.user import interface, link
+from fim.user import interface, link, node, composite_node
+from fim.slivers import maintenance_mode
 from tabulate import tabulate
 
 
@@ -108,22 +109,22 @@ class Resources:
             table.append(
                 [
                     site.name,
-                    self.get_cpu_capacity(site_name),
-                    f"{self.get_core_available(site_name)}/{self.get_core_capacity(site_name)}",
-                    f"{self.get_ram_available(site_name)}/{self.get_ram_capacity(site_name)}",
-                    f"{self.get_disk_available(site_name)}/{self.get_disk_capacity(site_name)}",
-                    # self.get_host_capacity(site_name),
-                    # self.get_location_postal(site_name),
-                    # self.get_location_lat_long(site_name),
-                    f"{self.get_component_available(site_name,'SharedNIC-ConnectX-6')}/{self.get_component_capacity(site_name,'SharedNIC-ConnectX-6')}",
-                    f"{self.get_component_available(site_name,'SmartNIC-ConnectX-6')}/{self.get_component_capacity(site_name,'SmartNIC-ConnectX-6')}",
-                    f"{self.get_component_available(site_name,'SmartNIC-ConnectX-5')}/{self.get_component_capacity(site_name,'SmartNIC-ConnectX-5')}",
-                    f"{self.get_component_available(site_name,'NVME-P4510')}/{self.get_component_capacity(site_name,'NVME-P4510')}",
-                    f"{self.get_component_available(site_name,'GPU-Tesla T4')}/{self.get_component_capacity(site_name,'GPU-Tesla T4')}",
-                    f"{self.get_component_available(site_name,'GPU-RTX6000')}/{self.get_component_capacity(site_name,'GPU-RTX6000')}",
-                    f"{self.get_component_available(site_name, 'GPU-A30')}/{self.get_component_capacity(site_name, 'GPU-A30')}",
-                    f"{self.get_component_available(site_name, 'GPU-A40')}/{self.get_component_capacity(site_name, 'GPU-A40')}",
-                    f"{self.get_component_available(site_name, 'FPGA-Xilinx-U280')}/{self.get_component_capacity(site_name, 'FPGA-Xilinx-U280')}",
+                    self.get_cpu_capacity(site),
+                    f"{self.get_core_available(site)}/{self.get_core_capacity(site)}",
+                    f"{self.get_ram_available(site)}/{self.get_ram_capacity(site)}",
+                    f"{self.get_disk_available(site)}/{self.get_disk_capacity(site)}",
+                    # self.get_host_capacity(site),
+                    # self.get_location_postal(site),
+                    # self.get_location_lat_long(site),
+                    f"{self.get_component_available(site,'SharedNIC-ConnectX-6')}/{self.get_component_capacity(site,'SharedNIC-ConnectX-6')}",
+                    f"{self.get_component_available(site,'SmartNIC-ConnectX-6')}/{self.get_component_capacity(site,'SmartNIC-ConnectX-6')}",
+                    f"{self.get_component_available(site,'SmartNIC-ConnectX-5')}/{self.get_component_capacity(site,'SmartNIC-ConnectX-5')}",
+                    f"{self.get_component_available(site,'NVME-P4510')}/{self.get_component_capacity(site,'NVME-P4510')}",
+                    f"{self.get_component_available(site,'GPU-Tesla T4')}/{self.get_component_capacity(site,'GPU-Tesla T4')}",
+                    f"{self.get_component_available(site,'GPU-RTX6000')}/{self.get_component_capacity(site,'GPU-RTX6000')}",
+                    f"{self.get_component_available(site, 'GPU-A30')}/{self.get_component_capacity(site, 'GPU-A30')}",
+                    f"{self.get_component_available(site, 'GPU-A40')}/{self.get_component_capacity(site, 'GPU-A40')}",
+                    f"{self.get_component_available(site, 'FPGA-Xilinx-U280')}/{self.get_component_capacity(site, 'FPGA-Xilinx-U280')}",
                 ]
             )
 
@@ -201,7 +202,7 @@ class Resources:
 
         return site_name_list
 
-    def get_topology_site(self, site_name: str) -> str:
+    def get_topology_site(self, site_name: str) -> node.Node:
         """
         Not recommended for most users.
         """
@@ -209,70 +210,86 @@ class Resources:
             return self.topology.sites[site_name]
         except Exception as e:
             logging.warning(f"Failed to get site {site_name}")
-            return ""
+            return None
 
-    def get_state(self, site_name: str):
+    def get_state(self, site: str or node.Node) -> str:
+        """
+        Gets the maintenance state of the node
+
+        :param site: site Node object or name
+        :type site: String or Node
+        :return: str(MaintenanceState)
+        """
+        site_name = ""
         try:
+            if isinstance(site, node.Node):
+                site_name = site.name
+                return str(site.maintenance_info.get(site).state)
+            site_name = site
             return str(
-                self.get_topology_site(site_name)
-                .get_property("maintenance_info")
-                .get(site_name)
+                self.get_topology_site(site)
+                .maintenance_info
+                .get(site)
                 .state
             )
         except Exception as e:
             logging.warning(f"Failed to get site state {site_name}")
             return ""
 
-    def get_component_capacity(self, site_name: str, component_model_name: str) -> int:
+    def get_component_capacity(self, site: str or node.Node, component_model_name: str) -> int:
         """
-        Gets gets the total site capacity of a component by model name.
+        Gets the total site capacity of a component by model name.
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site object or site name
+        :type site: String or Node
         :param component_model_name: component model name
         :type component_model_name: String
         :return: total component capacity
         :rtype: int
         """
         try:
+            if isinstance(site, node.Node):
+                return site.components[component_model_name].capacities.unit
             return (
-                self.get_topology_site(site_name)
+                self.get_topology_site(site)
                 .components[component_model_name]
                 .capacities.unit
             )
         except Exception as e:
-            # logging.debug(f"Failed to get {component_model_name} capacity {site_name}")
+            # logging.debug(f"Failed to get {component_model_name} capacity {site}")
             return 0
 
-    def get_component_allocated(self, site_name: str, component_model_name: str) -> int:
+    def get_component_allocated(self, site: str or node.Node, component_model_name: str) -> int:
         """
         Gets gets number of currently allocated components on a the site
         by the component by model name.
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site object or site name
+        :type site: String or Node
         :param component_model_name: component model name
         :type component_model_name: String
         :return: currently allocated component of this model
         :rtype: int
         """
         try:
+            if isinstance(site, node.Node):
+                return site.components[component_model_name].capacity_allocations.unit
             return (
-                self.get_topology_site(site_name)
+                self.get_topology_site(site)
                 .components[component_model_name]
                 .capacity_allocations.unit
             )
         except Exception as e:
-            # logging.debug(f"Failed to get {component_model_name} allocated {site_name}")
+            # logging.debug(f"Failed to get {component_model_name} allocated {site}")
             return 0
 
-    def get_component_available(self, site_name: str, component_model_name: str) -> int:
+    def get_component_available(self, site: str or node.Node, component_model_name: str) -> int:
         """
         Gets gets number of currently available components on the site
         by the component by model name.
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site object or site name
+        :type site: String or Node
         :param component_model_name: component model name
         :type component_model_name: String
         :return: currently available component of this model
@@ -280,213 +297,228 @@ class Resources:
         """
         try:
             return self.get_component_capacity(
-                site_name, component_model_name
-            ) - self.get_component_allocated(site_name, component_model_name)
+                site, component_model_name
+            ) - self.get_component_allocated(site, component_model_name)
         except Exception as e:
-            # logging.debug(f"Failed to get {component_model_name} available {site_name}")
-            return self.get_component_capacity(site_name, component_model_name)
+            # logging.debug(f"Failed to get {component_model_name} available {site}")
+            return self.get_component_capacity(site, component_model_name)
 
-    def get_location_lat_long(self, site_name: str) -> Tuple[float, float]:
+    def get_location_lat_long(self, site: str or node.Node) -> Tuple[float, float]:
         """
         Gets gets location of a site in latitude and longitude
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or site object
+        :type site: String or Node
         :return: latitude and longitude of the site
         :rtype: Tuple(float,float)
         """
         try:
-            # site.get_property("location").to_latlon()
+            if isinstance(site, node.Node):
+                return site.location.to_latlon()
             return (
-                self.get_topology_site(site_name).get_property("location").to_latlon()
+                self.get_topology_site(site).location.to_latlon()
             )
         except Exception as e:
-            # logging.warning(f"Failed to get location postal {site_name}")
+            # logging.warning(f"Failed to get location postal {site}")
             return 0, 0
 
-    def get_location_postal(self, site_name: str) -> str:
+    def get_location_postal(self, site: str or node.Node) -> str:
         """
         Gets the location of a site by postal address
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or site object
+        :type site: String or Node
         :return: postal address of the site
         :rtype: String
         """
         try:
-            return self.get_topology_site(site_name).location.postal
+            if isinstance(site, node.Node):
+                return site.location.postal
+            return self.get_topology_site(site).location.postal
         except Exception as e:
-            # logging.debug(f"Failed to get location postal {site_name}")
+            # logging.debug(f"Failed to get location postal {site}")
             return ""
 
-    def get_host_capacity(self, site_name: str) -> int:
+    def get_host_capacity(self, site: str or node.Node) -> int:
         """
         Gets the number of worker hosts at the site
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or site object
+        :type site: String or Node
         :return: host count
         :rtype: int
         """
         try:
-            return self.get_topology_site(site_name).capacities.unit
+            if isinstance(site, node.Node):
+                return site.capacities.unit
+            return self.get_topology_site(site).capacities.unit
         except Exception as e:
-            # logging.debug(f"Failed to get host count {site_name}")
+            # logging.debug(f"Failed to get host count {site}")
             return 0
 
-    def get_cpu_capacity(self, site_name: str) -> int:
+    def get_cpu_capacity(self, site: str or node.Node) -> int:
         """
         Gets the total number of cpus at the site
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or site object
+        :type site: String or node.Node
         :return: cpu count
         :rtype: int
         """
         try:
-            return self.get_topology_site(site_name).capacities.cpu
+            if isinstance(site, node.Node):
+                return site.capacities.cpu
+            return self.get_topology_site(site).capacities.cpu
         except Exception as e:
-            # logging.debug(f"Failed to get cpu capacity {site_name}")
+            # logging.debug(f"Failed to get cpu capacity {site}")
             return 0
 
-    def get_core_capacity(self, site_name: str) -> int:
+    def get_core_capacity(self, site: str or node.Node) -> int:
         """
         Gets the total number of cores at the site
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or object
+        :type site: String or Node
         :return: core count
         :rtype: int
         """
         try:
-            return self.get_topology_site(site_name).capacities.core
+            if isinstance(site, node.Node):
+                return site.capacities.core
+            return self.get_topology_site(site).capacities.core
         except Exception as e:
-            # logging.debug(f"Failed to get core capacity {site_name}")
+            # logging.debug(f"Failed to get core capacity {site}")
             return 0
 
-    def get_core_allocated(self, site_name: str) -> int:
+    def get_core_allocated(self, site: str or node.Node) -> int:
         """
         Gets the number of currently allocated cores at the site
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or object
+        :type site: String or Node
         :return: core count
         :rtype: int
         """
         try:
-            return self.get_topology_site(site_name).capacity_allocations.core
+            if isinstance(site, node.Node):
+                return site.capacity_allocations.core
+            return self.get_topology_site(site).capacity_allocations.core
         except Exception as e:
-            # logging.debug(f"Failed to get cores allocated {site_name}")
+            # logging.debug(f"Failed to get cores allocated {site}")
             return 0
 
-    def get_core_available(self, site_name: str) -> int:
+    def get_core_available(self, site: str or node.Node) -> int:
         """
         Gets the number of currently available cores at the site
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or object
+        :type site: String or Node
         :return: core count
         :rtype: int
         """
         try:
-            return self.get_core_capacity(site_name) - self.get_core_allocated(
-                site_name
-            )
+            return self.get_core_capacity(site) - self.get_core_allocated(site)
         except Exception as e:
-            # logging.debug(f"Failed to get cores available {site_name}")
-            return self.get_core_capacity(site_name)
+            # logging.debug(f"Failed to get cores available {site}")
+            return self.get_core_capacity(site)
 
-    def get_ram_capacity(self, site_name: str) -> int:
+    def get_ram_capacity(self, site: str or node.Node) -> int:
         """
         Gets the total amount of memory at the site in GB
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or object
+        :type site: String or Node
         :return: ram in GB
         :rtype: int
         """
         try:
-            return self.get_topology_site(site_name).capacities.ram
+            if isinstance(site, node.Node):
+                return site.capacities.ram
+            return self.get_topology_site(site).capacities.ram
         except Exception as e:
-            # logging.debug(f"Failed to get ram capacity {site_name}")
+            # logging.debug(f"Failed to get ram capacity {site}")
             return 0
 
-    def get_ram_allocated(self, site_name: str) -> int:
+    def get_ram_allocated(self, site: str or node.Node) -> int:
         """
         Gets the amount of memory currently  allocated the site in GB
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or object
+        :type site: String or Node
         :return: ram in GB
         :rtype: int
         """
         try:
-            return self.get_topology_site(site_name).capacity_allocations.ram
+            if isinstance(site, node.Node):
+                return site.capacity_allocations.ram
+            return self.get_topology_site(site).capacity_allocations.ram
         except Exception as e:
-            # logging.debug(f"Failed to get ram allocated {site_name}")
+            # logging.debug(f"Failed to get ram allocated {site}")
             return 0
 
-    def get_ram_available(self, site_name: str) -> int:
+    def get_ram_available(self, site: str or node.Node) -> int:
         """
         Gets the amount of memory currently  available the site in GB
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or object
+        :type site: String or Node
         :return: ram in GB
         :rtype: int
         """
         try:
-            return self.get_ram_capacity(site_name) - self.get_ram_allocated(site_name)
+            return self.get_ram_capacity(site) - self.get_ram_allocated(site)
         except Exception as e:
             # logging.debug(f"Failed to get ram available {site_name}")
-            return self.get_ram_capacity(site_name)
+            return self.get_ram_capacity(site)
 
-    def get_disk_capacity(self, site_name: str) -> int:
+    def get_disk_capacity(self, site: str or node.Node) -> int:
         """
         Gets the total amount of disk available the site in GB
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or object
+        :type site: String or Node
         :return: disk in GB
         :rtype: int
         """
         try:
-            return self.get_topology_site(site_name).capacities.disk
+            if isinstance(site, node.Node):
+                return site.capacities.disk
+            return self.get_topology_site(site).capacities.disk
         except Exception as e:
-            # logging.debug(f"Failed to get disk capacity {site_name}")
+            # logging.debug(f"Failed to get disk capacity {site}")
             return 0
 
-    def get_disk_allocated(self, site_name: str) -> int:
+    def get_disk_allocated(self, site: str or node.Node) -> int:
         """
         Gets the amount of disk allocated the site in GB
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name
+        :type site: String
         :return: disk in GB
         :rtype: int
         """
         try:
-            return self.get_topology_site(site_name).capacity_allocations.disk
+            if isinstance(site, node.Node):
+                return site.capacity_allocations.disk
+            return self.get_topology_site(site).capacity_allocations.disk
         except Exception as e:
-            # logging.debug(f"Failed to get disk allocated {site_name}")
+            # logging.debug(f"Failed to get disk allocated {site}")
             return 0
 
-    def get_disk_available(self, site_name: str) -> int:
+    def get_disk_available(self, site: str or node.Node) -> int:
         """
         Gets the amount of disk available the site in GB
 
-        :param site_name: site name
-        :type site_name: String
+        :param site: site name or object
+        :type site: String or Node
         :return: disk in GB
         :rtype: int
         """
         try:
-            return self.get_disk_capacity(site_name) - self.get_disk_allocated(
-                site_name
-            )
+            return self.get_disk_capacity(site) - self.get_disk_allocated(site)
         except Exception as e:
             # logging.debug(f"Failed to get disk available {site_name}")
-            return self.get_disk_capacity(site_name)
+            return self.get_disk_capacity(site)
 
     def get_fablib_manager(self):
         return self.fablib_manager
@@ -560,88 +592,87 @@ class Resources:
         return json.dumps(self.site_to_dict(site), indent=4)
 
     def site_to_dict(self, site):
-        site_name = site.name
         return {
             "name": site.name,
-            "state": self.get_state(site_name),
-            "address": self.get_location_postal(site_name),
-            "location": self.get_location_lat_long(site_name),
-            "hosts": self.get_host_capacity(site_name),
-            "cpus": self.get_cpu_capacity(site_name),
-            "cores_available": self.get_core_available(site_name),
-            "cores_capacity": self.get_core_capacity(site_name),
-            "cores_allocated": self.get_core_capacity(site_name)
-            - self.get_core_available(site_name),
-            "ram_available": self.get_ram_available(site_name),
-            "ram_capacity": self.get_ram_capacity(site_name),
-            "ram_allocated": self.get_ram_capacity(site_name)
-            - self.get_ram_available(site_name),
-            "disk_available": self.get_disk_available(site_name),
-            "disk_capacity": self.get_disk_capacity(site_name),
-            "disk_allocated": self.get_disk_capacity(site_name)
-            - self.get_disk_available(site_name),
+            "state": self.get_state(site),
+            "address": self.get_location_postal(site),
+            "location": self.get_location_lat_long(site),
+            "hosts": self.get_host_capacity(site),
+            "cpus": self.get_cpu_capacity(site),
+            "cores_available": self.get_core_available(site),
+            "cores_capacity": self.get_core_capacity(site),
+            "cores_allocated": self.get_core_capacity(site)
+            - self.get_core_available(site),
+            "ram_available": self.get_ram_available(site),
+            "ram_capacity": self.get_ram_capacity(site),
+            "ram_allocated": self.get_ram_capacity(site)
+            - self.get_ram_available(site),
+            "disk_available": self.get_disk_available(site),
+            "disk_capacity": self.get_disk_capacity(site),
+            "disk_allocated": self.get_disk_capacity(site)
+            - self.get_disk_available(site),
             "nic_basic_available": self.get_component_available(
-                site_name, "SharedNIC-ConnectX-6"
+                site, "SharedNIC-ConnectX-6"
             ),
             "nic_basic_capacity": self.get_component_capacity(
-                site_name, "SharedNIC-ConnectX-6"
+                site, "SharedNIC-ConnectX-6"
             ),
             "nic_basic_allocated": self.get_component_capacity(
-                site_name, "SharedNIC-ConnectX-6"
+                site, "SharedNIC-ConnectX-6"
             )
-            - self.get_component_available(site_name, "SharedNIC-ConnectX-6"),
+            - self.get_component_available(site, "SharedNIC-ConnectX-6"),
             "nic_connectx_6_available": self.get_component_available(
-                site_name, "SmartNIC-ConnectX-6"
+                site, "SmartNIC-ConnectX-6"
             ),
             "nic_connectx_6_capacity": self.get_component_capacity(
-                site_name, "SmartNIC-ConnectX-6"
+                site, "SmartNIC-ConnectX-6"
             ),
             "nic_connectx_6_allocated": self.get_component_capacity(
-                site_name, "SmartNIC-ConnectX-6"
+                site, "SmartNIC-ConnectX-6"
             )
-            - self.get_component_available(site_name, "SmartNIC-ConnectX-6"),
+            - self.get_component_available(site, "SmartNIC-ConnectX-6"),
             "nic_connectx_5_available": self.get_component_available(
-                site_name, "SmartNIC-ConnectX-5"
+                site, "SmartNIC-ConnectX-5"
             ),
             "nic_connectx_5_capacity": self.get_component_capacity(
-                site_name, "SmartNIC-ConnectX-5"
+                site, "SmartNIC-ConnectX-5"
             ),
             "nic_connectx_5_allocated": self.get_component_capacity(
-                site_name, "SmartNIC-ConnectX-5"
+                site, "SmartNIC-ConnectX-5"
             )
-            - self.get_component_available(site_name, "SmartNIC-ConnectX-5"),
-            "nvme_available": self.get_component_available(site_name, "NVME-P4510"),
-            "nvme_capacity": self.get_component_capacity(site_name, "NVME-P4510"),
-            "nvme_allocated": self.get_component_capacity(site_name, "NVME-P4510")
-            - self.get_component_available(site_name, "NVME-P4510"),
+            - self.get_component_available(site, "SmartNIC-ConnectX-5"),
+            "nvme_available": self.get_component_available(site, "NVME-P4510"),
+            "nvme_capacity": self.get_component_capacity(site, "NVME-P4510"),
+            "nvme_allocated": self.get_component_capacity(site, "NVME-P4510")
+            - self.get_component_available(site, "NVME-P4510"),
             "tesla_t4_available": self.get_component_available(
-                site_name, "GPU-Tesla T4"
+                site, "GPU-Tesla T4"
             ),
-            "tesla_t4_capacity": self.get_component_capacity(site_name, "GPU-Tesla T4"),
-            "tesla_t4_allocated": self.get_component_capacity(site_name, "GPU-Tesla T4")
-            - self.get_component_available(site_name, "GPU-Tesla T4"),
-            "rtx6000_available": self.get_component_available(site_name, "GPU-RTX6000"),
-            "rtx6000_capacity": self.get_component_capacity(site_name, "GPU-RTX6000"),
-            "rtx6000_allocated": self.get_component_capacity(site_name, "GPU-RTX6000")
-            - self.get_component_available(site_name, "GPU-RTX6000"),
-            "a30_available": self.get_component_available(site_name, "GPU-A30"),
-            "a30_capacity": self.get_component_capacity(site_name, "GPU-A30"),
-            "a30_allocated": self.get_component_capacity(site_name, "GPU-A30")
-            - self.get_component_available(site_name, "GPU-A30"),
-            "a40_available": self.get_component_available(site_name, "GPU-A40"),
-            "a40_capacity": self.get_component_capacity(site_name, "GPU-A40"),
-            "a40_allocated": self.get_component_capacity(site_name, "GPU-A40")
-            - self.get_component_available(site_name, "GPU-A40"),
+            "tesla_t4_capacity": self.get_component_capacity(site, "GPU-Tesla T4"),
+            "tesla_t4_allocated": self.get_component_capacity(site, "GPU-Tesla T4")
+            - self.get_component_available(site, "GPU-Tesla T4"),
+            "rtx6000_available": self.get_component_available(site, "GPU-RTX6000"),
+            "rtx6000_capacity": self.get_component_capacity(site, "GPU-RTX6000"),
+            "rtx6000_allocated": self.get_component_capacity(site, "GPU-RTX6000")
+            - self.get_component_available(site, "GPU-RTX6000"),
+            "a30_available": self.get_component_available(site, "GPU-A30"),
+            "a30_capacity": self.get_component_capacity(site, "GPU-A30"),
+            "a30_allocated": self.get_component_capacity(site, "GPU-A30")
+            - self.get_component_available(site, "GPU-A30"),
+            "a40_available": self.get_component_available(site, "GPU-A40"),
+            "a40_capacity": self.get_component_capacity(site, "GPU-A40"),
+            "a40_allocated": self.get_component_capacity(site, "GPU-A40")
+            - self.get_component_available(site, "GPU-A40"),
             "fpga_u280_available": self.get_component_available(
-                site_name, "FPGA-Xilinx-U280"
+                site, "FPGA-Xilinx-U280"
             ),
             "fpga_u280_capacity": self.get_component_capacity(
-                site_name, "FPGA-Xilinx-U280"
+                site, "FPGA-Xilinx-U280"
             ),
             "fpga_u280_allocated": self.get_component_capacity(
-                site_name, "FPGA-Xilinx-U280"
+                site, "FPGA-Xilinx-U280"
             )
-            - self.get_component_available(site_name, "FPGA-Xilinx-U280"),
+            - self.get_component_available(site, "FPGA-Xilinx-U280"),
         }
 
     def site_to_dictXXX(self, site):

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -30,8 +30,8 @@ from typing import List, Tuple
 
 from fabrictestbed.slice_editor import AdvertisedTopology, Capacities
 from fabrictestbed.slice_manager import Status
-from fim.user import interface, link, node, composite_node
 from fim.slivers import maintenance_mode, network_node
+from fim.user import composite_node, interface, link, node
 from tabulate import tabulate
 
 
@@ -159,7 +159,7 @@ class Resources:
         fields: list[str] = None,
         quiet: bool = False,
         pretty_names=True,
-        latlon=True
+        latlon=True,
     ) -> str:
         """
         Creates a tabulated string of all the available resources at a specific site.
@@ -228,18 +228,16 @@ class Resources:
                 return str(site.maintenance_info.get(site.get_name()).state)
             if isinstance(site, node.Node):
                 return str(site.maintenance_info.get(site.name).state)
-            return str(
-                self.get_topology_site(site)
-                .maintenance_info
-                .get(site)
-                .state
-            )
+            return str(self.get_topology_site(site).maintenance_info.get(site).state)
         except Exception as e:
-            #logging.warning(f"Failed to get site state {site_name}")
+            # logging.warning(f"Failed to get site state {site_name}")
             return ""
 
-    def get_component_capacity(self, site: str or node.Node or network_node.NodeSliver,
-                               component_model_name: str) -> int:
+    def get_component_capacity(
+        self,
+        site: str or node.Node or network_node.NodeSliver,
+        component_model_name: str,
+    ) -> int:
         """
         Gets the total site capacity of a component by model name.
 
@@ -252,7 +250,9 @@ class Resources:
         """
         try:
             if isinstance(site, network_node.NodeSliver):
-                return site.attached_components_info.get_device(component_model_name).capacities.unit
+                return site.attached_components_info.get_device(
+                    component_model_name
+                ).capacities.unit
             if isinstance(site, node.Node):
                 return site.components[component_model_name].capacities.unit
             return (
@@ -264,8 +264,11 @@ class Resources:
             # logging.debug(f"Failed to get {component_model_name} capacity {site}")
             return 0
 
-    def get_component_allocated(self, site: str or node.Node or network_node.NodeSliver,
-                                component_model_name: str) -> int:
+    def get_component_allocated(
+        self,
+        site: str or node.Node or network_node.NodeSliver,
+        component_model_name: str,
+    ) -> int:
         """
         Gets gets number of currently allocated components on a the site
         by the component by model name.
@@ -279,7 +282,9 @@ class Resources:
         """
         try:
             if isinstance(site, network_node.NodeSliver):
-                return site.attached_components_info.get_device(component_model_name).capacity_allocations.unit
+                return site.attached_components_info.get_device(
+                    component_model_name
+                ).capacity_allocations.unit
             if isinstance(site, node.Node):
                 return site.components[component_model_name].capacity_allocations.unit
             return (
@@ -291,8 +296,11 @@ class Resources:
             # logging.debug(f"Failed to get {component_model_name} allocated {site}")
             return 0
 
-    def get_component_available(self, site: str or node.Node or network_node.NodeSliver,
-                                component_model_name: str) -> int:
+    def get_component_available(
+        self,
+        site: str or node.Node or network_node.NodeSliver,
+        component_model_name: str,
+    ) -> int:
         """
         Gets gets number of currently available components on the site
         by the component by model name.
@@ -312,7 +320,9 @@ class Resources:
             # logging.debug(f"Failed to get {component_model_name} available {site}")
             return self.get_component_capacity(site, component_model_name)
 
-    def get_location_lat_long(self, site: str or node.Node or network_node.NodeSliver) -> Tuple[float, float]:
+    def get_location_lat_long(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> Tuple[float, float]:
         """
         Gets gets location of a site in latitude and longitude
 
@@ -326,14 +336,14 @@ class Resources:
                 return site.get_location().to_latlon()
             if isinstance(site, node.Node):
                 return site.location.to_latlon()
-            return (
-                self.get_topology_site(site).location.to_latlon()
-            )
+            return self.get_topology_site(site).location.to_latlon()
         except Exception as e:
             # logging.warning(f"Failed to get location postal {site}")
             return 0, 0
 
-    def get_location_postal(self, site: str or node.Node or network_node.NodeSliver) -> str:
+    def get_location_postal(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> str:
         """
         Gets the location of a site by postal address
 
@@ -352,7 +362,9 @@ class Resources:
             # logging.debug(f"Failed to get location postal {site}")
             return ""
 
-    def get_host_capacity(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_host_capacity(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the number of worker hosts at the site
 
@@ -371,7 +383,9 @@ class Resources:
             # logging.debug(f"Failed to get host count {site}")
             return 0
 
-    def get_cpu_capacity(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_cpu_capacity(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the total number of cpus at the site
 
@@ -390,7 +404,9 @@ class Resources:
             # logging.debug(f"Failed to get cpu capacity {site}")
             return 0
 
-    def get_core_capacity(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_core_capacity(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the total number of cores at the site
 
@@ -409,7 +425,9 @@ class Resources:
             # logging.debug(f"Failed to get core capacity {site}")
             return 0
 
-    def get_core_allocated(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_core_allocated(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the number of currently allocated cores at the site
 
@@ -428,7 +446,9 @@ class Resources:
             # logging.debug(f"Failed to get cores allocated {site}")
             return 0
 
-    def get_core_available(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_core_available(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the number of currently available cores at the site
 
@@ -443,7 +463,9 @@ class Resources:
             # logging.debug(f"Failed to get cores available {site}")
             return self.get_core_capacity(site)
 
-    def get_ram_capacity(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_ram_capacity(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the total amount of memory at the site in GB
 
@@ -462,7 +484,9 @@ class Resources:
             # logging.debug(f"Failed to get ram capacity {site}")
             return 0
 
-    def get_ram_allocated(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_ram_allocated(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the amount of memory currently  allocated the site in GB
 
@@ -481,7 +505,9 @@ class Resources:
             # logging.debug(f"Failed to get ram allocated {site}")
             return 0
 
-    def get_ram_available(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_ram_available(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the amount of memory currently  available the site in GB
 
@@ -496,7 +522,9 @@ class Resources:
             # logging.debug(f"Failed to get ram available {site_name}")
             return self.get_ram_capacity(site)
 
-    def get_disk_capacity(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_disk_capacity(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the total amount of disk available the site in GB
 
@@ -515,7 +543,9 @@ class Resources:
             # logging.debug(f"Failed to get disk capacity {site}")
             return 0
 
-    def get_disk_allocated(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_disk_allocated(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the amount of disk allocated the site in GB
 
@@ -534,7 +564,9 @@ class Resources:
             # logging.debug(f"Failed to get disk allocated {site}")
             return 0
 
-    def get_disk_available(self, site: str or node.Node or network_node.NodeSliver) -> int:
+    def get_disk_available(
+        self, site: str or node.Node or network_node.NodeSliver
+    ) -> int:
         """
         Gets the amount of disk available the site in GB
 
@@ -620,7 +652,9 @@ class Resources:
     def site_to_json(self, site, latlon=True):
         return json.dumps(self.site_to_dict(site, latlon=latlon), indent=4)
 
-    def site_to_dict(self, site: str or node.Node or network_node.NodeSliver, latlon=True):
+    def site_to_dict(
+        self, site: str or node.Node or network_node.NodeSliver, latlon=True
+    ):
         """
         Convert site information into a dictionary
 
@@ -884,7 +918,7 @@ class Resources:
         quiet=False,
         filter_function=None,
         pretty_names=True,
-        latlon=True
+        latlon=True,
     ):
         table = []
         for site_name, site in self.topology.sites.items():

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -223,9 +223,7 @@ class Resources:
         site_name = ""
         try:
             if isinstance(site, node.Node):
-                site_name = site.name
-                return str(site.maintenance_info.get(site).state)
-            site_name = site
+                return str(site.maintenance_info.get(site.name).state)
             return str(
                 self.get_topology_site(site)
                 .maintenance_info
@@ -233,7 +231,7 @@ class Resources:
                 .state
             )
         except Exception as e:
-            logging.warning(f"Failed to get site state {site_name}")
+            #logging.warning(f"Failed to get site state {site_name}")
             return ""
 
     def get_component_capacity(self, site: str or node.Node, component_model_name: str) -> int:
@@ -592,6 +590,31 @@ class Resources:
         return json.dumps(self.site_to_dict(site), indent=4)
 
     def site_to_dict(self, site):
+        core_a = self.get_core_available(site)
+        core_c = self.get_core_capacity(site)
+        ram_a = self.get_ram_available(site)
+        ram_c = self.get_ram_capacity(site)
+        disk_a = self.get_disk_available(site)
+        disk_c = self.get_disk_capacity(site)
+        nic_basic_a = self.get_component_available(site, "SharedNIC-ConnectX-6")
+        nic_basic_c = self.get_component_capacity(site, "SharedNIC-ConnectX-6")
+        nic_cx6_a = self.get_component_available(site, "SmartNIC-ConnectX-6")
+        nic_cx6_c = self.get_component_capacity(site, "SmartNIC-ConnectX-6")
+        nic_cx5_a = self.get_component_available(site, "SmartNIC-ConnectX-5")
+        nic_cx5_c = self.get_component_capacity(site, "SmartNIC-ConnectX-5")
+        nvme_a = self.get_component_available(site, "NVME-P4510")
+        nvme_c = self.get_component_capacity(site, "NVME-P4510")
+        tesla_t4_a = self.get_component_available(site, "GPU-Tesla T4")
+        tesla_t4_c = self.get_component_capacity(site, "GPU-Tesla T4")
+        rtx6000_a = self.get_component_available(site, "GPU-RTX6000")
+        rtx6000_c = self.get_component_capacity(site, "GPU-RTX6000")
+        a30_a = self.get_component_available(site, "GPU-A30")
+        a30_c = self.get_component_capacity(site, "GPU-A30")
+        a40_a = self.get_component_available(site, "GPU-A40")
+        a40_c = self.get_component_capacity(site, "GPU-A40")
+        u280_a = self.get_component_available(site, "FPGA-Xilinx-U280")
+        u280_c = self.get_component_capacity(site, "FPGA-Xilinx-U280")
+
         return {
             "name": site.name,
             "state": self.get_state(site),
@@ -599,80 +622,42 @@ class Resources:
             "location": self.get_location_lat_long(site),
             "hosts": self.get_host_capacity(site),
             "cpus": self.get_cpu_capacity(site),
-            "cores_available": self.get_core_available(site),
-            "cores_capacity": self.get_core_capacity(site),
-            "cores_allocated": self.get_core_capacity(site)
-            - self.get_core_available(site),
-            "ram_available": self.get_ram_available(site),
-            "ram_capacity": self.get_ram_capacity(site),
-            "ram_allocated": self.get_ram_capacity(site)
-            - self.get_ram_available(site),
-            "disk_available": self.get_disk_available(site),
-            "disk_capacity": self.get_disk_capacity(site),
-            "disk_allocated": self.get_disk_capacity(site)
-            - self.get_disk_available(site),
-            "nic_basic_available": self.get_component_available(
-                site, "SharedNIC-ConnectX-6"
-            ),
-            "nic_basic_capacity": self.get_component_capacity(
-                site, "SharedNIC-ConnectX-6"
-            ),
-            "nic_basic_allocated": self.get_component_capacity(
-                site, "SharedNIC-ConnectX-6"
-            )
-            - self.get_component_available(site, "SharedNIC-ConnectX-6"),
-            "nic_connectx_6_available": self.get_component_available(
-                site, "SmartNIC-ConnectX-6"
-            ),
-            "nic_connectx_6_capacity": self.get_component_capacity(
-                site, "SmartNIC-ConnectX-6"
-            ),
-            "nic_connectx_6_allocated": self.get_component_capacity(
-                site, "SmartNIC-ConnectX-6"
-            )
-            - self.get_component_available(site, "SmartNIC-ConnectX-6"),
-            "nic_connectx_5_available": self.get_component_available(
-                site, "SmartNIC-ConnectX-5"
-            ),
-            "nic_connectx_5_capacity": self.get_component_capacity(
-                site, "SmartNIC-ConnectX-5"
-            ),
-            "nic_connectx_5_allocated": self.get_component_capacity(
-                site, "SmartNIC-ConnectX-5"
-            )
-            - self.get_component_available(site, "SmartNIC-ConnectX-5"),
-            "nvme_available": self.get_component_available(site, "NVME-P4510"),
-            "nvme_capacity": self.get_component_capacity(site, "NVME-P4510"),
-            "nvme_allocated": self.get_component_capacity(site, "NVME-P4510")
-            - self.get_component_available(site, "NVME-P4510"),
-            "tesla_t4_available": self.get_component_available(
-                site, "GPU-Tesla T4"
-            ),
-            "tesla_t4_capacity": self.get_component_capacity(site, "GPU-Tesla T4"),
-            "tesla_t4_allocated": self.get_component_capacity(site, "GPU-Tesla T4")
-            - self.get_component_available(site, "GPU-Tesla T4"),
-            "rtx6000_available": self.get_component_available(site, "GPU-RTX6000"),
-            "rtx6000_capacity": self.get_component_capacity(site, "GPU-RTX6000"),
-            "rtx6000_allocated": self.get_component_capacity(site, "GPU-RTX6000")
-            - self.get_component_available(site, "GPU-RTX6000"),
-            "a30_available": self.get_component_available(site, "GPU-A30"),
-            "a30_capacity": self.get_component_capacity(site, "GPU-A30"),
-            "a30_allocated": self.get_component_capacity(site, "GPU-A30")
-            - self.get_component_available(site, "GPU-A30"),
-            "a40_available": self.get_component_available(site, "GPU-A40"),
-            "a40_capacity": self.get_component_capacity(site, "GPU-A40"),
-            "a40_allocated": self.get_component_capacity(site, "GPU-A40")
-            - self.get_component_available(site, "GPU-A40"),
-            "fpga_u280_available": self.get_component_available(
-                site, "FPGA-Xilinx-U280"
-            ),
-            "fpga_u280_capacity": self.get_component_capacity(
-                site, "FPGA-Xilinx-U280"
-            ),
-            "fpga_u280_allocated": self.get_component_capacity(
-                site, "FPGA-Xilinx-U280"
-            )
-            - self.get_component_available(site, "FPGA-Xilinx-U280"),
+            "cores_available": core_a,
+            "cores_capacity": core_c,
+            "cores_allocated": core_c - core_a,
+            "ram_available": ram_a,
+            "ram_capacity": ram_c,
+            "ram_allocated": ram_c - ram_a,
+            "disk_available": disk_a,
+            "disk_capacity": disk_c,
+            "disk_allocated": disk_c - disk_a,
+            "nic_basic_available": nic_basic_a,
+            "nic_basic_capacity": nic_basic_c,
+            "nic_basic_allocated": nic_basic_c - nic_basic_a,
+            "nic_connectx_6_available": nic_cx6_a,
+            "nic_connectx_6_capacity": nic_cx6_c,
+            "nic_connectx_6_allocated": nic_cx6_c - nic_cx6_a,
+            "nic_connectx_5_available": nic_cx5_a,
+            "nic_connectx_5_capacity": nic_cx5_c,
+            "nic_connectx_5_allocated": nic_cx5_c - nic_cx5_a,
+            "nvme_available": nvme_a,
+            "nvme_capacity": nvme_c,
+            "nvme_allocated": nvme_c - nvme_a,
+            "tesla_t4_available": tesla_t4_a,
+            "tesla_t4_capacity": tesla_t4_c,
+            "tesla_t4_allocated": tesla_t4_c - tesla_t4_a,
+            "rtx6000_available": rtx6000_a,
+            "rtx6000_capacity": rtx6000_c,
+            "rtx6000_allocated": rtx6000_c - rtx6000_a,
+            "a30_available": a30_a,
+            "a30_capacity": a30_c,
+            "a30_allocated": a30_c - a30_a,
+            "a40_available": a40_a,
+            "a40_capacity": a40_c,
+            "a40_allocated": a40_c - a40_a,
+            "fpga_u280_available": u280_a,
+            "fpga_u280_capacity": u280_c,
+            "fpga_u280_allocated": u280_c - u280_a,
         }
 
     def site_to_dictXXX(self, site):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "ipyleaflet",
     "ipycytoscape",
     "tabulate",
-    "fabrictestbed==1.5.5",
+    "fabrictestbed==1.5.6",
     "paramiko",
     "jinja2>=3.0.0",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "ipyleaflet",
     "ipycytoscape",
     "tabulate",
-    "fabrictestbed==1.5.4",
+    "fabrictestbed==1.5.5",
     "paramiko",
     "jinja2>=3.0.0",
     "pandas",


### PR DESCRIPTION
This provides multiple optimizations in fablib list_sites/show_site/get_random_site code.

The initial code had a lot of patterns like this:
```
for site_name, site_object in dictionary_of_sites.items():
    ... call a getter with site_name as a parameter ...

# then in the getter this
def get_generic_getter(site_name):
    ... retrieve site_object from the model using site_name ... <--- expensive operation
    ... operate on site object to retrieve its properties by converting it into site_sliver implicitly ...
```
I updated it to enable all getters to use any of the following options: 
- use a site name
- use a site object, which then retrieves site sliver object for every property get
- use a site sliver object derived from site object already retrieved from model (this one is the most efficient).

The new pattern looks like this:
```
for site_name, site_object in dictionary_of_sites.items():
    site_sliver = site_object.get_sliver()
    ... call getter with site_sliver ...

# then in the getter this
def get_generic_getter(site_name or site_object or site_sliver):
    if site_name do as before - inefficient query
    if site_object use it to get necessary attributes <- more efficient, but every attribute operation queries back to graph
    if site_sliver use it to get necessary attributes <- the fastest - uses in-memory representation, no graph query
```

Another optimization has to do with latlons.  They are not stored in the model - only the addresses are. If you want to get latlon the code calls openstreetmaps.org API with the address. If you do `list_sites()` with latlon - that adds 15 seconds of execution time (about 1/2 sec per site for an API call). 

I did not want to break the default behavior, so I added a boolean parameter to list_sites() and show_site() called `latlon` that is `True` by default, which means 'query for latlon'. The reason is because users are used to seeing coordinates in the site table. However going forward we should start switching this off by setting list_sites(latlon=False) in the notebooks wherever it makes sense.

If you turn off latlon lookup, now list_sites() returns in 2 seconds. Note that Orchestrator returns in about 150msec and the rest is local processing of the results. Before it was measured in minutes. This should allow JH to scale a lot better as CPU was always pegged on this operation (in JH container) and it was hard to imagine 400 of these executing concurrently.

Finally for selecting random sites I used a heuristic. If a filter function is passed in I do latlon lookup on the theory that the filter function may need it. However if there is no filter function I turn of latlon lookup to speed up the code. After that it calls list_sites with already described optimizations, so it is fast.

This required a minor mod to the FIM due to a bug in converting advertisement nodes into slivers. So this requires `fabric_fim==1.5.5` which is assumed to be included in `fabrictestbed==1.5.5` (version match is a coincidence). 

