### PR TITLE
Housekeeping updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix an error in `Node.list_networks()` (Issue
   [#239](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/239),
   PR [#241](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/241))
+- Honor wait_timeout in slice.submit()
+  ([#253](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/253))
 
 ### Added
 

--- a/tests/integration/test_bastion_ssh.py
+++ b/tests/integration/test_bastion_ssh.py
@@ -27,7 +27,7 @@ class BastionHostTests(unittest.TestCase):
         """
         fm = FablibManager(offline=True, bastion_username="")
         self.assertRaises(
-            paramiko.ssh_exception.AuthenticationException, fm.probe_bastion_host
+            paramiko.ssh_exception.SSHException, fm.probe_bastion_host
         )
 
     def test_probe_bastion_host_empty_key(self):
@@ -38,7 +38,7 @@ class BastionHostTests(unittest.TestCase):
 
         fm = FablibManager(offline=True, bastion_key_filename=keyfile.name)
         self.assertRaises(
-            paramiko.ssh_exception.AuthenticationException, fm.probe_bastion_host
+            paramiko.ssh_exception.SSHException, fm.probe_bastion_host
         )
 
     def test_probe_bastion_host_bad_key(self):
@@ -52,5 +52,5 @@ class BastionHostTests(unittest.TestCase):
 
         fm = FablibManager(offline=True, bastion_key_filename=keyfile.name)
         self.assertRaises(
-            paramiko.ssh_exception.AuthenticationException, fm.probe_bastion_host
+            paramiko.ssh_exception.SSHException, fm.probe_bastion_host
         )

--- a/tests/integration/test_bastion_ssh.py
+++ b/tests/integration/test_bastion_ssh.py
@@ -26,9 +26,7 @@ class BastionHostTests(unittest.TestCase):
         Test bastion with an empty username.
         """
         fm = FablibManager(offline=True, bastion_username="")
-        self.assertRaises(
-            paramiko.ssh_exception.SSHException, fm.probe_bastion_host
-        )
+        self.assertRaises(paramiko.ssh_exception.SSHException, fm.probe_bastion_host)
 
     def test_probe_bastion_host_empty_key(self):
         """
@@ -37,9 +35,7 @@ class BastionHostTests(unittest.TestCase):
         keyfile = tempfile.NamedTemporaryFile()
 
         fm = FablibManager(offline=True, bastion_key_filename=keyfile.name)
-        self.assertRaises(
-            paramiko.ssh_exception.SSHException, fm.probe_bastion_host
-        )
+        self.assertRaises(paramiko.ssh_exception.SSHException, fm.probe_bastion_host)
 
     def test_probe_bastion_host_bad_key(self):
         """
@@ -51,6 +47,4 @@ class BastionHostTests(unittest.TestCase):
         rsa_key.write_private_key_file(keyfile.name)
 
         fm = FablibManager(offline=True, bastion_key_filename=keyfile.name)
-        self.assertRaises(
-            paramiko.ssh_exception.SSHException, fm.probe_bastion_host
-        )
+        self.assertRaises(paramiko.ssh_exception.SSHException, fm.probe_bastion_host)


### PR DESCRIPTION
- Make `tox -e integration -- tests/integration/test_bastion_ssh.py` pass again, because paramiko's behavior has changed when connecting using an invalid ssh key.  (We get an `SSHException` instead of `AuthenticationException` when a wrong SSH key is used.)
- Update changelog to add an entry for #253.