### PR TITLE
Remove methods to get private bastion addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [#243](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/243),
   PR [#251](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/251))
 
+### Removed
+
+- Removed APIs to get private bastion addresses (Issue
+  [#257](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/257))
+
 
 ## [1.5.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed APIs to get private bastion addresses (Issue
-  [#257](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/257))
+  [#257](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/257),
+  PR [#259](https://github.com/fabric-testbed/fabrictestbed-extensions/pull/259))
 
 
 ## [1.5.5]

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -335,28 +335,6 @@ class fablib:
         return fablib.get_default_fablib_manager().get_bastion_public_addr()
 
     @staticmethod
-    def get_bastion_private_ipv4_addr() -> str:
-        """
-        Gets the FABRIC Bastion private IPv4 host address. This is the
-        internally faceing IPv4 address needed to use paramiko
-
-        :return: Bastion private IPv4 address
-        :rtype: String
-        """
-        return fablib.get_default_fablib_manager().get_bastion_private_ipv4_addr()
-
-    @staticmethod
-    def get_bastion_private_ipv6_addr() -> str:
-        """
-        Gets the FABRIC Bastion private IPv6 host address. This is the
-        internally faceing IPv4 address needed to use paramiko
-
-        :return: Bastion private IPv6 address
-        :rtype: String
-        """
-        return fablib.get_default_fablib_manager().get_bastion_private_ipv6_addr()
-
-    @staticmethod
     def get_slice_manager() -> SliceManager:
         """
         Not intended as API call
@@ -528,8 +506,6 @@ class FablibManager:
     FABRIC_BASTION_KEY_LOCATION = "FABRIC_BASTION_KEY_LOCATION"
     FABRIC_BASTION_HOST = "FABRIC_BASTION_HOST"
     FABRIC_BASTION_KEY_PASSWORD = "FABRIC_BASTION_KEY_PASSWORD"
-    FABRIC_BASTION_HOST_PRIVATE_IPV4 = "FABRIC_BASTION_HOST_PRIVATE_IPV4"
-    FABRIC_BASTION_HOST_PRIVATE_IPV6 = "FABRIC_BASTION_HOST_PRIVATE_IPV6"
     FABRIC_SLICE_PUBLIC_KEY_FILE = "FABRIC_SLICE_PUBLIC_KEY_FILE"
     FABRIC_SLICE_PRIVATE_KEY_FILE = "FABRIC_SLICE_PRIVATE_KEY_FILE"
     FABRIC_SLICE_PRIVATE_KEY_PASSPHRASE = "FABRIC_SLICE_PRIVATE_KEY_PASSPHRASE"
@@ -659,11 +635,6 @@ class FablibManager:
         self.bastion_key_filename = os.environ.get(self.FABRIC_BASTION_KEY_LOCATION)
         self.bastion_public_addr = os.environ.get(self.FABRIC_BASTION_HOST)
 
-        # if self.FABRIC_BASTION_HOST_PRIVATE_IPV4 in os.environ:
-        #    self.bastion_private_ipv4_addr = os.environ[self.FABRIC_BASTION_HOST_PRIVATE_IPV4]
-        # if self.FABRIC_BASTION_HOST_PRIVATE_IPV6 in os.environ:
-        #    self.bastion_private_ipv6_addr = os.environ[self.FABRIC_BASTION_HOST_PRIVATE_IPV6]
-
         # Slice Keys
         if self.FABRIC_SLICE_PUBLIC_KEY_FILE in os.environ:
             self.default_slice_key["slice_public_key_file"] = os.environ[
@@ -780,9 +751,6 @@ class FablibManager:
         #    logging.basicConfig(filename=self.log_file, level=self.LOG_LEVELS[self.log_level],
         #                        format='[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s',
         #                        datefmt='%H:%M:%S')
-
-        self.bastion_private_ipv4_addr = "0.0.0.0"
-        self.bastion_private_ipv6_addr = "0:0:0:0:0:0"
 
         self._validate_configuration()
 
@@ -1630,26 +1598,6 @@ class FablibManager:
         :rtype: String
         """
         return self.bastion_public_addr
-
-    def get_bastion_private_ipv4_addr(self) -> str:
-        """
-        Gets the FABRIC Bastion private IPv4 host address. This is the
-        internally faceing IPv4 address needed to use paramiko
-
-        :return: Bastion private IPv4 address
-        :rtype: String
-        """
-        return self.bastion_private_ipv4_addr
-
-    def get_bastion_private_ipv6_addr(self) -> str:
-        """
-        Gets the FABRIC Bastion private IPv6 host address. This is the
-        internally faceing IPv4 address needed to use paramiko
-
-        :return: Bastion private IPv6 address
-        :rtype: String
-        """
-        return self.bastion_private_ipv6_addr
 
     def probe_bastion_host(self) -> bool:
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1354,11 +1354,9 @@ class Node:
         # Get and test src and management_ips
         management_ip = str(self.get_fim_node().get_property(pname="management_ip"))
         if self.validIPAddress(management_ip) == "IPv4":
-            # src_addr = (self.get_fablib_manager().get_bastion_private_ipv4_addr(), 22)
             src_addr = ("0.0.0.0", 22)
 
         elif self.validIPAddress(management_ip) == "IPv6":
-            # src_addr = (self.get_fablib_manager().get_bastion_private_ipv6_addr(), 22)
             src_addr = ("0:0:0:0:0:0:0:0", 22)
         else:
             logging.error("node.execute: Management IP Invalid:", exc_info=True)


### PR DESCRIPTION
Resolves #257.

It appears that private bastion IPv4/IPv6 addresses are only used in the (oudated?) ["native api" example notebooks](https://github.com/fabric-testbed/jupyter-examples/tree/main/fabric_examples/native_api). and `get_bastion_private_ipv4_addr()` and `get_bastion_private_ipv6_addr()` are not used in any of the example notebooks.