### PR TITLE
Add missing docstrings for Node methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Display and filter by PTP availability at each site based on ARM
   information (PR [#236](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/236)).
-
+- Missing docstrings for Node module (PR
+  [#237](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/237))
 
 ### [1.5.4] - 2023-08-21
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2993,9 +2993,11 @@ class Node:
         """
         Run configuration tasks for this node.
 
-        Use this method in order to re-apply configuration to a
-        rebooted node.  Normally this method is invoked by
-        ``Slice.submit()`` or ``Slice.modify()``.
+        .. note ::
+
+            Use this method in order to re-apply configuration to a
+            rebooted node.  Normally this method is invoked by
+            ``Slice.submit()`` or ``Slice.modify()``.
 
         Configuration tasks include:
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2824,6 +2824,12 @@ class Node:
         self.set_fablib_data(fablib_data)
 
     def add_post_boot_execute(self, command: str):
+        """
+        Execute a command on the node after boot.
+
+        :param command: command to be executed on the node.
+        :type command: str
+        """
         fablib_data = self.get_fablib_data()
         if "post_boot_tasks" not in fablib_data:
             fablib_data["post_boot_tasks"] = []

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2837,6 +2837,9 @@ class Node:
         self.set_fablib_data(fablib_data)
 
     def post_boot_tasks(self):
+        """
+        Get the list of tasks to be performed on this node after boot.
+        """
         fablib_data = self.get_fablib_data()
 
         if "post_boot_tasks" in fablib_data:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2993,6 +2993,10 @@ class Node:
         """
         Run configuration tasks for this node.
 
+        Use this method in order to re-apply configuration to a
+        rebooted node.  Normally this method is invoked by
+        ``Slice.submit()`` or ``Slice.modify()``.
+
         Configuration tasks include:
 
             - Setting hostname.

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2210,6 +2210,18 @@ class Node:
         )
 
     def ip_addr_list(self, output="json", update=False):
+        """
+        Return the list of IP addresses assciated with this node.
+
+        :param output: Output format; ``"json"`` by default.
+        :param update: Setting this to ``True`` will force-update the
+            cached list of IP addresses; default is ``False``.
+
+        :returns: When ``output`` is set to ``"json"`` (which is the
+                  default), the result of running ``ip -j[son] addr
+                  list``, converted to a Python object.  Otherwise the
+                  result of ``ip addr list``.
+        """
         try:
             if self.ip_addr_list_json is not None and update == False:
                 return self.ip_addr_list_json

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2768,6 +2768,9 @@ class Node:
         self.set_fablib_data(fablib_data)
 
     def add_post_update_command(self, command: str):
+        """
+        Run a command after boot.
+        """
         fablib_data = self.get_fablib_data()
         if "post_update_commands" not in fablib_data:
             fablib_data["post_update_commands"] = []

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2990,6 +2990,25 @@ class Node:
         self.set_fablib_data(fablib_data)
 
     def config(self, log_dir="."):
+        """
+        Run configuration tasks for this node.
+
+        Configuration tasks include:
+
+            - Setting hostname.
+
+            - Configuring interfaces.
+
+            - Configuring routes.
+
+            - Running post-boot tasks added by
+              ``add_post_boot_execute()``,
+              ``add_post_boot_upload_file()``, and
+              ``add_post_boot_upload_directory()``.
+
+            - Running post-update commands added by
+              ``add_post_update_command()``.
+        """
         self.execute(f"sudo hostnamectl set-hostname '{self.get_name()}'", quiet=True)
 
         for iface in self.get_interfaces():

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2231,7 +2231,7 @@ class Node:
                     self.ip_addr_list_json = json.loads(stdout)
                     return self.ip_addr_list_json
                 else:
-                    stdout, stderr = self.execute(f"sudo ip list", quiet=True)
+                    stdout, stderr = self.execute(f"sudo ip addr list", quiet=True)
                     return stdout
         except Exception as e:
             logging.debug(f"Failed to get ip addr list: {e}")

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2806,6 +2806,15 @@ class Node:
     def add_post_boot_upload_file(
         self, local_file_path: str, remote_file_path: str = "."
     ):
+        """
+        Upload a file to the node after boot.
+
+        :param local_file_path: path to file on local filesystem.
+        :type local_file_path: str
+        
+        :param remote_file_path: path to file on the node.
+        :type remote_file_path: str
+        """
         fablib_data = self.get_fablib_data()
         if "post_boot_tasks" not in fablib_data:
             fablib_data["post_boot_tasks"] = []

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2786,6 +2786,15 @@ class Node:
     def add_post_boot_upload_directory(
         self, local_directory_path: str, remote_directory_path: str = "."
     ):
+        """
+        Upload a directory to the node after boot.
+
+        :param local_directory_path: local directory.
+        :type local_directory_path: str
+        
+        :param remote_directory_path: directory on the node.
+        :type remote_directory_path: str
+        """
         fablib_data = self.get_fablib_data()
         if "post_boot_tasks" not in fablib_data:
             fablib_data["post_boot_tasks"] = []

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3262,6 +3262,9 @@ class Node:
             raise e
 
     def os_reboot(self):
+        """
+        Reboot the node.
+        """
         status = self.poa(operation="reboot")
         if status == "Failed":
             raise Exception("Failed to reboot the server")

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2820,7 +2820,7 @@ class Node:
 
         :param local_directory_path: local directory.
         :type local_directory_path: str
-        
+
         :param remote_directory_path: directory on the node.
         :type remote_directory_path: str
         """
@@ -2840,7 +2840,7 @@ class Node:
 
         :param local_file_path: path to file on local filesystem.
         :type local_file_path: str
-        
+
         :param remote_file_path: path to file on the node.
         :type remote_file_path: str
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2770,6 +2770,17 @@ class Node:
         subnet: IPv4Network or IPv6Network,
         next_hop: IPv4Address or IPv6Address or NetworkService,
     ):
+        """
+        Add a route.
+
+        :param subnet: an IPv4 or IPv6 address.
+
+        :type subnet:IPv4Network or IPv6Network.
+
+        :param next_hop: a gateway address (IPv4Address or
+            IPv6Address) or a NetworkService.
+        :type next_hop: IPv4Address or IPv6Address or NetworkService.
+        """
         if type(next_hop) == NetworkService:
             next_hop = next_hop.get_name()
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2779,6 +2779,9 @@ class Node:
         self.set_fablib_data(fablib_data)
 
     def get_post_update_commands(self):
+        """
+        Get the list of commands that are to be run after boot.
+        """
         fablib_data = self.get_fablib_data()
 
         if "post_update_commands" in fablib_data:


### PR DESCRIPTION
Partly resolves #235.

It is not immediately apparent which methods really _deserve_ docstrings, so I went though the notebook examples, and documented the methods that appear to be public.  The rest should be either marked as private, or documented, but this will require some consideration.