### PR TITLE
minor fixes for adding/removing interfaces from network service

### DIFF
--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -988,9 +988,13 @@ class NetworkService:
             self.interfaces = []
             for interface in self.get_fim_network_service().interface_list:
                 logging.debug(f"interface: {interface}")
-                self.interfaces.append(
-                    self.get_slice().get_interface(name=interface.name)
-                )
+
+                try:
+                    self.interfaces.append(
+                        self.get_slice().get_interface(name=interface.name)
+                    )
+                except:
+                    logging.warning(f"interface not found: {interface.name}")
 
         return self.interfaces
 
@@ -1189,6 +1193,9 @@ class NetworkService:
         allocated_ips_strs = []
         for ip in allocated_ips:
             allocated_ips_strs.append(str(ip))
+
+        if "subnet" not in fablib_data:
+            fablib_data["subnet"] = {}
 
         fablib_data["subnet"]["allocated_ips"] = allocated_ips_strs
         self.set_fablib_data(fablib_data)


### PR DESCRIPTION
- catch exception in add_interface when interface is not in slice. This happens with a facility port
- avoid key error by first checking for key subnets before update fablib_data
- Tested by creating a slice with a single node, a network service and a facility port. Then I modified the slice by adding/removing a node