### PR TITLE
Add module docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#242](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/242),
   [#243](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/243),
   PR [#251](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/251))
-
+- Module docstrings (PR
+  [#256](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/256))
 
 ## [1.5.5]
 

--- a/docs/source/component.rst
+++ b/docs/source/component.rst
@@ -1,4 +1,4 @@
-Component
+component
 =========
 
 .. automodule:: fabrictestbed_extensions.fablib.component

--- a/docs/source/component.rst
+++ b/docs/source/component.rst
@@ -6,4 +6,4 @@ component
 
 .. autoclass:: fabrictestbed_extensions.fablib.component.Component
    :members:
-   :special-members: __init__, __str__
+   :special-members: __str__

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,9 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# Use __init__ method’s docstrings in class docs.  Other options are
+# "class" and "both".
+autoclass_content = "init"
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/fablib.rst
+++ b/docs/source/fablib.rst
@@ -1,5 +1,5 @@
-FablibManager
-=============
+fablib
+======
 
 .. automodule:: fabrictestbed_extensions.fablib.fablib
    :members:

--- a/docs/source/fablib.rst
+++ b/docs/source/fablib.rst
@@ -6,4 +6,4 @@ fablib
 
 .. autoclass:: fabrictestbed_extensions.fablib.fablib.FablibManager
    :members:
-   :special-members: __init__, __str__
+   :special-members: __str__

--- a/docs/source/facility_port.rst
+++ b/docs/source/facility_port.rst
@@ -6,4 +6,4 @@ facility_port
 
 .. autoclass:: fabrictestbed_extensions.fablib.facility_port.FacilityPort
    :members:
-   :special-members: __init__, __str__
+   :special-members: __str__

--- a/docs/source/facility_port.rst
+++ b/docs/source/facility_port.rst
@@ -1,5 +1,5 @@
-FacilityPort
-============
+facility_port
+=============
 
 .. automodule:: fabrictestbed_extensions.fablib.facility_port
    :members:

--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -6,4 +6,4 @@ interface
 
 .. autoclass:: fabrictestbed_extensions.fablib.interface.Interface
    :members:
-   :special-members: __init__, __str__
+   :special-members: __str__

--- a/docs/source/interface.rst
+++ b/docs/source/interface.rst
@@ -1,4 +1,4 @@
-Interface
+interface
 =========
 
 .. automodule:: fabrictestbed_extensions.fablib.interface

--- a/docs/source/network_service.rst
+++ b/docs/source/network_service.rst
@@ -6,4 +6,4 @@ network_service
 
 .. autoclass:: fabrictestbed_extensions.fablib.network_service.NetworkService
    :members:
-   :special-members: __init__, __str__
+   :special-members: __str__

--- a/docs/source/network_service.rst
+++ b/docs/source/network_service.rst
@@ -1,5 +1,5 @@
-NetworkService
-==============
+network_service
+===============
 
 .. automodule:: fabrictestbed_extensions.fablib.network_service
    :members:

--- a/docs/source/node.rst
+++ b/docs/source/node.rst
@@ -6,4 +6,4 @@ node
 
 .. autoclass:: fabrictestbed_extensions.fablib.node.Node
    :members:
-   :special-members: __init__, __str__
+   :special-members: __str__

--- a/docs/source/node.rst
+++ b/docs/source/node.rst
@@ -1,4 +1,4 @@
-Node
+node
 ====
 
 .. automodule:: fabrictestbed_extensions.fablib.node

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -6,4 +6,4 @@ resources
 
 .. autoclass:: fabrictestbed_extensions.fablib.resources.Resources
    :members:
-   :special-members: __init__, __str__
+   :special-members: __str__

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -1,4 +1,4 @@
-Resources
+resources
 =========
 
 .. automodule:: fabrictestbed_extensions.fablib.resources

--- a/docs/source/slice.rst
+++ b/docs/source/slice.rst
@@ -1,4 +1,4 @@
-Slice
+slice
 =====
 
 .. automodule:: fabrictestbed_extensions.fablib.slice

--- a/docs/source/slice.rst
+++ b/docs/source/slice.rst
@@ -6,4 +6,4 @@ slice
 
 .. autoclass:: fabrictestbed_extensions.fablib.slice.Slice
    :members:
-   :special-members: __init__, __str__
+   :special-members: __str__

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -22,6 +22,18 @@
 # SOFTWARE.
 #
 # Author: Paul Ruth (pruth@renci.org)
+
+"""
+This module contains methods to work with FABRIC components.
+
+A FABRIC component is a virtualized piece of hardware that a user may
+add to a virtual machine (VM) to expand the VM’s capabilities.
+Examples include graphical processing units (GPUs), network
+identification cards (NICs), storage access such as nonvolatile memory
+express (NVME).  Components represent a more fine-grained type of
+resource.
+"""
+
 from __future__ import annotations
 
 import json

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -322,12 +322,15 @@ class Component:
 
     def __init__(self, node: Node = None, fim_component: FimComponent = None):
         """
-        Not intended for API use
+        Typically invoked when you add a component to a ``Node``.
 
-        Constructor. Sets the FIM component and fablib node to the inputted values.
+        .. note ::
+
+            ``Component`` constructer is not meant to be directly used.
 
         :param node: the fablib node to build the component on
         :type node: Node
+
         :param fim_component: the FIM component this object represents
         :type fim_component: FIMComponent
         """

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -32,6 +32,12 @@ Examples include graphical processing units (GPUs), network
 identification cards (NICs), storage access such as nonvolatile memory
 express (NVME).  Components represent a more fine-grained type of
 resource.
+
+You normally would not create ``Component`` objects with a directly;
+they are created when you invoke ``Node.add_component()``::
+
+    node.add_component(model='NVME_P4510', name="nvme1")
+    node.add_component(model='NIC_Basic', name="nic1")
 """
 
 from __future__ import annotations

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -24,17 +24,12 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-This module contains methods to work with FABRIC components.
+This module contains methods to work with FABRIC components_.
 
-A FABRIC component is a virtualized piece of hardware that a user may
-add to a virtual machine (VM) to expand the VM’s capabilities.
-Examples include graphical processing units (GPUs), network
-identification cards (NICs), storage access such as nonvolatile memory
-express (NVME).  Components represent a more fine-grained type of
-resource.
+.. _components: https://learn.fabric-testbed.net/knowledge-base/glossary/#component
 
-You normally would not create ``Component`` objects directly with a
-constructor call; they are created when you invoke
+You normally would not create :class:`Component` objects directly with
+a constructor call; they are created when you invoke
 :py:func:`fabrictestbed_extensions.fablib.node.Node.add_component()`,
 like so::
 

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -24,7 +24,7 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-This module contains methods to work with FABRIC components_.
+Methods to work with FABRIC components_.
 
 .. _components: https://learn.fabric-testbed.net/knowledge-base/glossary/#component
 

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -33,8 +33,10 @@ identification cards (NICs), storage access such as nonvolatile memory
 express (NVME).  Components represent a more fine-grained type of
 resource.
 
-You normally would not create ``Component`` objects with a directly;
-they are created when you invoke ``Node.add_component()``::
+You normally would not create ``Component`` objects directly with a
+constructor call; they are created when you invoke
+:py:func:`fabrictestbed_extensions.fablib.node.Node.add_component()`,
+like so::
 
     node.add_component(model='NVME_P4510', name="nvme1")
     node.add_component(model='NIC_Basic', name="nic1")

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -22,6 +22,20 @@
 # SOFTWARE.
 #
 # Author: Paul Ruth (pruth@renci.org)
+
+"""
+This module exports ``FablibManager`` class and a ``fablib`` class,
+which allows you to, among other things:
+
+    - Query FABRIC testbed resources.
+
+    - Create, modify, and delete slices.
+
+    - Manage the SSH keys you use with FABRIC.
+
+They also contain some helpful utility methods.
+"""
+
 from __future__ import annotations
 
 import json

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -24,8 +24,8 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-This module exports ``FablibManager`` class and a ``fablib`` class,
-which allows you to, among other things:
+This module exports a :class:`FablibManager` class and a
+:class:`fablib` class, which allows you to, among other things:
 
     - Query FABRIC testbed resources.
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -25,7 +25,8 @@
 
 """
 This module exports a :class:`FablibManager` class and a
-:class:`fablib` class, which allows you to, among other things:
+:class:`fablib` class available, which allows you to, among other
+things:
 
     - Query FABRIC testbed resources.
 
@@ -33,7 +34,24 @@ This module exports a :class:`FablibManager` class and a
 
     - Manage the SSH keys you use with FABRIC.
 
-They also contain some helpful utility methods.
+    - etc.
+
+In most cases you would need to create a :class:`FablibManager`
+instance to interact with FABRIC testbed::
+
+    from fabrictestbed_extensions.fablib.fablib import FablibManager
+
+    fablib = FablibManager()
+
+    slice = fablib.new_slice(name="MySlice")
+    node = slice.add_node(name="node1")
+    slice.submit();
+
+.. note::
+
+    Some configuration in the form of a configuration file, environment variables, or :class:`FablibManager` constructor parameters is required for the library to work.  Please see the FABRIC project's `documentation on getting started <learn>`_.
+
+.. _learn: https://learn.fabric-testbed.net/article-categories/getting-started/
 """
 
 from __future__ import annotations

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -630,13 +630,49 @@ class FablibManager:
         offline: bool = False,
     ):
         """
-        Constructor. Builds FablibManager.  Tries to get configuration from:
+        FablibManager constructor.
 
-         - constructor parameters (high priority)
-         - fabric_rc file (middle priority)
-         - environment variables (low priority)
-         - defaults (if needed and possible)
+        A FablibManager object can be managed to query FABRIC testbed
+        for available resources, create and configure slices, manage
+        SSH keys in nodes in slices and FABRIC's bastion host, etc.
 
+        Tries to get configuration from:
+
+            - constructor parameters (high priority)
+
+            - fabric_rc file (middle priority)
+
+            - environment variables (low priority)
+
+            - defaults (if needed and possible)
+
+        :param fabric_rc: Path to fablib configuration file.  Defaults
+            to ``"${HOME}/work/fabric_config/fabric_rc"``.
+        :param credmgr_host: Name of credential manager host.
+        :param orchestrator_host: Name of FABRIC orchestrator host.
+        :param fabric_token: Path to the file that contains your
+            FABRIC auth token.
+        :param project_id: Your FABRIC project ID, obtained from
+            https://cm.fabric-testbed.net/, usually via FABRIC portal.
+        :param bastion_username: Your username on FABRIC bastion host,
+            obtained from FABRIC portal.
+        :param bastion_key_filename: Path to your bastion SSH key.
+        :param log_file: Path where fablib logs are written; defaults
+            to ``"/tmp/fablib/fablib.log"``.
+        :param log_level: Level of detail in the logs written.
+            Defaults to ``"DEBUG"``; other possible log levels are
+            ``"INFO"``, ``"WARNING"``, ``"ERROR"``, and
+            ``"CRITICAL"``, in reducing order of verbosity.
+        :param data_dir: directory for fablib to store temporary data.
+        :param output: Format of fablib output; can be either
+            ``"pandas"`` or ``"text"``.  Defaults to ``"pandas"`` in a
+            Jupyter notebook environment; ``"text"`` otherwise.
+        :param execute_thread_pool_size: Number of worker threads in
+            the thread pool fablib uses to execute commands in nodes.
+            Defaults to 64.
+        :param offline: Avoid using FABRIC services when initializing.
+            This is ``False`` by default, and set to ``True`` only in
+            some unit tests.
         """
 
         if output != None:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -630,21 +630,24 @@ class FablibManager:
         offline: bool = False,
     ):
         """
-        FablibManager constructor.
+        ``FablibManager`` is the main interface to FABRIC services.
 
-        A FablibManager object can be managed to query FABRIC testbed
-        for available resources, create and configure slices, manage
-        SSH keys in nodes in slices and FABRIC's bastion host, etc.
-
-        Tries to get configuration from:
+        A ``FablibManager`` object is used to query FABRIC testbed for
+        available resources, create and configure slices, manage SSH
+        keys in nodes in slices and FABRIC's bastion host, etc.  This
+        requires some configuration, which is gathered from:
 
             - constructor parameters (high priority)
 
-            - fabric_rc file (middle priority)
+            - a configuration file (medium priority)
 
             - environment variables (low priority)
 
-            - defaults (if needed and possible)
+            - defaults (if needed, and when possible)
+
+        Typically you would use the configuration file located at
+        ``"${HOME}/work/fabric_config/fabric_rc"``, and/or environment
+        variables.
 
         :param fabric_rc: Path to fablib configuration file.  Defaults
             to ``"${HOME}/work/fabric_config/fabric_rc"``.

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -66,6 +66,10 @@ from fabrictestbed_extensions.fablib.slice import Slice
 
 
 class fablib:
+    """
+    Convenience static methods to work with FABRIC testbed.
+    """
+
     default_fablib_manager = None
 
     @staticmethod

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -47,6 +47,9 @@ instance to interact with FABRIC testbed::
     node = slice.add_node(name="node1")
     slice.submit();
 
+See FABRIC project's Jupyter notebook examples for more complete code
+samples.
+
 .. note::
 
     Some configuration in the form of a configuration file, environment variables, or :class:`FablibManager` constructor parameters is required for the library to work.  Please see the FABRIC project's `documentation on getting started <learn>`_.

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -52,7 +52,10 @@ complete code samples.
 
 .. note::
 
-    Some configuration in the form of a configuration file, environment variables, or :class:`FablibManager` constructor parameters is required for the library to work.  Please see the FABRIC project's `documentation on getting started <learn>`_.
+    Some configuration in the form of a configuration file, environment
+    variables, or :class:`FablibManager` constructor parameters is
+    required for the library to work.  Please see the FABRIC project's
+    `documentation on getting started <learn>`_.
 
 .. _learn: https://learn.fabric-testbed.net/article-categories/getting-started/
 .. _examples: https://github.com/fabric-testbed/jupyter-examples/

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -47,14 +47,15 @@ instance to interact with FABRIC testbed::
     node = slice.add_node(name="node1")
     slice.submit();
 
-See FABRIC project's Jupyter notebook examples for more complete code
-samples.
+See FABRIC project's `Jupyter notebook examples <examples>`_ for more
+complete code samples.
 
 .. note::
 
     Some configuration in the form of a configuration file, environment variables, or :class:`FablibManager` constructor parameters is required for the library to work.  Please see the FABRIC project's `documentation on getting started <learn>`_.
 
 .. _learn: https://learn.fabric-testbed.net/article-categories/getting-started/
+.. _examples: https://github.com/fabric-testbed/jupyter-examples/
 """
 
 from __future__ import annotations

--- a/fabrictestbed_extensions/fablib/facility_port.py
+++ b/fabrictestbed_extensions/fablib/facility_port.py
@@ -52,13 +52,11 @@ class FacilityPort:
 
     def __init__(self, slice: Slice, fim_interface: FimInterface):
         """
-        Sets the fablib slice and FIM node based on arguments.
-
         :param slice: the fablib slice to have this node on
         :type slice: Slice
 
-        :param node: the FIM node that this Node represents
-        :type node: Node
+        :param fim_interface:
+        :type fim_interface: FimInterface
         """
         super().__init__()
         self.fim_interface = fim_interface

--- a/fabrictestbed_extensions/fablib/facility_port.py
+++ b/fabrictestbed_extensions/fablib/facility_port.py
@@ -22,6 +22,13 @@
 # SOFTWARE.
 #
 # Author: Paul Ruth (pruth@renci.org)
+
+"""
+This module contains methods to work with FABRIC `facility ports`_.
+
+.. _`facility ports`: https://learn.fabric-testbed.net/knowledge-base/glossary/#facility_port
+"""
+
 from __future__ import annotations
 
 import json

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -59,11 +59,15 @@ class Interface:
 
     def __init__(self, component: Component = None, fim_interface: FimInterface = None):
         """
-        Constructor. Sets keyword arguments as instance fields.
+        .. note::
+
+            Objects of this class are not created directly.
 
         :param component: the component to set on this interface
         :type component: Component
-        :param fim_interface: the FABRIC information model interface to set on this fablib interface
+
+        :param fim_interface: the FABRIC information model interface
+            to set on this fablib interface
         :type fim_interface: FimInterface
         """
         super().__init__()

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -22,6 +22,11 @@
 # SOFTWARE.
 #
 # Author: Paul Ruth (pruth@renci.org)
+
+"""
+Methods to work with FABRIC network interfaces.
+"""
+
 from __future__ import annotations
 
 import ipaddress

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -22,6 +22,13 @@
 # SOFTWARE.
 #
 # Author: Paul Ruth (pruth@renci.org)
+
+"""
+This module contains methods to work with FABRIC `network services`_.
+
+.. _`network services`: https://learn.fabric-testbed.net/knowledge-base/glossary/#network_service
+"""
+
 from __future__ import annotations
 
 import logging

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -573,14 +573,16 @@ class NetworkService:
         self, slice: Slice = None, fim_network_service: FimNetworkService = None
     ):
         """
-        Not inteded for API use.
+        .. note::
 
-        Constructor. Sets the fablib slice and the FABRIC network service.
+            Not inteded for API use.
 
         :param slice: the fablib slice to set as instance state
         :type slice: Slice
-        :param fim_network_service: the FIM network service to set as instance state
-        :type fim_network_service: FIMNetworkService
+
+        :param fim_network_service: the FIM network service to set as
+            instance state
+        :type fim_network_service: FimNetworkService
         """
         super().__init__()
         self.fim_network_service = fim_network_service

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -24,7 +24,7 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-This module contains methods to work with FABRIC `network services`_.
+Methods to work with FABRIC `network services`_.
 
 .. _`network services`: https://learn.fabric-testbed.net/knowledge-base/glossary/#network_service
 """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -22,6 +22,15 @@
 # SOFTWARE.
 #
 # Author: Paul Ruth (pruth@renci.org)
+
+"""
+Methods to manage FABRIC nodes.
+
+A FABRIC node is an individual element (e.g., virtual machine) in a
+topology that is connected to other nodes to represent the physical
+and logical structure of a network.
+"""
+
 from __future__ import annotations
 
 import concurrent.futures

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -24,14 +24,11 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-This module contains methods to work with FABRIC nodes.
+Methods to work with FABRIC `nodes`_.
 
-A FABRIC node is an individual element (e.g., virtual machine) in a
-topology that is connected to other nodes to represent the physical
-and logical structure of a network.
+.. _`nodes`: https://learn.fabric-testbed.net/knowledge-base/glossary/#node
 
-Once you create a FABRIC slice, you would add a node and operate on it
-like so::
+You would add a node and operate on it like so::
 
     from fabrictestbed_extensions.fablib.fablib import FablibManager
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -24,11 +24,26 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-Methods to manage FABRIC nodes.
+This module contains methods to work with FABRIC nodes.
 
 A FABRIC node is an individual element (e.g., virtual machine) in a
 topology that is connected to other nodes to represent the physical
 and logical structure of a network.
+
+Once you create a FABRIC slice, you would add a node and operate on it
+like so::
+
+    from fabrictestbed_extensions.fablib.fablib import FablibManager
+
+    fablib = FablibManager()
+
+    slice = fablib.new_slice(name="MySlice")
+    node = slice.add_node(name="node1")
+    slice.submit();
+
+    node.execute('echo Hello, FABRIC from node `hostname -s`')
+
+    slice.delete()
 """
 
 from __future__ import annotations

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -76,7 +76,7 @@ class Node:
 
     def __init__(self, slice: Slice, node: FimNode):
         """
-        Sets the fablib slice and FIM node based on arguments.
+        Node constructor, usually invoked by ``Slice.add_node()``.
 
         :param slice: the fablib slice to have this node on
         :type slice: Slice

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -24,7 +24,7 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-This module contains methods to work with FABRIC `resources`_.
+Methods to work with FABRIC `resources`_.
 
 .. _`resources`: https://learn.fabric-testbed.net/knowledge-base/glossary/#resource
 """

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -91,8 +91,12 @@ class Resources:
 
     def __init__(self, fablib_manager, force_refresh: bool = False):
         """
-        Constructor
-        :return:
+        :param fablib_manager: a :class:`FablibManager` instance.
+        :type fablib_manager: fablib.FablibManager
+
+        :param force_refresh: force a refresh of available testbed
+            resources.
+        :type force_refresh: bool
         """
         super().__init__()
 

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -22,6 +22,16 @@
 # SOFTWARE.
 #
 # Author: Paul Ruth (pruth@renci.org)
+
+"""
+This module contains methods to work with FABRIC resources.
+
+A FABRIC resource is a physical or virtual entity that can be
+provisioned by the Control Framework for use in an experiment (i.e.,
+experimental resources) or for collecting measurements about
+experiments (i.e., measurement resources).
+"""
+
 from __future__ import annotations
 
 import json

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -24,12 +24,9 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-This module contains methods to work with FABRIC resources.
+This module contains methods to work with FABRIC `resources`_.
 
-A FABRIC resource is a physical or virtual entity that can be
-provisioned by the Control Framework for use in an experiment (i.e.,
-experimental resources) or for collecting measurements about
-experiments (i.e., measurement resources).
+.. _`resources`: https://learn.fabric-testbed.net/knowledge-base/glossary/#resource
 """
 
 from __future__ import annotations

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -24,11 +24,9 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-The ``slice`` module provides methods to manage FABRIC slices.
+Methods to manage FABRIC `slices`_.
 
-In FABRIC terminology, a "slice" is a logically related collection of
-resources (nodes, networks, services, etc.) that you create when
-running an experiment.
+.. _`slices`: https://learn.fabric-testbed.net/knowledge-base/glossary/#slice
 
 You would create and use a slice like so::
 

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -26,8 +26,29 @@
 """
 The ``slice`` module provides methods to manage FABRIC slices.
 
-In FABRIC testbed terminology, a "slice" is related collection of
-nodes, links, and other components that a project creates.
+In FABRIC terminology, a "slice" is a logically related collection of
+resources (nodes, networks, services, etc.) that you create when
+running an experiment.
+
+You would create and use a slice like so::
+
+    from ipaddress import IPv4Address
+    from fabrictestbed_extensions.fablib.fablib import FablibManager
+
+    fablib = FablibManager()
+
+    # Create a slice and add resources to it, creating a topology.
+    slice = fablib.new_slice(name="MySlice")
+    node1 = slice.add_node(name="node1", site="TACC")
+    net1 = slice.add_l2network(name="net1", subnet=IPv4Network("192.168.1.0/24"))
+
+    # Do more setup, and then run your experiment.
+
+    # Delete the slice after you are done.
+    slice.delete()
+
+See FABRIC project's Jupyter notebook examples for more complete code
+samples.
 """
 
 from __future__ import annotations

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -22,6 +22,11 @@
 # SOFTWARE.
 #
 # Author: Paul Ruth (pruth@renci.org)
+
+"""
+TODO: do we have a good definition of a "slice"?
+"""
+
 from __future__ import annotations
 
 import ipaddress

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -47,8 +47,6 @@ You would create and use a slice like so::
     # Delete the slice after you are done.
     slice.delete()
 
-See FABRIC project's Jupyter notebook examples for more complete code
-samples.
 """
 
 from __future__ import annotations

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -24,7 +24,10 @@
 # Author: Paul Ruth (pruth@renci.org)
 
 """
-TODO: do we have a good definition of a "slice"?
+The ``slice`` module provides methods to manage FABRIC slices.
+
+In FABRIC testbed terminology, a "slice" is related collection of
+nodes, links, and other components that a project creates.
 """
 
 from __future__ import annotations

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -92,7 +92,7 @@ from fabrictestbed_extensions.fablib.node import Node
 class Slice:
     def __init__(self, fablib_manager: FablibManager, name: str = None):
         """
-        Constructor. Sets the default slice state to be callable.
+        Create a FABRIC slice, and set its state to be callable.
 
         :param name: the name of this fablib slice
         :type name: str


### PR DESCRIPTION
Resolves #235 partly. Changes: 

- Adds module docstrings, with links to FABRIC glossary where it makes sense.
- Avoids duplicating constructor docstrings as class docstrings.  (Sphinx allows a choice between "init", "class", or "both", and I chose "class", because I thought the docs generated that way looked nicer.)

Please see the PR build to see the rendered version: https://fabric-fablib--256.org.readthedocs.build/en/256/index.html