### PR TITLE
Run commit signing checks on pull_request_target

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read
@@ -25,7 +25,11 @@ jobs:
           fetch-depth: 0 # since we need to diff against origin/main.
 
       # https://github.com/marketplace/actions/check-signed-commits-in-pr
+      # runs on pull_request_target and pull_request events, but
+      # pull_request_target is preferred because of the ability to
+      # leave comments on external PRs created from forks.
       - name: Check that commits are signed
+        if: github.event_name == 'pull_request_target'
         uses: 1Password/check-signed-commits-action@v1
 
       - name: Set up Python 3.9
@@ -50,7 +54,7 @@ jobs:
 
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no changelog')
+        if: github.event_name == 'pull_request_target' && !contains(github.event.pull_request_target.labels.*.name, 'no changelog')
         run: |
           # `git diff --exit-code` exits with 1 if there were
           # differences and 0 means no differences. Here we negate

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - "main"
+  pull_request:
   pull_request_target:
 
 permissions:
@@ -29,7 +30,7 @@ jobs:
       # pull_request_target is preferred because of the ability to
       # leave comments on external PRs created from forks.
       - name: Check that commits are signed
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
         uses: 1Password/check-signed-commits-action@v1
 
       - name: Set up Python 3.9
@@ -54,7 +55,7 @@ jobs:
 
       # Remind PR authors to update CHANGELOG.md
       - name: Check that Changelog has been updated
-        if: github.event_name == 'pull_request_target' && !contains(github.event.pull_request_target.labels.*.name, 'no changelog')
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no changelog')
         run: |
           # `git diff --exit-code` exits with 1 if there were
           # differences and 0 means no differences. Here we negate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+
+## [1.6.0] - 2024-01-03
+
 ### Fixed
 
 - Fix an error in `Node.list_networks()` (Issue


### PR DESCRIPTION
1Password/check-signed-commits-action@v1 is designed to be used with `pull_request_target` or `pull_request` events, with the former preferred.  It fails on `push` events, such as when a PR is merged.  Here's an example of such a failure:

https://github.com/fabric-testbed/fabrictestbed-extensions/actions/runs/7400337712/job/20133749344

Also sneaks in a changelog sub-title change because of the recent release. :-)