### PR TITLE
Version in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Missing docstrings for `Node.add_fabnet()` (PR
   [#240](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/240))
-
+- Version in pyproject.toml (Issue
+  [#248](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/248))
 
 ## [1.5.5]
 

--- a/README.md
+++ b/README.md
@@ -151,13 +151,10 @@ the packages on PyPI, and (4) create a GitHub release.
 In order to "manually" upload FABlib packages (such as in the case of
 release candidate versions), bump up the version string in the
 appropriate place, and then do:
-
-1. Update the package version in `pyproject.toml`.
-2. Build the source and wheel packages, and upload packages to PyPI with:
-
-    ```console
-    $ flit publish
-    ```
+ 
+```console
+$ flit publish
+```
 
 Continuing to use twine to publish packages is an option too:
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ appropriate place, and then do:
     $ flit publish
     ```
 
+Continuing to use twine to publish packages is an option too:
+
+```console
+$ twine upload dist/*
+```
+
 For details about publishing to PyPI, see flit documentation about
 [package uploads].
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ $ pip install flit
 $ flit build
 ```
 
+While using flit as the build backend, continuing to use [build] as
+the build frontend should work too:
+
+```
+$ pip install build
+$ python -m build
+```
+
+
 ## Releasing FABlib
 
 The "[publish]" workflow automates building packages and publishing
@@ -184,6 +193,7 @@ For details about publishing to PyPI, see flit documentation about
 [flit]: https://flit.pypa.io/en/stable/
 [package uploads]: https://flit.pypa.io/en/latest/upload.html
 
+[build]: https://pypi.org/project/build/
 [tox]: https://pypi.org/project/tox/
 [pytest]: https://pypi.org/project/pytest/
 [black]: https://pypi.org/project/black/

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ $ python -m build
 ## Releasing FABlib
 
 When it is time to release a new version of FABlib, remember to: (1)
-update the package version in top-level `__init__.py`, (2) build the
-source and wheel packages, and (3) upload packages to PyPI:
+update the package version in `pyproject.toml`, (2) build the source
+and wheel packages, and (3) upload packages to PyPI:
 
 ```console
 $ flit publish

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The "[publish]" workflow automates building packages and publishing
 them on PyPI.  In order to publish a new FABlib version on PyPI,
 follow these steps:
 
-1. Bump up version in top-level `__init__.py`.
+1. Bump up version in `pyproject.toml`.
 2. Update changelog.
 3. Start a PR with these changes, and get it merged.
 4. Tag the release, and push the tag to GitHub:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ the top-level `tests` directory.  Unit tests can be run like so, using
 [tox]:
 
 ```console
-$ pip install -e .[test]
+$ pip install tox
 $ tox
 ```
 
@@ -88,6 +88,7 @@ Tox attempts to run tests in an isolated virtual environment.  If you
 want to run some tests directly using [pytest], that is possible too:
 
 ```
+$ pip install -e .[test]
 $ pytest -s tests/integration/test_hello_fabric.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ them on PyPI.  In order to publish a new FABlib version on PyPI,
 follow these steps:
 
 1. Bump up version in `pyproject.toml`.
-2. Update changelog.
+2. Update `CHANGELOG.md`.
 3. Start a PR with these changes, and get it merged.
 4. Tag the release, and push the tag to GitHub:
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ the packages on PyPI, and (4) create a GitHub release.
 In order to "manually" upload FABlib packages (such as in the case of
 release candidate versions), bump up the version string in the
 appropriate place, and then do:
- 
+
 ```console
 $ flit publish
 ```

--- a/README.md
+++ b/README.md
@@ -117,15 +117,6 @@ $ pip install flit
 $ flit build
 ```
 
-While using flit as the build backend, continuing to use [build] as
-the build frontend should work too:
-
-```
-$ pip install build
-$ python -m build
-```
-
-
 ## Releasing FABlib
 
 When it is time to release a new version of FABlib, remember to: 
@@ -171,7 +162,6 @@ For details about publishing to PyPI, see flit documentation about
 [flit]: https://flit.pypa.io/en/stable/
 [package uploads]: https://flit.pypa.io/en/latest/upload.html
 
-[build]: https://pypi.org/project/build/
 [tox]: https://pypi.org/project/tox/
 [pytest]: https://pypi.org/project/pytest/
 [black]: https://pypi.org/project/black/

--- a/README.md
+++ b/README.md
@@ -128,13 +128,14 @@ $ python -m build
 
 ## Releasing FABlib
 
-When it is time to release a new version of FABlib, remember to: (1)
-update the package version in `pyproject.toml`, (2) build the source
-and wheel packages, and (3) upload packages to PyPI:
+When it is time to release a new version of FABlib, remember to: 
 
-```console
-$ flit publish
-```
+1. Update the package version in `pyproject.toml`.
+2. Build the source and wheel packages, and upload packages to PyPI with:
+
+    ```console
+    $ flit publish
+    ```
 
 Continuing to use twine to publish packages is an option too:
 

--- a/README.md
+++ b/README.md
@@ -128,12 +128,6 @@ When it is time to release a new version of FABlib, remember to:
     $ flit publish
     ```
 
-Continuing to use twine to publish packages is an option too:
-
-```console
-$ twine upload dist/*
-```
-
 For details about publishing to PyPI, see flit documentation about
 [package uploads].
 

--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 __all__ = ["__version__"]
 
 from importlib.metadata import version

--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -20,8 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-__all__ = ["__version__"]
-
 from importlib.metadata import version
+
+__all__ = ["__version__"]
 
 __version__ = version(__name__)

--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -1,3 +1,5 @@
-# Please update version number here when making a release: flit, the
-# build backend we use, picks up the version from here.
-__version__ = "1.5.5"
+__all__ = ["__version__"]
+
+from importlib.metadata import version
+
+__version__ = version(__name__)

--- a/fabrictestbed_extensions/__init__.py
+++ b/fabrictestbed_extensions/__init__.py
@@ -24,4 +24,5 @@ from importlib.metadata import version
 
 __all__ = ["__version__"]
 
+# Version gets picked up from package metadata in pyproject.toml.
 __version__ = version(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "fabrictestbed-extensions"
-"version" = "1.5.5"
+version = "1.5.5"
 description = "FABRIC Python Client Library and CLI Extensions"
 authors = [
     {name="Paul Ruth", email="pruth@renci.org"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,17 @@ Documentation = "https://fabric-fablib.readthedocs.io/"
 ChangeLog = "https://github.com/fabric-testbed/fabrictestbed-extensions/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
-doc = ["sphinx", "furo"]
-test = ["black==23.*", "isort==5.*", "tox==4.*", "pytest", "coverage[toml]"]
+doc = [
+  "sphinx",
+  "furo"
+]
+test = [
+  "black==23.*",
+  "isort==5.*",
+  "tox==4.*",
+  "pytest",
+  "coverage[toml]"
+]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,33 +7,33 @@ name = "fabrictestbed-extensions"
 version = "1.5.5"
 description = "FABRIC Python Client Library and CLI Extensions"
 authors = [
-    {name="Paul Ruth", email="pruth@renci.org"},
-    {name="Komal Thareja", email="kthare10@renci.org"}
-    ]
+  { name = "Paul Ruth", email = "pruth@renci.org" },
+  { name = "Komal Thareja", email = "kthare10@renci.org" },
+]
 
-readme = {file = "README.md", content-type = "text/markdown"}
-license = {file = "LICENSE" }
+readme = { file = "README.md", content-type = "text/markdown" }
+license = { file = "LICENSE" }
 requires-python = ">=3.9"
 dependencies = [
-    "ipycytoscape",
-    "ipywidgets",
-    "ipyleaflet",
-    "ipycytoscape",
-    "tabulate",
-    "fabrictestbed==1.5.6",
-    "paramiko",
-    "jinja2>=3.0.0",
-    "pandas",
-    "numpy",
-    "ipython>=8.12.0",
-    "fabric_fss_utils>=1.5.1"
-    ]
+  "ipycytoscape",
+  "ipywidgets",
+  "ipyleaflet",
+  "ipycytoscape",
+  "tabulate",
+  "fabrictestbed==1.5.6",
+  "paramiko",
+  "jinja2>=3.0.0",
+  "pandas",
+  "numpy",
+  "ipython>=8.12.0",
+  "fabric_fss_utils>=1.5.1",
+]
 
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-    ]
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+]
 
 [project.urls]
 Homepage = "https://fabric-testbed.net/"
@@ -43,17 +43,11 @@ ChangeLog = "https://github.com/fabric-testbed/fabrictestbed-extensions/blob/mai
 
 [project.optional-dependencies]
 doc = ["sphinx", "furo"]
-test = [
-    "black==23.*",
-    "isort==5.*",
-    "tox==4.*",
-    "pytest",
-    "coverage[toml]"
-    ]
+test = ["black==23.*", "isort==5.*", "tox==4.*", "pytest", "coverage[toml]"]
 
 [tool.coverage.run]
 branch = true
-omit = [ "fabrictestbed_extensions/tests/*" ]
+omit = ["fabrictestbed_extensions/tests/*"]
 
 [tool.black]
 src_paths = ["fabrictestbed_extensions", "docs/source/conf.py", "tests"]
@@ -68,6 +62,4 @@ addopts = "-ra -q"
 # By default, run only unit tests when pytest is invoked.  Integration
 # tests will require some manual setup (namely token acquisition), and
 # thus we can't run them on CI.
-testpaths = [
-    "tests/unit/",
-]
+testpaths = ["tests/unit/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "fabrictestbed-extensions"
-# Bump version up in top-level __init.py__.
-dynamic = ["version"]
+"version" = "1.5.5"
 description = "FABRIC Python Client Library and CLI Extensions"
 authors = [
     {name="Paul Ruth", email="pruth@renci.org"},


### PR DESCRIPTION
Resolves #248.  Changes:

- Specify package version in `pyproject.toml` (and _not_ in top-level `__init__.py`), so that `pyproject.toml` will be the single source of package metadata.
- Update README accordingly.  Also updates notes about testing for accuracy.
- For backward compatibility, continue to export a `fabrictestbed_extensions.__version__` symbol.  This is implemented using [`importlib.metadata.version()`](https://docs.python.org/3/library/importlib.metadata.html#distribution-versions).
- Format `pyproject.toml` using [taplo](https://taplo.tamasfe.dev/). 