### PR TITLE
Fix an error in Node.list_networks()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix an error in `Node.list_networks()` (Issue
+  [#239](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/239),
+  PR [#241](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/241))
+
 ### Added
 
 - Missing docstrings for `Node.add_fabnet()` (PR

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -586,6 +586,10 @@ class Node:
             field values.
         :type filter_function: lambda
 
+        :param pretty_names: Use "nicer" names in column headers.
+            Default is ``True``.
+        :type pretty_names: bool
+
         :return: table in format specified by output parameter
         :rtype: Object
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -615,17 +615,12 @@ class Node:
 
             return False
 
-        if pretty_names and len(networks) > 0:
-            pretty_names_dict = networks[0].get_pretty_name_dict()
-        else:
-            pretty_names_dict = {}
-
         return self.get_slice().list_networks(
             fields=fields,
             output=output,
             quiet=quiet,
             filter_function=combined_filter_function,
-            pretty_names_dict=pretty_names_dict,
+            pretty_names=pretty_names,
         )
 
     def get_networks(self):

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -2101,6 +2101,10 @@ class Slice:
         :param filter_function: lambda function
         :type filter_function: lambda
 
+        :param pretty_names: Use "nicer" names in column headers.
+            Default is ``True``.
+        :type pretty_names: bool
+
         :return: table in format specified by output parameter
         :rtype: Object
         """

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -2070,31 +2070,37 @@ class Slice:
         """
         Lists all the networks in the slice.
 
-        There are several output options: "text", "pandas", and "json" that determine the format of the
-        output that is returned and (optionally) displayed/printed.
+        There are several output options: "text", "pandas", and "json"
+        that determine the format of the output that is returned and
+        (optionally) displayed/printed.
 
-        output:  'text': string formatted with tabular
-                  'pandas': pandas dataframe
-                  'json': string in json format
+        output: 'text': string formatted with tabular 'pandas': pandas
+        dataframe 'json': string in json format
 
         fields: json output will include all available fields/columns.
 
         Example: fields=['Name','State']
 
-        filter_function:  A lambda function to filter data by field values.
+        filter_function: A lambda function to filter data by field
+        values.
 
         Example: filter_function=lambda s: s['State'] == 'Active'
 
         :param output: output format
         :type output: str
+
         :param fields: list of fields (table columns) to show
         :type fields: List[str]
-        :param quiet: True to specify printing/display
-        :type quiet: bool
-        :param filter_function: lambda function
-        :type filter_function: lambda
+
         :param colors: True to add colors to the table when possible
         :type colors: bool
+
+        :param quiet: True to specify printing/display
+        :type quiet: bool
+
+        :param filter_function: lambda function
+        :type filter_function: lambda
+
         :return: table in format specified by output parameter
         :rtype: Object
         """

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -42,15 +42,14 @@ class FablibNodeTests(unittest.TestCase):
         self.slice = self.fablib.new_slice(name=slice_name)
         self.node = self.slice.add_node(name="node-1")
 
+        self.assertIsInstance(self.fablib.get_config(), dict)
+        self.assertIsInstance(self.slice, Slice)
+        self.assertIsInstance(self.node, Node)
+
         self.slice.submit()
 
     def tearDown(self):
         self.slice.delete()
-
-    def test_setup(self):
-        self.assertIsInstance(self.fablib.get_config(), dict)
-        self.assertIsInstance(self.slice, Slice)
-        self.assertIsInstance(self.node, Node)
 
     def test_list_networks(self):
         networks = self.node.list_networks()

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -44,6 +44,9 @@ class FablibNodeTests(unittest.TestCase):
 
         self.slice.submit()
 
+    def tearDown(self):
+        self.slice.delete()
+
     def test_setup(self):
         self.assertIsInstance(self.fablib.get_config(), dict)
         self.assertIsInstance(self.slice, Slice)

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -63,6 +63,9 @@ class FablibNodeTests(unittest.TestCase):
         networks = self.node.list_networks(pretty_names=True)
         self.assertEqual(networks, "")
 
+        networks = self.node.list_networks(pretty_names=False)
+        self.assertEqual(networks, "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -56,15 +56,11 @@ class FablibNodeTests(unittest.TestCase):
         self.slice.delete()
 
     def test_list_networks(self):
-        networks = self.node.list_networks()
-        self.assertEqual(networks, "")
+        self.assertEqual(self.node.list_networks(), "")
 
     def test_list_networks_pretty(self):
-        networks = self.node.list_networks(pretty_names=True)
-        self.assertEqual(networks, "")
-
-        networks = self.node.list_networks(pretty_names=False)
-        self.assertEqual(networks, "")
+        self.assertEqual(self.node.list_networks(pretty_names=True), "")
+        self.assertEqual(self.node.list_networks(pretty_names=False), "")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -35,7 +35,7 @@ class FablibNodeTests(unittest.TestCase):
     """
     Tests for fabrictestbed_extensions.fablib.node.Node.
     """
-    
+
     def setUp(self):
         self.fablib = FablibManager()
 

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -32,6 +32,10 @@ from fabrictestbed_extensions.fablib.slice import Slice
 
 
 class FablibNodeTests(unittest.TestCase):
+    """
+    Tests for fabrictestbed_extensions.fablib.node.Node.
+    """
+    
     def setUp(self):
         self.fablib = FablibManager()
 

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -57,8 +57,6 @@ class FablibNodeTests(unittest.TestCase):
 
     def test_list_networks(self):
         self.assertEqual(self.node.list_networks(), "")
-
-    def test_list_networks_pretty(self):
         self.assertEqual(self.node.list_networks(pretty_names=True), "")
         self.assertEqual(self.node.list_networks(pretty_names=False), "")
 

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+import socket
+import time
+import unittest
+
+from fabrictestbed_extensions.fablib.fablib import FablibManager
+from fabrictestbed_extensions.fablib.node import Node
+from fabrictestbed_extensions.fablib.slice import Slice
+
+
+class FablibNodeTests(unittest.TestCase):
+    def setUp(self):
+        self.fablib = FablibManager()
+
+        time_stamp = time.strftime("%Y-%m-%d %H:%M:%S")
+        host = socket.gethostname()
+        slice_name = f"integration test @ {time_stamp} on {host}"
+
+        self.slice = self.fablib.new_slice(name=slice_name)
+        self.node = self.slice.add_node(name="node-1")
+
+        self.slice.submit()
+
+    def test_setup(self):
+        self.assertIsInstance(self.fablib.get_config(), dict)
+        self.assertIsInstance(self.slice, Slice)
+        self.assertIsInstance(self.node, Node)
+
+    def test_list_networks(self):
+        networks = self.node.list_networks()
+        self.assertEqual(networks, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -53,6 +53,10 @@ class FablibNodeTests(unittest.TestCase):
         networks = self.node.list_networks()
         self.assertEqual(networks, "")
 
+    def test_list_networks_pretty(self):
+        networks = self.node.list_networks(pretty_names=True)
+        self.assertEqual(networks, "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #239.  This is a simple fix where the right parameter should be passed to `Slice.list_networks()`, but it also ended up accumulating a simple integration test and some docstring updates in the process.