### PR TITLE
Validate slice against available resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 ### Fixed
+- Error *may* be inaccurate or wrong when I issue an invalid configuration. (Issue [#304](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/304))
 - Add Facility Port to allow adding multiple interfaces (Issue [#289](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/289))
 - validate_config errors out when config directory does not exist (Issue [#299](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/299)
 - create_ssh_config adds extra indentation (Issue [#300](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/300)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 ### Fixed
+- Add display of switch port name to network service table listing (Issue [#152](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/152))
 - Error *may* be inaccurate or wrong when I issue an invalid configuration. (Issue [#304](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/304))
 - Add Facility Port to allow adding multiple interfaces (Issue [#289](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/289))
 - validate_config errors out when config directory does not exist (Issue [#299](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/299)

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -669,8 +669,9 @@ class Component:
             return {}
 
     def delete(self):
-        for interface in self.get_interfaces():
-            interface.delete()
+        if self.get_interfaces():
+            for interface in self.get_interfaces():
+                interface.delete()
 
         self.get_slice().get_fim_topology().nodes[
             self.get_node().get_name()

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2254,11 +2254,15 @@ Host * !bastion.fabric-testbed.net
     def validate(self, node: Node) -> bool:
         site = self.get_resources().get_topology_site(site_name=node.get_name())
         workers = self.get_resources().get_nodes(site=site)
+        if not workers:
+            logging.warning(f"Can't do Node validation, worker information not available for {site}")
+            return False
         allocated_comps_per_worker = {}
 
         if node.get_host():
             if node.get_host() not in workers:
                 print(f"Requested Host {node.get_host()} does not exist on site: {node.get_site()}")
+                return False
             worker = workers.get(node.get_host())
             allocated_comps = allocated_comps_per_worker.setdefault(worker.name, {})
             return self.__can_allocate_node_in_worker(worker=worker, node=node, allocated_comps=allocated_comps)

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2230,8 +2230,8 @@ Host * !bastion.fabric-testbed.net
         """
         msg = f"Node can be allocated on the worker: {worker.name}"
         allocated_core = allocated.setdefault('core', 0)
-        allocated_ram = allocated.setdefault('core', 0)
-        allocated_disk = allocated.setdefault('core', 0)
+        allocated_ram = allocated.setdefault('ram', 0)
+        allocated_disk = allocated.setdefault('disk', 0)
         available_cores = worker.capacities.core - (worker.capacity_allocations.core
                                                     if worker.capacity_allocations is not None else 0) - allocated_core
         available_ram = worker.capacities.ram - (worker.capacity_allocations.ram

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2230,6 +2230,8 @@ Host * !bastion.fabric-testbed.net
         :return: Tuple indicating status for validation and error message in case of failure
         :rtype: Tuple[bool, str]
         """
+        if not worker or not site or not allocated:
+            return False, f"Worker: {worker}, Site: {site}, allocated: {allocated} not available."
         msg = f"Node can be allocated on the host: {worker.name}."
 
         worker_maint_info = site.maintenance_info.get(worker.name)
@@ -2316,6 +2318,8 @@ Host * !bastion.fabric-testbed.net
         if allocated is None:
             allocated = {}
         site = self.get_resources().get_topology_site(site_name=node.get_site())
+        if not site:
+            return False, f"Site: {node.get_site()} not available in resources."
         site_maint_info = site.maintenance_info.get(site.name)
         if site_maint_info and str(site_maint_info.state) != "Active":
             msg = f"Node cannot be allocated on {node.get_site()}, {node.get_site()} is in {site_maint_info.state}."
@@ -2334,7 +2338,7 @@ Host * !bastion.fabric-testbed.net
 
             worker = workers.get(node.get_host())
 
-            allocated_comps = allocated.setdefault(worker.name, {})
+            allocated_comps = allocated.setdefault(node.get_host(), {})
             status, error = self.__can_allocate_node_in_worker(
                 worker=worker, node=node, allocated=allocated_comps, site=site
             )

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2242,14 +2242,14 @@ Host * !bastion.fabric-testbed.net
         if (node.get_requested_cores() > available_cores or
                 node.get_requested_disk() > available_disk or
                 node.get_requested_ram() > available_ram):
-            msg = f"Insufficient Resources: Worker: {worker} does not meet core/ram/disk requirements!"
+            msg = f"Insufficient Resources: Worker: {worker.name} does not meet core/ram/disk requirements!"
             return False, msg
 
         # Check if there are enough components available
         for c in node.get_components():
             comp_model_type = f"{c.get_type()}-{c.get_fim_model()}"
             if comp_model_type not in worker.components:
-                msg = f"Invalid Request: Worker: {worker} does not have the requested component: {comp_model_type}"
+                msg = f"Invalid Request: Worker: {worker.name} does not have the requested component: {comp_model_type}"
                 return False, msg
 
             allocated_comp_count = allocated.setdefault(comp_model_type, 0)
@@ -2258,7 +2258,7 @@ Host * !bastion.fabric-testbed.net
                                 if worker.components[comp_model_type].capacity_allocations else 0) -
                                allocated_comp_count)
             if available_comps <= 0:
-                msg = f"Insufficient Resources: Worker: {worker} has reached the limit for component: {comp_model_type}"
+                msg = f"Insufficient Resources: Worker: {worker.name} has reached the limit for component: {comp_model_type}"
                 return False, msg
 
             allocated[comp_model_type] += 1
@@ -2301,6 +2301,7 @@ Host * !bastion.fabric-testbed.net
                                                                allocated=allocated_comps)
             if status:
                 return status, error
-        msg = f"Invalid Request: Requested Node cannot be allocated with combination of components " \
-              f"on any of the workers on site: {site.name}"
+        msg = f"Invalid Request: Requested Node cannot accomodated by any of the workers on site: {site.name}."
+        if error:
+            msg += f" Last Error: {error}"
         return False, msg

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2222,9 +2222,9 @@ Host * !bastion.fabric-testbed.net
 
     @staticmethod
     def __can_allocate_node_in_worker(worker: FimNode, node: Node, allocated_comps: dict):
-        available_cores = worker.capacities.cores - worker.capacity_allocations.cores
-        available_ram = worker.capacities.ram - worker.capacity_allocations.ram
-        available_disk = worker.capacities.disk - worker.capacity_allocations.disk
+        available_cores = worker.capacities.core - worker.capacity_allocations.core if worker.capacity_allocations is not None else 0
+        available_ram = worker.capacities.ram - worker.capacity_allocations.ram if worker.capacity_allocations is not None else 0
+        available_disk = worker.capacities.disk - worker.capacity_allocations.disk if worker.capacity_allocations is not None else 0
 
         if (node.get_cores() > available_cores or
                 node.get_disk() > available_disk or
@@ -2252,7 +2252,7 @@ Host * !bastion.fabric-testbed.net
         return True
 
     def validate(self, node: Node) -> bool:
-        site = self.get_resources().get_topology_site(site_name=node.get_name())
+        site = self.get_resources().get_topology_site(site_name=node.get_site())
         workers = self.get_resources().get_nodes(site=site)
         if not workers:
             print(f"Can't do Node validation, worker information not available for {site}")

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2238,7 +2238,7 @@ Host * !bastion.fabric-testbed.net
 
         # Check if there are enough components available
         for c in node.get_components():
-            comp_model = c.get_model()
+            comp_model = c.get_fim_model()
             if comp_model not in worker.components:
                 msg = f"Worker: {worker} does not have the requested component: {comp_model}"
                 return False, msg
@@ -2281,5 +2281,5 @@ Host * !bastion.fabric-testbed.net
                                                                allocated_comps=allocated_comps)
             if status:
                 return status, msg
-        msg = f"Node can not be allocated on any worker on site: {site}"
+        msg = f"Node can not be allocated on any worker on site: {site.name}"
         return False, msg

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2226,9 +2226,9 @@ Host * !bastion.fabric-testbed.net
         available_ram = worker.capacities.ram - worker.capacity_allocations.ram if worker.capacity_allocations is not None else 0
         available_disk = worker.capacities.disk - worker.capacity_allocations.disk if worker.capacity_allocations is not None else 0
 
-        if (node.get_cores() > available_cores or
-                node.get_disk() > available_disk or
-                node.get_ram() > available_ram):
+        if (node.get_requested_cores() > available_cores or
+                node.get_requested_disk() > available_disk or
+                node.get_requested_ram() > available_ram):
             print(f"Worker: {worker} does not meet core/ram/disk requirements!")
             return False
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2222,6 +2222,12 @@ Host * !bastion.fabric-testbed.net
 
     @staticmethod
     def __can_allocate_node_in_worker(worker: FimNode, node: Node, allocated: dict) -> Tuple[bool, str]:
+        """
+        Check if a node can be provisioned on a worker node on a site w.r.t available resources on that site
+
+        :return: Tuple indicating status for validation and error message in case of failure
+        :rtype: Tuple[bool, str]
+        """
         msg = f"Node can be allocated on the worker: {worker.name}"
         allocated_core = allocated.setdefault('core', 0)
         allocated_ram = allocated.setdefault('core', 0)
@@ -2264,6 +2270,12 @@ Host * !bastion.fabric-testbed.net
         return True, msg
 
     def validate_node(self, node: Node, allocated: dict = None) -> Tuple[bool, str]:
+        """
+        Validate a node w.r.t available resources on a site before submission
+
+        :return: Tuple indicating status for validation and error message in case of failure
+        :rtype: Tuple[bool, str]
+        """
         if allocated is None:
             allocated = {}
         site = self.get_resources().get_topology_site(site_name=node.get_site())

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2230,8 +2230,8 @@ Host * !bastion.fabric-testbed.net
         :return: Tuple indicating status for validation and error message in case of failure
         :rtype: Tuple[bool, str]
         """
-        if not worker or not site or not allocated:
-            return False, f"Worker: {worker}, Site: {site}, allocated: {allocated} not available."
+        if worker is None or site is None:
+            return False, f"Worker: {worker}, Site: {site} not available."
         msg = f"Node can be allocated on the host: {worker.name}."
 
         worker_maint_info = site.maintenance_info.get(worker.name)

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2245,7 +2245,8 @@ Host * !bastion.fabric-testbed.net
 
             allocated_comp_count = allocated_comps.setdefault(comp_model_type, 0)
             available_comps = (worker.components[comp_model_type].capacities.unit -
-                               worker.components[comp_model_type].capacity_allocations.unit -
+                               (worker.components[comp_model_type].capacity_allocations.unit
+                                if worker.components[comp_model_type].capacity_allocations else 0) -
                                allocated_comp_count)
             if available_comps <= 0:
                 msg = f"Worker: {worker} has reached the limit for component: {comp_model_type}"

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2222,9 +2222,9 @@ Host * !bastion.fabric-testbed.net
 
     @staticmethod
     def __can_allocate_node_in_worker(worker: FimNode, node: Node, allocated_comps: dict):
-        available_cores = worker.capacities.core - worker.capacity_allocations.core if worker.capacity_allocations is not None else 0
-        available_ram = worker.capacities.ram - worker.capacity_allocations.ram if worker.capacity_allocations is not None else 0
-        available_disk = worker.capacities.disk - worker.capacity_allocations.disk if worker.capacity_allocations is not None else 0
+        available_cores = worker.capacities.core - (worker.capacity_allocations.core if worker.capacity_allocations is not None else 0)
+        available_ram = worker.capacities.ram - (worker.capacity_allocations.ram if worker.capacity_allocations is not None else 0)
+        available_disk = worker.capacities.disk - (worker.capacity_allocations.disk if worker.capacity_allocations is not None else 0)
 
         if (node.get_requested_cores() > available_cores or
                 node.get_requested_disk() > available_disk or

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2276,6 +2276,7 @@ Host * !bastion.fabric-testbed.net
         :return: Tuple indicating status for validation and error message in case of failure
         :rtype: Tuple[bool, str]
         """
+        error = None
         if allocated is None:
             allocated = {}
         site = self.get_resources().get_topology_site(site_name=node.get_site())
@@ -2301,7 +2302,7 @@ Host * !bastion.fabric-testbed.net
                                                                allocated=allocated_comps)
             if status:
                 return status, error
-        msg = f"Invalid Request: Requested Node cannot accomodated by any of the workers on site: {site.name}."
+        msg = f"Invalid Request: Requested Node cannot be accommodated by any of the workers on site: {site.name}."
         if error:
-            msg += f" Last Error: {error}"
+            msg += f" Details: {error}"
         return False, msg

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2233,7 +2233,7 @@ Host * !bastion.fabric-testbed.net
         msg = f"Node can be allocated on the host: {worker.name}."
 
         worker_maint_info = site.maintenance_info.get(worker.name)
-        if worker_maint_info and worker_maint_info.state != "Active":
+        if worker_maint_info and str(worker_maint_info.state) != "Active":
             msg = f"Node cannot be allocated on {worker.name}, {worker.name} is in {worker_maint_info.state}!"
             return False, msg
 
@@ -2317,7 +2317,7 @@ Host * !bastion.fabric-testbed.net
             allocated = {}
         site = self.get_resources().get_topology_site(site_name=node.get_site())
         site_maint_info = site.maintenance_info.get(site.name)
-        if site_maint_info and site_maint_info.state != "Active":
+        if site_maint_info and str(site_maint_info.state) != "Active":
             msg = f"Node cannot be allocated on {node.get_site()}, {node.get_site()} is in {site_maint_info.state}."
             return False, msg
         workers = self.get_resources().get_nodes(site=site)

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2255,7 +2255,7 @@ Host * !bastion.fabric-testbed.net
         site = self.get_resources().get_topology_site(site_name=node.get_name())
         workers = self.get_resources().get_nodes(site=site)
         if not workers:
-            logging.warning(f"Can't do Node validation, worker information not available for {site}")
+            print(f"Can't do Node validation, worker information not available for {site}")
             return False
         allocated_comps_per_worker = {}
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2238,20 +2238,20 @@ Host * !bastion.fabric-testbed.net
 
         # Check if there are enough components available
         for c in node.get_components():
-            comp_model = c.get_fim_model()
-            if comp_model not in worker.components:
-                msg = f"Worker: {worker} does not have the requested component: {comp_model}"
+            comp_model_type = f"{c.get_type()}-{c.get_fim_model()}"
+            if comp_model_type not in worker.components:
+                msg = f"Worker: {worker} does not have the requested component: {comp_model_type}"
                 return False, msg
 
-            allocated_comp_count = allocated_comps.setdefault(comp_model, 0)
-            available_comps = (worker.components[comp_model].capacities.unit -
-                               worker.components[comp_model].capacity_allocations.unit -
+            allocated_comp_count = allocated_comps.setdefault(comp_model_type, 0)
+            available_comps = (worker.components[comp_model_type].capacities.unit -
+                               worker.components[comp_model_type].capacity_allocations.unit -
                                allocated_comp_count)
             if available_comps <= 0:
-                msg = f"Worker: {worker} has reached the limit for component: {comp_model}"
+                msg = f"Worker: {worker} has reached the limit for component: {comp_model_type}"
                 return False, msg
 
-            allocated_comps[comp_model] += 1
+            allocated_comps[comp_model_type] += 1
 
         return True, msg
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2234,7 +2234,7 @@ Host * !bastion.fabric-testbed.net
 
         worker_maint_info = site.maintenance_info.get(worker.name)
         if worker_maint_info and worker_maint_info.state != "Active":
-            msg = f"Node cannot be allocated on {worker.name}, {worker.name} is in {worker_maint_info.state}."
+            msg = f"Node cannot be allocated on {worker.name}, {worker.name} is in {worker_maint_info.state}!"
             return False, msg
 
         allocated_core = allocated.setdefault("core", 0)

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2221,7 +2221,9 @@ Host * !bastion.fabric-testbed.net
         return table
 
     @staticmethod
-    def __can_allocate_node_in_worker(worker: FimNode, node: Node, allocated: dict) -> Tuple[bool, str]:
+    def __can_allocate_node_in_worker(
+        worker: FimNode, node: Node, allocated: dict
+    ) -> Tuple[bool, str]:
         """
         Check if a node can be provisioned on a worker node on a site w.r.t available resources on that site
 
@@ -2229,19 +2231,42 @@ Host * !bastion.fabric-testbed.net
         :rtype: Tuple[bool, str]
         """
         msg = f"Node can be allocated on the worker: {worker.name}"
-        allocated_core = allocated.setdefault('core', 0)
-        allocated_ram = allocated.setdefault('ram', 0)
-        allocated_disk = allocated.setdefault('disk', 0)
-        available_cores = worker.capacities.core - (worker.capacity_allocations.core
-                                                    if worker.capacity_allocations is not None else 0) - allocated_core
-        available_ram = worker.capacities.ram - (worker.capacity_allocations.ram
-                                                 if worker.capacity_allocations is not None else 0) - allocated_ram
-        available_disk = worker.capacities.disk - (worker.capacity_allocations.disk
-                                                   if worker.capacity_allocations is not None else 0) - allocated_disk
+        allocated_core = allocated.setdefault("core", 0)
+        allocated_ram = allocated.setdefault("ram", 0)
+        allocated_disk = allocated.setdefault("disk", 0)
+        available_cores = (
+            worker.capacities.core
+            - (
+                worker.capacity_allocations.core
+                if worker.capacity_allocations is not None
+                else 0
+            )
+            - allocated_core
+        )
+        available_ram = (
+            worker.capacities.ram
+            - (
+                worker.capacity_allocations.ram
+                if worker.capacity_allocations is not None
+                else 0
+            )
+            - allocated_ram
+        )
+        available_disk = (
+            worker.capacities.disk
+            - (
+                worker.capacity_allocations.disk
+                if worker.capacity_allocations is not None
+                else 0
+            )
+            - allocated_disk
+        )
 
-        if (node.get_requested_cores() > available_cores or
-                node.get_requested_disk() > available_disk or
-                node.get_requested_ram() > available_ram):
+        if (
+            node.get_requested_cores() > available_cores
+            or node.get_requested_disk() > available_disk
+            or node.get_requested_ram() > available_ram
+        ):
             msg = f"Insufficient Resources: Worker: {worker.name} does not meet core/ram/disk requirements!"
             return False, msg
 
@@ -2253,19 +2278,24 @@ Host * !bastion.fabric-testbed.net
                 return False, msg
 
             allocated_comp_count = allocated.setdefault(comp_model_type, 0)
-            available_comps = (worker.components[comp_model_type].capacities.unit -
-                               (worker.components[comp_model_type].capacity_allocations.unit
-                                if worker.components[comp_model_type].capacity_allocations else 0) -
-                               allocated_comp_count)
+            available_comps = (
+                worker.components[comp_model_type].capacities.unit
+                - (
+                    worker.components[comp_model_type].capacity_allocations.unit
+                    if worker.components[comp_model_type].capacity_allocations
+                    else 0
+                )
+                - allocated_comp_count
+            )
             if available_comps <= 0:
                 msg = f"Insufficient Resources: Worker: {worker.name} has reached the limit for component: {comp_model_type}"
                 return False, msg
 
             allocated[comp_model_type] += 1
 
-        allocated['core'] += node.get_requested_cores()
-        allocated['ram'] += node.get_requested_ram()
-        allocated['disk'] += node.get_requested_disk()
+        allocated["core"] += node.get_requested_cores()
+        allocated["ram"] += node.get_requested_ram()
+        allocated["disk"] += node.get_requested_disk()
 
         return True, msg
 
@@ -2282,7 +2312,9 @@ Host * !bastion.fabric-testbed.net
         site = self.get_resources().get_topology_site(site_name=node.get_site())
         workers = self.get_resources().get_nodes(site=site)
         if not workers:
-            msg = f"Node cannot be validated, worker information not available for {site}"
+            msg = (
+                f"Node cannot be validated, worker information not available for {site}"
+            )
             return False, msg
 
         if node.get_host():
@@ -2291,15 +2323,17 @@ Host * !bastion.fabric-testbed.net
                 return False, msg
             worker = workers.get(node.get_host())
             allocated_comps = allocated.setdefault(worker.name, {})
-            status, error = self.__can_allocate_node_in_worker(worker=worker, node=node,
-                                                               allocated=allocated_comps)
+            status, error = self.__can_allocate_node_in_worker(
+                worker=worker, node=node, allocated=allocated_comps
+            )
             if not status:
                 return status, error
 
         for worker in workers.values():
             allocated_comps = allocated.setdefault(worker.name, {})
-            status, error = self.__can_allocate_node_in_worker(worker=worker, node=node,
-                                                               allocated=allocated_comps)
+            status, error = self.__can_allocate_node_in_worker(
+                worker=worker, node=node, allocated=allocated_comps
+            )
             if status:
                 return status, error
         msg = f"Invalid Request: Requested Node cannot be accommodated by any of the workers on site: {site.name}."

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -935,5 +935,5 @@ class Interface:
 
     def delete(self):
         net = self.get_network()
-
-        net.remove_interface(self)
+        if net:
+            net.remove_interface(self)

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -114,6 +114,7 @@ class Interface:
             ["Device", self.get_os_interface()],
             ["Address", self.get_ip_addr()],
             ["Numa Node", self.get_numa_node()],
+            ["Switch Port", self.get_switch_port()]
         ]
 
         return tabulate(table)
@@ -149,6 +150,7 @@ class Interface:
             "mode": "Mode",
             "ip_addr": "IP Address",
             "numa": "Numa Node",
+            "switch_port": "Switch Port",
         }
 
     def toDict(self, skip=[]):
@@ -200,7 +202,14 @@ class Interface:
             "dev": dev,
             "ip_addr": ip_addr,
             "numa": str(self.get_numa_node()),
+            "switch_port": str(self.get_switch_port())
         }
+
+    def get_switch_port(self) -> str:
+        if self.get_network() and self.get_network().get_fim():
+            ifs = self.get_network().get_fim().interfaces.get(self.get_name())
+            if ifs and ifs.labels and ifs.labels.local_name:
+                return ifs.labels.local_name
 
     def get_numa_node(self) -> str:
         if self.get_component() is not None:

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -544,6 +544,22 @@ class Interface:
 
         return self
 
+    def set_bandwidth(self, bw: int):
+        """
+        Set the Bandwidths on the FABRIC request.
+
+        :param addr: bw
+        :type addr: int
+        """
+        if not bw:
+            return
+
+        if_capacities = self.get_fim_interface().get_property(pname="capacities")
+        if_capacities.bw = int(bw)
+        self.get_fim_interface().set_properties(capacities=if_capacities)
+
+        return self
+
     def get_fim_interface(self) -> FimInterface:
         """
         Not recommended for most users.
@@ -581,6 +597,19 @@ class Interface:
         except:
             vlan = None
         return vlan
+
+    def get_bw(self) -> int:
+        """
+        Gets the FABRIC bandwidth of an interface.
+
+        :return: VLAN
+        :rtype: String
+        """
+        try:
+            bw = self.get_fim_interface().get_property(pname="capacities").bw
+        except:
+            bw = None
+        return bw
 
     def get_reservation_id(self) -> str or None:
         try:

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -206,8 +206,13 @@ class Interface:
         }
 
     def get_switch_port(self) -> str:
-        if self.get_network() and self.get_network().get_fim():
-            ifs = self.get_network().get_fim().interfaces.get(self.get_name())
+        network = self.get_network()
+        if network and network.get_fim():
+            ifs = None
+            for ifs_name in network.get_fim().interfaces.keys():
+                if self.get_name() in ifs_name:
+                    ifs = network.get_fim().interfaces[ifs_name]
+                    break
             if ifs and ifs.labels and ifs.labels.local_name:
                 return ifs.labels.local_name
 

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -598,7 +598,7 @@ class Interface:
             vlan = None
         return vlan
 
-    def get_bw(self) -> int:
+    def get_bandwidth(self) -> int:
         """
         Gets the FABRIC bandwidth of an interface.
 

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -114,7 +114,7 @@ class Interface:
             ["Device", self.get_os_interface()],
             ["Address", self.get_ip_addr()],
             ["Numa Node", self.get_numa_node()],
-            ["Switch Port", self.get_switch_port()]
+            ["Switch Port", self.get_switch_port()],
         ]
 
         return tabulate(table)
@@ -202,7 +202,7 @@ class Interface:
             "dev": dev,
             "ip_addr": ip_addr,
             "numa": str(self.get_numa_node()),
-            "switch_port": str(self.get_switch_port())
+            "switch_port": str(self.get_switch_port()),
         }
 
     def get_switch_port(self) -> str:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -85,7 +85,7 @@ class Node:
     default_image = "default_rocky_8"
 
     def __init__(
-        self, slice: Slice, node: FimNode, check: bool = False, remove: bool = True
+        self, slice: Slice, node: FimNode, validate: bool = False, remove: bool = True
     ):
         """
         Node constructor, usually invoked by ``Slice.add_node()``.
@@ -96,8 +96,8 @@ class Node:
         :param node: the FIM node that this Node represents
         :type node: Node
 
-        :param check: Validate node can be allocated w.r.t available resources
-        :type check: bool
+        :param validate: Validate node can be allocated w.r.t available resources
+        :type validate: bool
 
         :param remove: Remove the node if validation w.r.t available resources fails
         :type remove: bool
@@ -108,7 +108,7 @@ class Node:
         self.slice = slice
         self.host = None
         self.ip_addr_list_json = None
-        self.check = check
+        self.validate = validate
         self.remove = remove
 
         # Try to set the username.
@@ -175,7 +175,7 @@ class Node:
         name: str = None,
         site: str = None,
         avoid: List[str] = [],
-        check: bool = False,
+        validate: bool = False,
         remove: bool = True,
     ):
         """
@@ -196,8 +196,8 @@ class Node:
         :param avoid: a list of node names to avoid
         :type avoid: List[str]
 
-        :param check: Validate node can be allocated w.r.t available resources
-        :type check: bool
+        :param validate: Validate node can be allocated w.r.t available resources
+        :type validate: bool
 
         :param remove: Remove the node if validation w.r.t available resources fails
         :type remove: bool
@@ -214,7 +214,7 @@ class Node:
         node = Node(
             slice,
             slice.topology.add_node(name=name, site=site),
-            check=check,
+            validate=validate,
             remove=remove,
         )
         node.set_capacities(
@@ -1181,7 +1181,7 @@ class Node:
         component = Component.new_component(
             node=self, model=model, name=name, user_data=user_data
         )
-        if self.check:
+        if self.validate:
             status, error = self.get_fablib_manager().validate_node(node=self)
             if not status:
                 if self.remove:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1159,11 +1159,14 @@ class Node:
             node=self, model=model, name=name, user_data=user_data
         )
         if self.check:
-            if self.get_fablib_manager().validate(node=self):
+            status, error = self.get_fablib_manager().validate(node=self)
+            if not status:
                 if self.remove:
-                    component.delete()
+                    print(f"{self.get_name()} removed from the topology with reason: {error}!")
+                    self.delete()
                 else:
-                    raise ValueError("Component cannot be attached")
+                    raise ValueError(f"{self.get_name()} cannot be allocated as requested on site: "
+                                     f"{self.get_site()}, reason: {error}")
         return component
 
     def get_components(self) -> List[Component]:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1186,6 +1186,7 @@ class Node:
             if not status:
                 component.delete()
                 component = None
+                logging.warning(error)
                 if self.raise_exception:
                     raise ValueError(error)
         return component

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -84,7 +84,9 @@ class Node:
     default_disk = 10
     default_image = "default_rocky_8"
 
-    def __init__(self, slice: Slice, node: FimNode, check: bool = False, remove: bool = True):
+    def __init__(
+        self, slice: Slice, node: FimNode, check: bool = False, remove: bool = True
+    ):
         """
         Node constructor, usually invoked by ``Slice.add_node()``.
 
@@ -169,7 +171,12 @@ class Node:
 
     @staticmethod
     def new_node(
-        slice: Slice = None, name: str = None, site: str = None, avoid: List[str] = [], check: bool = False, remove: bool = True
+        slice: Slice = None,
+        name: str = None,
+        site: str = None,
+        avoid: List[str] = [],
+        check: bool = False,
+        remove: bool = True,
     ):
         """
         Not intended for API call.  See: Slice.add_node()
@@ -199,11 +206,20 @@ class Node:
         :rtype: Node
         """
         if site is None:
-            [site] = slice.get_fablib_manager().get_random_sites(avoid=avoid,
-                                                                 filter_function=lambda x: x['cores_available'] > Node.default_cores and x['ram_available'] > Node.default_ram and x['disk_available'] > Node.default_disk)
+            [site] = slice.get_fablib_manager().get_random_sites(
+                avoid=avoid,
+                filter_function=lambda x: x["cores_available"] > Node.default_cores
+                and x["ram_available"] > Node.default_ram
+                and x["disk_available"] > Node.default_disk,
+            )
 
         logging.info(f"Adding node: {name}, slice: {slice.get_name()}, site: {site}")
-        node = Node(slice, slice.topology.add_node(name=name, site=site), check=check, remove=remove)
+        node = Node(
+            slice,
+            slice.topology.add_node(name=name, site=site),
+            check=check,
+            remove=remove,
+        )
         node.set_capacities(
             cores=Node.default_cores, ram=Node.default_ram, disk=Node.default_disk
         )
@@ -927,7 +943,9 @@ class Node:
         try:
             if self.host is not None:
                 return self.host
-            label_allocations = self.get_fim_node().get_property(pname="label_allocations")
+            label_allocations = self.get_fim_node().get_property(
+                pname="label_allocations"
+            )
             labels = self.get_fim_node().get_property(pname="labels")
             if label_allocations:
                 return label_allocations.instance_parent
@@ -1174,8 +1192,10 @@ class Node:
                     component.delete()
                     component = None
                 else:
-                    raise ValueError(f"{name} cannot be added to the Node: {self.get_name()} as requested on site: "
-                                     f"{self.get_site()}. Reason: {error}")
+                    raise ValueError(
+                        f"{name} cannot be added to the Node: {self.get_name()} as requested on site: "
+                        f"{self.get_site()}. Reason: {error}"
+                    )
         return component
 
     def get_components(self) -> List[Component]:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -826,6 +826,18 @@ class Node:
         except:
             return None
 
+    def get_requested_cores(self) -> int or None:
+        """
+        Gets the requested number of cores on the FABRIC node.
+
+        :return: the requested number of cores on the node
+        :rtype: int
+        """
+        try:
+            return self.get_fim_node().get_property(pname="capacities").core
+        except:
+            return None
+
     def get_ram(self) -> int or None:
         """
         Gets the amount of RAM on the FABRIC node.
@@ -838,6 +850,18 @@ class Node:
         except:
             return None
 
+    def get_requested_ram(self) -> int or None:
+        """
+        Gets the requested amount of RAM on the FABRIC node.
+
+        :return: the requested amount of RAM on the node
+        :rtype: int
+        """
+        try:
+            return self.get_fim_node().get_property(pname="capacities").ram
+        except:
+            return None
+
     def get_disk(self) -> int or None:
         """
         Gets the amount of disk space on the FABRIC node.
@@ -847,6 +871,18 @@ class Node:
         """
         try:
             return self.get_fim_node().get_property(pname="capacity_allocations").disk
+        except:
+            return None
+
+    def get_requested_disk(self) -> int or None:
+        """
+        Gets the amount of disk space on the FABRIC node.
+
+        :return: the amount of disk space on the node
+        :rtype: int
+        """
+        try:
+            return self.get_fim_node().get_property(pname="capacities").disk
         except:
             return None
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -836,7 +836,7 @@ class Node:
         try:
             return self.get_fim_node().get_property(pname="capacities").core
         except:
-            return None
+            return 0
 
     def get_ram(self) -> int or None:
         """
@@ -860,7 +860,7 @@ class Node:
         try:
             return self.get_fim_node().get_property(pname="capacities").ram
         except:
-            return None
+            return 0
 
     def get_disk(self) -> int or None:
         """
@@ -884,7 +884,7 @@ class Node:
         try:
             return self.get_fim_node().get_property(pname="capacities").disk
         except:
-            return None
+            return 0
 
     def get_image(self) -> str or None:
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -84,7 +84,7 @@ class Node:
     default_disk = 10
     default_image = "default_rocky_8"
 
-    def __init__(self, slice: Slice, node: FimNode, check: bool = False, remove: bool = True):
+    def __init__(self, slice: Slice, node: FimNode, check: bool = True, remove: bool = True):
         """
         Node constructor, usually invoked by ``Slice.add_node()``.
 
@@ -1091,7 +1091,7 @@ class Node:
         return self.get_slice().get_private_key_passphrase()
 
     def add_component(
-        self, model: str = None, name: str = None, user_data: dict = {}, check: bool = False, remove: bool = True
+        self, model: str = None, name: str = None, user_data: dict = {}
     ) -> Component:
         """
         Creates a new FABRIC component using this fablib node.
@@ -1122,12 +1122,6 @@ class Node:
         :param name: the name of the new component
         :type name: String
 
-        :param check: Validate if the component can be attached to the node on the requested site
-        :type check: bool
-
-        :param remove: Remove the component from the topology if it can't be provisioned
-        :type remove: bool
-
         :return: the new component
         :rtype: Component
         """
@@ -1136,7 +1130,7 @@ class Node:
         )
         if self.check:
             if self.get_fablib_manager().validate(node=self):
-                if remove:
+                if self.remove:
                     component.delete()
                 else:
                     raise ValueError("Component cannot be attached")

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -93,6 +93,13 @@ class Node:
 
         :param node: the FIM node that this Node represents
         :type node: Node
+
+        :param check: Validate node can be allocated w.r.t available resources
+        :type check: bool
+
+        :param remove: Remove the node if validation w.r.t available resources fails
+        :type remove: bool
+
         """
         super().__init__()
         self.fim_node = node
@@ -182,10 +189,10 @@ class Node:
         :param avoid: a list of node names to avoid
         :type avoid: List[str]
 
-        :param check: Validate if the node can be provisioned on a site
+        :param check: Validate node can be allocated w.r.t available resources
         :type check: bool
 
-        :param remove: Remove the node from the topology if it can't be provisioned
+        :param remove: Remove the node if validation w.r.t available resources fails
         :type remove: bool
 
         :return: a new fablib node

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -84,7 +84,7 @@ class Node:
     default_disk = 10
     default_image = "default_rocky_8"
 
-    def __init__(self, slice: Slice, node: FimNode, check: bool = True, remove: bool = True):
+    def __init__(self, slice: Slice, node: FimNode, check: bool = False, remove: bool = True):
         """
         Node constructor, usually invoked by ``Slice.add_node()``.
 
@@ -162,7 +162,7 @@ class Node:
 
     @staticmethod
     def new_node(
-        slice: Slice = None, name: str = None, site: str = None, avoid: List[str] = [], check: bool = True, remove: bool = True
+        slice: Slice = None, name: str = None, site: str = None, avoid: List[str] = [], check: bool = False, remove: bool = True
     ):
         """
         Not intended for API call.  See: Slice.add_node()
@@ -1159,15 +1159,15 @@ class Node:
             node=self, model=model, name=name, user_data=user_data
         )
         if self.check:
-            status, error = self.get_fablib_manager().validate(node=self)
+            status, error = self.get_fablib_manager().validate_node(node=self)
             if not status:
                 if self.remove:
-                    print(f"{name} removed from the topology with reason: {error}!")
+                    print(f"{name} removed from the topology. Reason: {error}!")
                     component.delete()
                     component = None
                 else:
                     raise ValueError(f"{name} cannot be added to the Node: {self.get_name()} as requested on site: "
-                                     f"{self.get_site()}, reason: {error}")
+                                     f"{self.get_site()}. Reason: {error}")
         return component
 
     def get_components(self) -> List[Component]:
@@ -3245,7 +3245,7 @@ class Node:
         VM INFO looks like:
         In this example below, no CPU pinning has been applied so CPU Affinity lists all the CPUs
         After the pinning has been applied, CPU Affinity would show only the pinned CPU
-        [{'CPU': '116', 'CPU Affinity': '0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127', 'CPU time': '20.2s', 'State': 'running', 'VCPU': '0'},
+            [{'CPU': '116', 'CPU Affinity': '0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127', 'CPU time': '20.2s', 'State': 'running', 'VCPU': '0'},
         {'CPU': '118', 'CPU Affinity': '0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127', 'CPU time': '9.0s', 'State': 'running', 'VCPU': '1'},
         {'CPU': '117', 'CPU Affinity': '0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127', 'CPU time': '8.9s', 'State': 'running', 'VCPU': '2'},
         {'CPU': '119', 'CPU Affinity': '0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127', 'CPU time': '8.8s', 'State': 'running', 'VCPU': '3'},

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1187,10 +1187,7 @@ class Node:
                 component.delete()
                 component = None
                 if self.raise_exception:
-                    raise ValueError(
-                        f"{name} cannot be added to the Node: {self.get_name()} as requested on site: "
-                        f"{self.get_site()}. Reason: {error}"
-                    )
+                    raise ValueError(error)
         return component
 
     def get_components(self) -> List[Component]:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -927,11 +927,12 @@ class Node:
         try:
             if self.host is not None:
                 return self.host
-            return (
-                self.get_fim_node()
-                .get_property(pname="label_allocations")
-                .instance_parent
-            )
+            label_allocations = self.get_fim_node().get_property(pname="label_allocations")
+            labels = self.get_fim_node().get_property(pname="labels")
+            if label_allocations:
+                return label_allocations.instance_parent
+            if labels:
+                return labels.instance_parent
         except:
             return None
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1162,10 +1162,11 @@ class Node:
             status, error = self.get_fablib_manager().validate(node=self)
             if not status:
                 if self.remove:
-                    print(f"{self.get_name()} removed from the topology with reason: {error}!")
-                    self.delete()
+                    print(f"{name} removed from the topology with reason: {error}!")
+                    component.delete()
+                    component = None
                 else:
-                    raise ValueError(f"{self.get_name()} cannot be allocated as requested on site: "
+                    raise ValueError(f"{name} cannot be added to the Node: {self.get_name()} as requested on site: "
                                      f"{self.get_site()}, reason: {error}")
         return component
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -204,6 +204,12 @@ class Node:
 
         node.init_fablib_data()
 
+        if check:
+            if slice.get_fablib_manager().validate(node=node):
+                if remove:
+                    node.delete()
+                else:
+                    raise ValueError("Node cannot be added")
         return node
 
     @staticmethod
@@ -1129,12 +1135,12 @@ class Node:
             node=self, model=model, name=name, user_data=user_data
         )
         if self.check:
-            worker_found = self.get_fablib_manager().resources.validate(node=self)
-            if not worker_found:
+            if self.get_fablib_manager().validate(node=self):
                 if remove:
                     component.delete()
                 else:
-                    raise Exception("Component cannot be attached")
+                    raise ValueError("Component cannot be attached")
+        return component
 
     def get_components(self) -> List[Component]:
         """

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -204,12 +204,6 @@ class Node:
 
         node.init_fablib_data()
 
-        if check:
-            if slice.get_fablib_manager().validate(node=node):
-                if remove:
-                    node.delete()
-                else:
-                    raise ValueError("Node cannot be added")
         return node
 
     @staticmethod

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -208,9 +208,6 @@ class Node:
         if site is None:
             [site] = slice.get_fablib_manager().get_random_sites(
                 avoid=avoid,
-                filter_function=lambda x: x["cores_available"] > Node.default_cores
-                and x["ram_available"] > Node.default_ram
-                and x["disk_available"] > Node.default_disk,
             )
 
         logging.info(f"Adding node: {name}, slice: {slice.get_name()}, site: {site}")

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -120,27 +120,26 @@ class Resources:
         table = []
         for site_name, site in self.topology.sites.items():
             # logging.debug(f"site -- {site}")
-            site_sliver = site.get_sliver()
             table.append(
                 [
                     site.name,
-                    f"{self.get_ptp_capable(site_name)}",
-                    self.get_cpu_capacity(site_sliver),
-                    f"{self.get_core_available(site_sliver)}/{self.get_core_capacity(site_sliver)}",
-                    f"{self.get_ram_available(site_sliver)}/{self.get_ram_capacity(site_sliver)}",
-                    f"{self.get_disk_available(site_sliver)}/{self.get_disk_capacity(site_sliver)}",
+                    f"{self.get_ptp_capable(site)}",
+                    self.get_cpu_capacity(site),
+                    f"{self.get_core_available(site)}/{self.get_core_capacity(site)}",
+                    f"{self.get_ram_available(site)}/{self.get_ram_capacity(site)}",
+                    f"{self.get_disk_available(site)}/{self.get_disk_capacity(site)}",
                     # self.get_host_capacity(site),
                     # self.get_location_postal(site),
                     # self.get_location_lat_long(site),
-                    f"{self.get_component_available(site_sliver,'SharedNIC-ConnectX-6')}/{self.get_component_capacity(site_sliver,'SharedNIC-ConnectX-6')}",
-                    f"{self.get_component_available(site_sliver,'SmartNIC-ConnectX-6')}/{self.get_component_capacity(site_sliver,'SmartNIC-ConnectX-6')}",
-                    f"{self.get_component_available(site_sliver,'SmartNIC-ConnectX-5')}/{self.get_component_capacity(site_sliver,'SmartNIC-ConnectX-5')}",
-                    f"{self.get_component_available(site_sliver,'NVME-P4510')}/{self.get_component_capacity(site_sliver,'NVME-P4510')}",
-                    f"{self.get_component_available(site_sliver,'GPU-Tesla T4')}/{self.get_component_capacity(site_sliver,'GPU-Tesla T4')}",
-                    f"{self.get_component_available(site_sliver,'GPU-RTX6000')}/{self.get_component_capacity(site_sliver,'GPU-RTX6000')}",
-                    f"{self.get_component_available(site_sliver, 'GPU-A30')}/{self.get_component_capacity(site_sliver, 'GPU-A30')}",
-                    f"{self.get_component_available(site_sliver, 'GPU-A40')}/{self.get_component_capacity(site_sliver, 'GPU-A40')}",
-                    f"{self.get_component_available(site_sliver, 'FPGA-Xilinx-U280')}/{self.get_component_capacity(site_sliver, 'FPGA-Xilinx-U280')}",
+                    f"{self.get_component_available(site,'SharedNIC-ConnectX-6')}/{self.get_component_capacity(site,'SharedNIC-ConnectX-6')}",
+                    f"{self.get_component_available(site,'SmartNIC-ConnectX-6')}/{self.get_component_capacity(site,'SmartNIC-ConnectX-6')}",
+                    f"{self.get_component_available(site,'SmartNIC-ConnectX-5')}/{self.get_component_capacity(site,'SmartNIC-ConnectX-5')}",
+                    f"{self.get_component_available(site,'NVME-P4510')}/{self.get_component_capacity(site,'NVME-P4510')}",
+                    f"{self.get_component_available(site,'GPU-Tesla T4')}/{self.get_component_capacity(site,'GPU-Tesla T4')}",
+                    f"{self.get_component_available(site,'GPU-RTX6000')}/{self.get_component_capacity(site,'GPU-RTX6000')}",
+                    f"{self.get_component_available(site, 'GPU-A30')}/{self.get_component_capacity(site, 'GPU-A30')}",
+                    f"{self.get_component_available(site, 'GPU-A40')}/{self.get_component_capacity(site, 'GPU-A40')}",
+                    f"{self.get_component_available(site, 'FPGA-Xilinx-U280')}/{self.get_component_capacity(site, 'FPGA-Xilinx-U280')}",
                 ]
             )
 
@@ -189,7 +188,7 @@ class Resources:
         """
         site = self.topology.sites[site_name]
 
-        data = self.site_to_dict(site.get_sliver(), latlon=latlon)
+        data = self.site_to_dict(site, latlon=latlon)
 
         if pretty_names:
             pretty_names_dict = self.site_pretty_names
@@ -256,6 +255,7 @@ class Resources:
         :type site: String
         """
         try:
+            traceback.print_stack()
             from fim.graph.abc_property_graph import ABCPropertyGraph
             from fim.view_only_dict import ViewOnlyDict
             from fim.user import Node
@@ -990,7 +990,7 @@ class Resources:
     ):
         table = []
         for site_name, site in self.topology.sites.items():
-            table.append(self.site_to_dict(site.get_sliver(), latlon=latlon))
+            table.append(self.site_to_dict(site, latlon=latlon))
 
         if pretty_names:
             pretty_names_dict = self.site_pretty_names

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -67,7 +67,7 @@ class Resources:
     DISK = "disk"
 
     site_attribute_name_mappings = {
-        CORES: {NON_PRETTY_NAME: CPUS, PRETTY_NAME: "Cores", HEADER_NAME: "Cores"},
+        CORES: {NON_PRETTY_NAME: CORES, PRETTY_NAME: "Cores", HEADER_NAME: "Cores"},
         RAM: {
             NON_PRETTY_NAME: RAM,
             PRETTY_NAME: "Ram",

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -40,8 +40,8 @@ from fabrictestbed.slice_editor import AdvertisedTopology, Capacities
 from fabrictestbed.slice_manager import Status
 from fim.slivers import network_node
 from fim.user import interface, link, node
-from tabulate import tabulate
 from fim.view_only_dict import ViewOnlyDict
+from tabulate import tabulate
 
 
 class Resources:
@@ -255,17 +255,26 @@ class Resources:
         """
         try:
             from fim.graph.abc_property_graph import ABCPropertyGraph
+
             if isinstance(site, str):
                 site = self.get_topology_site(site)
 
-            node_id_list = site.topo.graph_model.get_first_neighbor(node_id=site.node_id, rel=ABCPropertyGraph.REL_HAS,
-                                                                    node_label=ABCPropertyGraph.CLASS_NetworkNode)
+            node_id_list = site.topo.graph_model.get_first_neighbor(
+                node_id=site.node_id,
+                rel=ABCPropertyGraph.REL_HAS,
+                node_label=ABCPropertyGraph.CLASS_NetworkNode,
+            )
             ret = dict()
             for nid in node_id_list:
                 _, node_props = site.topo.graph_model.get_node_properties(node_id=nid)
-                n = node.Node(name=node_props[ABCPropertyGraph.PROP_NAME], node_id=nid, topo=site.topo)
+                n = node.Node(
+                    name=node_props[ABCPropertyGraph.PROP_NAME],
+                    node_id=nid,
+                    topo=site.topo,
+                )
                 # exclude Facility nodes
                 from fim.user import NodeType
+
                 if n.type != NodeType.Facility:
                     ret[n.name] = n
             return ViewOnlyDict(ret)
@@ -294,7 +303,9 @@ class Resources:
             if nodes:
                 for w in nodes.values():
                     if component_model_name in w.components:
-                        component_capacity += w.components[component_model_name].capacities.unit
+                        component_capacity += w.components[
+                            component_model_name
+                        ].capacities.unit
         except Exception as e:
             logging.error(f"Failed to get {component_model_name} capacity {site}: {e}")
         return component_capacity
@@ -321,7 +332,9 @@ class Resources:
             if nodes:
                 for w in nodes.values():
                     if component_model_name in w.components:
-                        component_allocated += w.components[component_model_name].capacity_allocations.unit
+                        component_allocated += w.components[
+                            component_model_name
+                        ].capacity_allocations.unit
         except Exception as e:
             logging.error(f"Failed to get {component_model_name} allocated {site}: {e}")
         return component_allocated

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -133,15 +133,21 @@ class Resources:
         "location": "Location",
         "ptp_capable": "PTP Capable",
         HOSTS.lower(): HOSTS,
-        CPUS.lower(): CPUS
+        CPUS.lower(): CPUS,
     }
     for attribute, names in site_attribute_name_mappings.items():
         non_pretty_name = names.get(NON_PRETTY_NAME)
         pretty_name = names.get(PRETTY_NAME)
         site_pretty_names[non_pretty_name] = pretty_name
-        site_pretty_names[f"{non_pretty_name}_{AVAILABLE.lower()}"] = f"{pretty_name} {AVAILABLE}"
-        site_pretty_names[f"{non_pretty_name}_{CAPACITY.lower()}"] = f"{pretty_name} {CAPACITY}"
-        site_pretty_names[f"{non_pretty_name}_{ALLOCATED.lower()}"] = f"{pretty_name} {ALLOCATED}"
+        site_pretty_names[
+            f"{non_pretty_name}_{AVAILABLE.lower()}"
+        ] = f"{pretty_name} {AVAILABLE}"
+        site_pretty_names[
+            f"{non_pretty_name}_{CAPACITY.lower()}"
+        ] = f"{pretty_name} {CAPACITY}"
+        site_pretty_names[
+            f"{non_pretty_name}_{ALLOCATED.lower()}"
+        ] = f"{pretty_name} {ALLOCATED}"
 
     def __init__(self, fablib_manager, force_refresh: bool = False):
         """
@@ -354,7 +360,9 @@ class Resources:
                             comp_cap.setdefault(self.ALLOCATED.lower(), 0)
                             comp_cap[self.CAPACITY.lower()] += c.capacities.unit
                             if c.capacity_allocations:
-                                comp_cap[self.ALLOCATED.lower()] += c.capacity_allocations.unit
+                                comp_cap[
+                                    self.ALLOCATED.lower()
+                                ] += c.capacity_allocations.unit
 
             return site_info
         except Exception as e:
@@ -845,12 +853,18 @@ class Resources:
                 self.PRETTY_NAME: "Location",
                 self.VALUE: self.get_location_lat_long(site_name),
             },
-            "ptp": {self.PRETTY_NAME: "PTP Capable", self.VALUE: self.get_ptp_capable(site)},
+            "ptp": {
+                self.PRETTY_NAME: "PTP Capable",
+                self.VALUE: self.get_ptp_capable(site),
+            },
             self.HOSTS.lower(): {
                 self.PRETTY_NAME: self.HOSTS,
                 self.VALUE: self.get_host_capacity(site_name),
             },
-            self.CPUS.lower(): {self.PRETTY_NAME: self.CPUS, self.VALUE: self.get_cpu_capacity(site_name)},
+            self.CPUS.lower(): {
+                self.PRETTY_NAME: self.CPUS,
+                self.VALUE: self.get_cpu_capacity(site_name),
+            },
         }
 
         for attribute, names in self.site_attribute_name_mappings.items():

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -294,7 +294,8 @@ class Resources:
             nodes = self.get_nodes(site=site)
             if nodes:
                 for w in nodes.values():
-                    component_capacity += w.components[component_model_name].capacities.unit
+                    if component_model_name in w.components:
+                        component_capacity += w.components[component_model_name].capacities.unit
         except Exception as e:
             logging.error(f"Failed to get {component_model_name} capacity {site}: {e}")
         return component_capacity
@@ -320,7 +321,8 @@ class Resources:
             nodes = self.get_nodes(site=site)
             if nodes:
                 for w in nodes.values():
-                    component_allocated += w.components[component_model_name].capacity_allocations.unit
+                    if component_model_name in w.components:
+                        component_allocated += w.components[component_model_name].capacity_allocations.unit
         except Exception as e:
             logging.error(f"Failed to get {component_model_name} allocated {site}: {e}")
         return component_allocated
@@ -977,7 +979,9 @@ class Resources:
     ):
         table = []
         for site_name, site in self.topology.sites.items():
-            table.append(self.site_to_dict(site, latlon=latlon))
+            site_dict = self.site_to_dict(site, latlon=latlon)
+            if site_dict.get("hosts"):
+                table.append(site_dict)
 
         if pretty_names:
             pretty_names_dict = self.site_pretty_names

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -303,8 +303,9 @@ class Resources:
                 return site.components[component_model_name].capacities.unit
 
             nodes = self.get_nodes(site=site)
-            for w in nodes.values():
-                component_capacity += w.components[component_model_name].unit
+            if nodes:
+                for w in nodes.values():
+                    component_capacity += w.components[component_model_name].unit
         except Exception as e:
             logging.error(f"Failed to get {component_model_name} capacity {site}: {e}")
         return component_capacity
@@ -330,8 +331,9 @@ class Resources:
             if isinstance(site, node.Node):
                 return site.components[component_model_name].capacity_allocations.unit
             nodes = self.get_nodes(site=site)
-            for w in nodes.values():
-                component_allocated += w.components[component_model_name].capacity_allocations.unit
+            if nodes:
+                for w in nodes.values():
+                    component_allocated += w.components[component_model_name].capacity_allocations.unit
         except Exception as e:
             logging.error(f"Failed to get {component_model_name} allocated {site}: {e}")
         return component_allocated

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -257,21 +257,15 @@ class Resources:
         try:
             traceback.print_stack()
             from fim.graph.abc_property_graph import ABCPropertyGraph
-            from fim.view_only_dict import ViewOnlyDict
-            from fim.user import Node
             if isinstance(site, str):
-                s = self.get_topology_site(site)
-            elif isinstance(site, network_node.NodeSliver):
-                s = site
-            else:
-                raise Exception(f"Invalid arguments: {site} is of {type(site)}, expected str or network_node.NodeSliver")
+                site = self.get_topology_site(site)
 
-            node_id_list = s.topo.graph_model.get_first_neighbor(node_id=s.node_id, rel=ABCPropertyGraph.REL_HAS,
-                                                                 node_label=ABCPropertyGraph.CLASS_NetworkNode)
+            node_id_list = site.topo.graph_model.get_first_neighbor(node_id=site.node_id, rel=ABCPropertyGraph.REL_HAS,
+                                                                    node_label=ABCPropertyGraph.CLASS_NetworkNode)
             ret = dict()
             for nid in node_id_list:
-                _, node_props = s.topo.graph_model.get_node_properties(node_id=nid)
-                n = Node(name=node_props[ABCPropertyGraph.PROP_NAME], node_id=nid, topo=s.topo)
+                _, node_props = site.topo.graph_model.get_node_properties(node_id=nid)
+                n = node.Node(name=node_props[ABCPropertyGraph.PROP_NAME], node_id=nid, topo=site.topo)
                 # exclude Facility nodes
                 from fim.user import NodeType
                 if n.type != NodeType.Facility:
@@ -298,10 +292,6 @@ class Resources:
         """
         component_capacity = 0
         try:
-            if isinstance(site, node.Node):
-                print("KOMAL -- Site is a node.Node")
-                return site.components[component_model_name].capacities.unit
-
             nodes = self.get_nodes(site=site)
             if nodes:
                 for w in nodes.values():
@@ -328,8 +318,6 @@ class Resources:
         """
         component_allocated = 0
         try:
-            if isinstance(site, node.Node):
-                return site.components[component_model_name].capacity_allocations.unit
             nodes = self.get_nodes(site=site)
             if nodes:
                 for w in nodes.values():

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -43,10 +43,6 @@ from fim.user import interface, link, node
 from tabulate import tabulate
 from fim.view_only_dict import ViewOnlyDict
 
-from typing import TYPE_CHECKING
-if TYPE_CHECKING:
-    from fabrictestbed_extensions.fablib.node import Node
-
 
 class Resources:
     site_pretty_names = {
@@ -1232,45 +1228,3 @@ class FacilityPorts(Resources):
             filter_function=filter_function,
             pretty_names_dict=pretty_names_dict,
         )
-
-    def validate(self, node: Node) -> bool:
-        site = self.get_topology_site(site_name=node.get_name())
-        workers = self.get_nodes(site=site)
-        allocated_comps_per_worker = {}
-        worker_found = False
-        for w in workers.values():
-            if w.name not in allocated_comps_per_worker:
-                allocated_comps_per_worker[w.name] = {}
-            available_cores = w.capacities.cores - w.capacity_allocations.cores
-            available_ram = w.capacities.ram - w.capacity_allocations.ram
-            available_disk = w.capacities.disk - w.capacity_allocations.disk
-            if (node.get_cores() > available_cores or
-                    node.get_disk() > available_disk or
-                    node.get_ram() > available_ram):
-                print(f"Worker: {w} does not meet core/ram/disk requirements!")
-                continue
-
-            error = False
-            # Check if there are enough components available
-            for c in node.get_components():
-                comp_model = c.get_model()
-                if comp_model not in w.components:
-                    print(f"Worker: {w} does not have the requested component: {comp_model}")
-                    error = True
-                    break
-                if comp_model not in allocated_comps_per_worker[w.name]:
-                    allocated_comps_per_worker[w.name][comp_model] = 0
-                available_comps = w.components[comp_model].capacities.unit - w.components[comp_model].capacity_allocations.unit
-                available_comps -= allocated_comps_per_worker[w.name][comp_model]
-                if not available_comps:
-                    print(f"Worker: {w} has reached the limit for component: {comp_model}")
-                    error = True
-                    break
-                allocated_comps_per_worker[w.name][comp_model] += 1
-
-            if error:
-                continue
-
-            worker_found = True
-            break
-        return worker_found

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -69,7 +69,7 @@ class Resources:
     HOSTS = "Hosts"
 
     site_attribute_name_mappings = {
-        CORES.lower(): {NON_PRETTY_NAME: CORES, PRETTY_NAME: CORES, HEADER_NAME: CORES},
+        CORES.lower(): {NON_PRETTY_NAME: CORES.lower(), PRETTY_NAME: CORES, HEADER_NAME: CORES},
         RAM.lower(): {
             NON_PRETTY_NAME: RAM.lower(),
             PRETTY_NAME: RAM,

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -332,7 +332,10 @@ class Resources:
             nodes = self.get_nodes(site=site)
             if nodes:
                 for w in nodes.values():
-                    if component_model_name in w.components:
+                    if (
+                        component_model_name in w.components
+                        and w.components[component_model_name].capacity_allocations
+                    ):
                         component_allocated += w.components[
                             component_model_name
                         ].capacity_allocations.unit

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -306,9 +306,10 @@ class Resources:
                         component_capacity += w.components[
                             component_model_name
                         ].capacities.unit
+            return component_capacity
         except Exception as e:
-            logging.error(f"Failed to get {component_model_name} capacity {site}: {e}")
-        return component_capacity
+            #logging.error(f"Failed to get {component_model_name} capacity {site}: {e}")
+            return component_capacity
 
     def get_component_allocated(
         self,
@@ -335,9 +336,10 @@ class Resources:
                         component_allocated += w.components[
                             component_model_name
                         ].capacity_allocations.unit
+            return component_allocated
         except Exception as e:
-            logging.error(f"Failed to get {component_model_name} allocated {site}: {e}")
-        return component_allocated
+            #logging.error(f"Failed to get {component_model_name} allocated {site}: {e}")
+            return component_allocated
 
     def get_component_available(
         self,

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -308,7 +308,7 @@ class Resources:
                         ].capacities.unit
             return component_capacity
         except Exception as e:
-            #logging.error(f"Failed to get {component_model_name} capacity {site}: {e}")
+            # logging.error(f"Failed to get {component_model_name} capacity {site}: {e}")
             return component_capacity
 
     def get_component_allocated(
@@ -338,7 +338,7 @@ class Resources:
                         ].capacity_allocations.unit
             return component_allocated
         except Exception as e:
-            #logging.error(f"Failed to get {component_model_name} allocated {site}: {e}")
+            # logging.error(f"Failed to get {component_model_name} allocated {site}: {e}")
             return component_allocated
 
     def get_component_available(

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -296,23 +296,18 @@ class Resources:
         :return: total component capacity
         :rtype: int
         """
+        component_capacity = 0
         try:
-            if isinstance(site, network_node.NodeSliver):
-                return site.attached_components_info.get_device(
-                    component_model_name
-                ).capacities.unit
             if isinstance(site, node.Node):
+                print("KOMAL -- Site is a node.Node")
                 return site.components[component_model_name].capacities.unit
 
-            # String
             nodes = self.get_nodes(site=site)
-            total_comp_capacity = 0
             for w in nodes.values():
-                total_comp_capacity += w.components[component_model_name].unit
-
+                component_capacity += w.components[component_model_name].unit
         except Exception as e:
-            # logging.debug(f"Failed to get {component_model_name} capacity {site}")
-            return 0
+            logging.error(f"Failed to get {component_model_name} capacity {site}: {e}")
+        return component_capacity
 
     def get_component_allocated(
         self,
@@ -330,21 +325,16 @@ class Resources:
         :return: currently allocated component of this model
         :rtype: int
         """
+        component_allocated = 0
         try:
-            if isinstance(site, network_node.NodeSliver):
-                return site.attached_components_info.get_device(
-                    component_model_name
-                ).capacity_allocations.unit
             if isinstance(site, node.Node):
                 return site.components[component_model_name].capacity_allocations.unit
-            return (
-                self.get_topology_site(site)
-                .components[component_model_name]
-                .capacity_allocations.unit
-            )
+            nodes = self.get_nodes(site=site)
+            for w in nodes.values():
+                component_allocated += w.components[component_model_name].capacity_allocations.unit
         except Exception as e:
-            # logging.debug(f"Failed to get {component_model_name} allocated {site}")
-            return 0
+            logging.error(f"Failed to get {component_model_name} allocated {site}: {e}")
+        return component_allocated
 
     def get_component_available(
         self,

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import json
 import logging
 import traceback
-from typing import List, Tuple, Dict
+from typing import Dict, List, Tuple
 
 from fabrictestbed.slice_editor import AdvertisedTopology, Capacities
 from fabrictestbed.slice_manager import Status
@@ -62,8 +62,14 @@ class Resources:
 
     component_name_mappings = {
         NIC_SHARED_CONNECTX_6: {NON_PRETTY_NAME: "nic_basic", PRETTY_NAME: "Basic NIC"},
-        SMART_NIC_CONNECTX_6: {NON_PRETTY_NAME: "nic_connectx_6", PRETTY_NAME: "ConnectX-6"},
-        SMART_NIC_CONNECTX_5: {NON_PRETTY_NAME: "nic_connectx_5", PRETTY_NAME: "ConnectX-5"},
+        SMART_NIC_CONNECTX_6: {
+            NON_PRETTY_NAME: "nic_connectx_6",
+            PRETTY_NAME: "ConnectX-6",
+        },
+        SMART_NIC_CONNECTX_5: {
+            NON_PRETTY_NAME: "nic_connectx_5",
+            PRETTY_NAME: "ConnectX-5",
+        },
         NVME_P4510: {NON_PRETTY_NAME: "nvme", PRETTY_NAME: "NVMe"},
         GPU_TESLA_T4: {NON_PRETTY_NAME: "tesla_t4", PRETTY_NAME: "Tesla T4"},
         GPU_RTX6000: {NON_PRETTY_NAME: "rtx6000", PRETTY_NAME: "RTX6000"},
@@ -161,66 +167,6 @@ class Resources:
                 row.append(f"{available}/{capacity}")
 
             table.append(row)
-
-        return tabulate(
-            table,
-            headers=[
-                "Name",
-                "PTP Capable",
-                "CPUs",
-                "Cores",
-                f"RAM ({Capacities.UNITS['ram']})",
-                f"Disk ({Capacities.UNITS['disk']})",
-                # "Workers"
-                # "Physical Address",
-                # "Location Coordinates"
-                "Basic (100 Gbps NIC)",
-                "ConnectX-6 (100 Gbps x2 NIC)",
-                "ConnectX-5 (25 Gbps x2 NIC)",
-                "P4510 (NVMe 1TB)",
-                "Tesla T4 (GPU)",
-                "RTX6000 (GPU)",
-                "A30 (GPU)",
-                "A40 (GPU)",
-                "FPGA-Xilinx-U280",
-            ],
-        )
-
-    def __str__old(self) -> str:
-        """
-        Creates a tabulated string of all the available resources.
-
-        Intended for printing available resources.
-
-        :return: Tabulated string of available resources
-        :rtype: String
-        """
-        table = []
-        for site_name, site in self.topology.sites.items():
-            # logging.debug(f"site -- {site}")
-            components = self.get_components_capacities_and_allocations(site)
-            table.append(
-                [
-                    site.name,
-                    f"{self.get_ptp_capable(site)}",
-                    self.get_cpu_capacity(site),
-                    f"{self.get_core_available(site)}/{self.get_core_capacity(site)}",
-                    f"{self.get_ram_available(site)}/{self.get_ram_capacity(site)}",
-                    f"{self.get_disk_available(site)}/{self.get_disk_capacity(site)}",
-                    # self.get_host_capacity(site),
-                    # self.get_location_postal(site),
-                    # self.get_location_lat_long(site),
-                    f"{self.get_component_available(site,'SharedNIC-ConnectX-6')}/{self.get_component_capacity(site,'SharedNIC-ConnectX-6')}",
-                    f"{self.get_component_available(site,'SmartNIC-ConnectX-6')}/{self.get_component_capacity(site,'SmartNIC-ConnectX-6')}",
-                    f"{self.get_component_available(site,'SmartNIC-ConnectX-5')}/{self.get_component_capacity(site,'SmartNIC-ConnectX-5')}",
-                    f"{self.get_component_available(site,'NVME-P4510')}/{self.get_component_capacity(site,'NVME-P4510')}",
-                    f"{self.get_component_available(site,'GPU-Tesla T4')}/{self.get_component_capacity(site,'GPU-Tesla T4')}",
-                    f"{self.get_component_available(site,'GPU-RTX6000')}/{self.get_component_capacity(site,'GPU-RTX6000')}",
-                    f"{self.get_component_available(site, 'GPU-A30')}/{self.get_component_capacity(site, 'GPU-A30')}",
-                    f"{self.get_component_available(site, 'GPU-A40')}/{self.get_component_capacity(site, 'GPU-A40')}",
-                    f"{self.get_component_available(site, 'FPGA-Xilinx-U280')}/{self.get_component_capacity(site, 'FPGA-Xilinx-U280')}",
-                ]
-            )
 
         return tabulate(
             table,
@@ -362,8 +308,7 @@ class Resources:
             logging.error(traceback.format_exc())
 
     def get_components_capacities_and_allocations(
-        self,
-        site: str or node.Node or network_node.NodeSliver
+        self, site: str or node.Node or network_node.NodeSliver
     ) -> Dict[str, Dict[str, int]]:
         """
         Gets the total site capacity of all components for a site
@@ -831,7 +776,9 @@ class Resources:
     def site_to_json(self, site, latlon=True):
         return json.dumps(self.site_to_dict(site, latlon=latlon), indent=4)
 
-    def site_to_dict(self, site: str or node.Node or network_node.NodeSliver, latlon=True):
+    def site_to_dict(
+        self, site: str or node.Node or network_node.NodeSliver, latlon=True
+    ):
         """
         Convert site information into a dictionary
 
@@ -847,7 +794,7 @@ class Resources:
             "location": self.get_location_lat_long(site) if latlon else "",
             "ptp_capable": self.get_ptp_capable(site),
             "hosts": self.get_host_capacity(site),
-            "cpus": self.get_cpu_capacity(site)
+            "cpus": self.get_cpu_capacity(site),
         }
 
         for comp_model_name, names in self.component_name_mappings.items():
@@ -863,117 +810,10 @@ class Resources:
 
         return d
 
-    def site_to_dict_old(
-        self, site: str or node.Node or network_node.NodeSliver, latlon=True
-    ):
-        """
-        Convert site information into a dictionary
-
-        :param site: site name or site object
-        :param latlon: convert address to latlon (makes online call to openstreetmaps.org)
-        """
-        core_a = self.get_core_available(site)
-        core_c = self.get_core_capacity(site)
-        ram_a = self.get_ram_available(site)
-        ram_c = self.get_ram_capacity(site)
-        disk_a = self.get_disk_available(site)
-        disk_c = self.get_disk_capacity(site)
-        components = self.get_components_capacities_and_allocations(site)
-        nic_basic_a = components.get(self.NIC_SHARED_CONNECTX_6).get(self.ALLOCATED) if components.get(self.NIC_SHARED_CONNECTX_6) else 0
-        nic_basic_c = components.get(self.NIC_SHARED_CONNECTX_6).get(self.CAPACITIES) if components.get(self.NIC_SHARED_CONNECTX_6) else 0
-        nic_cx6_a = components.get(self.SMART_NIC_CONNECTX_6).get(self.ALLOCATED) if components.get(self.SMART_NIC_CONNECTX_6) else 0
-        nic_cx6_c = components.get(self.SMART_NIC_CONNECTX_6).get(self.CAPACITIES) if components.get(self.SMART_NIC_CONNECTX_6) else 0
-        nic_cx5_a = components.get(self.SMART_NIC_CONNECTX_5).get(self.ALLOCATED) if components.get(self.SMART_NIC_CONNECTX_5) else 0
-        nic_cx5_c = components.get(self.SMART_NIC_CONNECTX_5).get(self.CAPACITIES) if components.get(self.SMART_NIC_CONNECTX_5) else 0
-        nvme_a = components.get(self.NVME_P4510).get(self.ALLOCATED) if components.get(self.NVME_P4510) else 0
-        nvme_c = components.get(self.NVME_P4510).get(self.CAPACITIES) if components.get(self.NVME_P4510) else 0
-        tesla_t4_a = components.get(self.GPU_TESLA_T4).get(self.ALLOCATED) if components.get(self.GPU_TESLA_T4) else 0
-        tesla_t4_c = components.get(self.GPU_TESLA_T4).get(self.CAPACITIES) if components.get(self.GPU_TESLA_T4) else 0
-        rtx6000_a = components.get(self.GPU_RTX6000).get(self.ALLOCATED) if components.get(self.GPU_RTX6000) else 0
-        rtx6000_c = components.get(self.GPU_RTX6000).get(self.CAPACITIES) if components.get(self.GPU_RTX6000) else 0
-        a30_a = components.get(self.GPU_A30).get(self.ALLOCATED) if components.get(self.GPU_A30) else 0
-        a30_c = components.get(self.GPU_A30).get(self.CAPACITIES) if components.get(self.GPU_A30) else 0
-        a40_a = components.get(self.GPU_A40).get(self.ALLOCATED) if components.get(self.GPU_A40) else 0
-        a40_c = components.get(self.GPU_A40).get(self.CAPACITIES) if components.get(self.GPU_A40) else 0
-        u280_a = components.get(self.FPGA_XILINX_U280).get(self.ALLOCATED) if components.get(self.FPGA_XILINX_U280) else 0
-        u280_c = components.get(self.FPGA_XILINX_U280).get(self.CAPACITIES) if components.get(self.FPGA_XILINX_U280) else 0
-        ptp = self.get_ptp_capable(site)
-
-        d = {
-            "name": site.name if isinstance(site, node.Node) else site.get_name(),
-            "state": self.get_state(site),
-            "address": self.get_location_postal(site),
-            "location": self.get_location_lat_long(site) if latlon else "",
-            "ptp_capable": ptp,
-            "hosts": self.get_host_capacity(site),
-            "cpus": self.get_cpu_capacity(site),
-            "cores_available": core_c - core_a,
-            "cores_capacity": core_c,
-            "cores_allocated": core_a,
-            "ram_available": ram_c - ram_a,
-            "ram_capacity": ram_c,
-            "ram_allocated": ram_c,
-            "disk_available": disk_c - disk_a,
-            "disk_capacity": disk_c,
-            "disk_allocated": disk_a,
-            "nic_basic_available": nic_basic_c - nic_basic_a,
-            "nic_basic_capacity": nic_basic_c,
-            "nic_basic_allocated": nic_basic_a,
-            "nic_connectx_6_available": nic_cx6_c - nic_cx6_a,
-            "nic_connectx_6_capacity": nic_cx6_c,
-            "nic_connectx_6_allocated": nic_cx6_a,
-            "nic_connectx_5_available": nic_cx5_c - nic_cx5_a,
-            "nic_connectx_5_capacity": nic_cx5_c,
-            "nic_connectx_5_allocated": nic_cx5_a,
-            "nvme_available": nvme_c - nvme_a,
-            "nvme_capacity": nvme_c,
-            "nvme_allocated": nvme_a,
-            "tesla_t4_available": tesla_t4_c - tesla_t4_a,
-            "tesla_t4_capacity": tesla_t4_c,
-            "tesla_t4_allocated": tesla_t4_a,
-            "rtx6000_available": rtx6000_c - rtx6000_a,
-            "rtx6000_capacity": rtx6000_c,
-            "rtx6000_allocated": rtx6000_a,
-            "a30_available": a30_c - a30_a,
-            "a30_capacity": a30_c,
-            "a30_allocated": a30_a,
-            "a40_available": a40_c - a40_a,
-            "a40_capacity": a40_c,
-            "a40_allocated": a40_a,
-            "fpga_u280_available": u280_c - u280_a,
-            "fpga_u280_capacity": u280_c,
-            "fpga_u280_allocated": u280_a,
-        }
-        if not latlon:
-            d.pop("location")
-        return d
-
     def site_to_dictXXX(self, site):
         site_name = site.name
         components = self.get_components_capacities_and_allocations(site)
         d = {
-            "name": {"pretty_name": "Name", "value": site.name},
-            "address": {"pretty_name": "Address", "value": self.get_location_postal(site_name)},
-            "location": {"pretty_name": "Location", "value": self.get_location_lat_long(site_name)},
-            "ptp": {"pretty_name": "PTP Capable", "value": self.get_ptp_capable(site)},
-            "hosts": {"pretty_name": "Hosts", "value": self.get_host_capacity(site_name)},
-            "cpus": {"pretty_name": "CPUs", "value": self.get_cpu_capacity(site_name)}
-        }
-
-        for comp_model_name, names in self.component_name_mappings.items():
-            capacity = components.get(comp_model_name, {}).get(self.CAPACITIES, 0)
-            allocated = components.get(comp_model_name, {}).get(self.ALLOCATED, 0)
-            available = capacity - allocated
-
-            d[f"{names.get(self.NON_PRETTY_NAME)}_available"] = {"pretty_name": f"{names.get(self.PRETTY_NAME)} Available", "value": available}
-            d[f"{names.get(self.NON_PRETTY_NAME)}_capacity"] = {"pretty_name": f"{names.get(self.PRETTY_NAME)} Capacity", "value": capacity}
-            d[f"{names.get(self.NON_PRETTY_NAME)}_allocated"] = {"pretty_name": f"{names.get(self.PRETTY_NAME)} Allocated", "value": allocated}
-
-        return d
-
-    def site_to_dictXXX_old(self, site):
-        site_name = site.name
-        return {
             "name": {"pretty_name": "Name", "value": site.name},
             "address": {
                 "pretty_name": "Address",
@@ -983,174 +823,33 @@ class Resources:
                 "pretty_name": "Location",
                 "value": self.get_location_lat_long(site_name),
             },
-            "ptp": {
-                "pretty_name": "PTP Capable",
-                "value": self.get_ptp_capable(site),
-            },
+            "ptp": {"pretty_name": "PTP Capable", "value": self.get_ptp_capable(site)},
             "hosts": {
                 "pretty_name": "Hosts",
                 "value": self.get_host_capacity(site_name),
             },
             "cpus": {"pretty_name": "CPUs", "value": self.get_cpu_capacity(site_name)},
-            "cores_available": {
-                "pretty_name": "Cores Available",
-                "value": self.get_core_available(site_name),
-            },
-            "cores_capacity": {
-                "pretty_name": "Cores Capacity",
-                "value": self.get_core_capacity(site_name),
-            },
-            "cores_allocated": {
-                "pretty_name": "Cores Allocated",
-                "value": self.get_core_capacity(site_name)
-                - self.get_core_available(site_name),
-            },
-            "ram_available": {
-                "pretty_name": "RAM Available",
-                "value": self.get_ram_available(site_name),
-            },
-            "ram_capacity": {
-                "pretty_name": "RAM Capacity",
-                "value": self.get_ram_capacity(site_name),
-            },
-            "ram_allocated": {
-                "pretty_name": "RAM Allocated",
-                "value": self.get_ram_capacity(site_name)
-                - self.get_ram_available(site_name),
-            },
-            "disk_available": {
-                "pretty_name": "Disk Available",
-                "value": self.get_disk_available(site_name),
-            },
-            "disk_capacity": {
-                "pretty_name": "Disk Capacity",
-                "value": self.get_disk_capacity(site_name),
-            },
-            "disk_allocated": {
-                "pretty_name": "Disk Allocated",
-                "value": self.get_disk_capacity(site_name)
-                - self.get_disk_available(site_name),
-            },
-            "nic_basic_available": {
-                "pretty_name": "Basic NIC Available",
-                "value": self.get_component_available(
-                    site_name, "SharedNIC-ConnectX-6"
-                ),
-            },
-            "nic_basic_capacity": {
-                "pretty_name": "Basic NIC Capacity",
-                "value": self.get_component_capacity(site_name, "SharedNIC-ConnectX-6"),
-            },
-            "nic_basic_allocated": {
-                "pretty_name": "Basic NIC Allocated",
-                "value": self.get_component_capacity(site_name, "SharedNIC-ConnectX-6")
-                - self.get_component_available(site_name, "SharedNIC-ConnectX-6"),
-            },
-            "nic_connectx_6_available": {
-                "pretty_name": "ConnectX-6 Available",
-                "value": self.get_component_available(site_name, "SmartNIC-ConnectX-6"),
-            },
-            "nic_connectx_6_capacity": {
-                "pretty_name": "ConnectX-6 Capacity",
-                "value": self.get_component_capacity(site_name, "SmartNIC-ConnectX-6"),
-            },
-            "nic_connectx_6_allocated": {
-                "pretty_name": "ConnectX-6 Allocated",
-                "value": self.get_component_capacity(site_name, "SmartNIC-ConnectX-6")
-                - self.get_component_available(site_name, "SmartNIC-ConnectX-6"),
-            },
-            "nic_connectx_5_available": {
-                "pretty_name": "ConnectX-5 Available",
-                "value": self.get_component_available(site_name, "SmartNIC-ConnectX-5"),
-            },
-            "nic_connectx_5_capacity": {
-                "pretty_name": "ConnectX-5 Capacity",
-                "value": self.get_component_capacity(site_name, "SmartNIC-ConnectX-5"),
-            },
-            "nic_connectx_5_allocated": {
-                "pretty_name": "ConnectX-5 Allocated",
-                "value": self.get_component_capacity(site_name, "SmartNIC-ConnectX-5")
-                - self.get_component_available(site_name, "SmartNIC-ConnectX-5"),
-            },
-            "nvme_available": {
-                "pretty_name": "NVMe Available",
-                "value": self.get_component_available(site_name, "NVME-P4510"),
-            },
-            "nvme_capacity": {
-                "pretty_name": "NVMe Capacity",
-                "value": self.get_component_capacity(site_name, "NVME-P4510"),
-            },
-            "nvme_allocated": {
-                "pretty_name": "NVMe Allocated",
-                "value": self.get_component_capacity(site_name, "NVME-P4510")
-                - self.get_component_available(site_name, "NVME-P4510"),
-            },
-            "tesla_t4_available": {
-                "pretty_name": "Tesla T4 Available",
-                "value": self.get_component_available(site_name, "GPU-Tesla T4"),
-            },
-            "tesla_t4_capacity": {
-                "pretty_name": "Tesla T4 Capacity",
-                "value": self.get_component_capacity(site_name, "GPU-Tesla T4"),
-            },
-            "tesla_t4_allocated": {
-                "pretty_name": "Tesla T4 Allocated",
-                "value": self.get_component_capacity(site_name, "GPU-Tesla T4")
-                - self.get_component_available(site_name, "GPU-Tesla T4"),
-            },
-            "rtx6000_available": {
-                "pretty_name": "RTX6000 Available",
-                "value": self.get_component_available(site_name, "GPU-RTX6000"),
-            },
-            "rtx6000_capacity": {
-                "pretty_name": "RTX6000 Capacity",
-                "value": self.get_component_capacity(site_name, "GPU-RTX6000"),
-            },
-            "rtx6000_allocated": {
-                "pretty_name": "RTX6000 Allocated",
-                "value": self.get_component_capacity(site_name, "GPU-RTX6000")
-                - self.get_component_available(site_name, "GPU-RTX6000"),
-            },
-            "a30_available": {
-                "pretty_name": "A30 Available",
-                "value": self.get_component_available(site_name, "GPU-A30"),
-            },
-            "a30_capacity": {
-                "pretty_name": "A30 Capacity",
-                "value": self.get_component_capacity(site_name, "GPU-A30"),
-            },
-            "a30_allocated": {
-                "pretty_name": "A30 Allocated",
-                "value": self.get_component_capacity(site_name, "GPU-A30")
-                - self.get_component_available(site_name, "GPU-A30"),
-            },
-            "a40_available": {
-                "pretty_name": "A40 Available",
-                "value": self.get_component_available(site_name, "GPU-A40"),
-            },
-            "a40_capacity": {
-                "pretty_name": "A40 Capacity",
-                "value": self.get_component_capacity(site_name, "GPU-A40"),
-            },
-            "a40_allocated": {
-                "pretty_name": "A40 Allocated",
-                "value": self.get_component_capacity(site_name, "GPU-A40")
-                - self.get_component_available(site_name, "GPU-A40"),
-            },
-            "fpga_u280_available": {
-                "pretty_name": "FPGA U280 Available",
-                "value": self.get_component_available(site_name, "FPGA-Xilinx-U280"),
-            },
-            "fpga_u280_capacity": {
-                "pretty_name": "FPGA U280 Capacity",
-                "value": self.get_component_capacity(site_name, "FPGA-Xilinx-U280"),
-            },
-            "fpga_u280_allocated": {
-                "pretty_name": "FPGA U280 Allocated",
-                "value": self.get_component_capacity(site_name, "FPGA-Xilinx-U280")
-                - self.get_component_available(site_name, "FPGA-Xilinx-U280"),
-            },
         }
+
+        for comp_model_name, names in self.component_name_mappings.items():
+            capacity = components.get(comp_model_name, {}).get(self.CAPACITIES, 0)
+            allocated = components.get(comp_model_name, {}).get(self.ALLOCATED, 0)
+            available = capacity - allocated
+
+            d[f"{names.get(self.NON_PRETTY_NAME)}_available"] = {
+                "pretty_name": f"{names.get(self.PRETTY_NAME)} Available",
+                "value": available,
+            }
+            d[f"{names.get(self.NON_PRETTY_NAME)}_capacity"] = {
+                "pretty_name": f"{names.get(self.PRETTY_NAME)} Capacity",
+                "value": capacity,
+            }
+            d[f"{names.get(self.NON_PRETTY_NAME)}_allocated"] = {
+                "pretty_name": f"{names.get(self.PRETTY_NAME)} Allocated",
+                "value": allocated,
+            }
+
+        return d
 
     def list_sites(
         self,

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -255,7 +255,6 @@ class Resources:
         :type site: String
         """
         try:
-            traceback.print_stack()
             from fim.graph.abc_property_graph import ABCPropertyGraph
             if isinstance(site, str):
                 site = self.get_topology_site(site)
@@ -295,7 +294,7 @@ class Resources:
             nodes = self.get_nodes(site=site)
             if nodes:
                 for w in nodes.values():
-                    component_capacity += w.components[component_model_name].unit
+                    component_capacity += w.components[component_model_name].capacities.unit
         except Exception as e:
             logging.error(f"Failed to get {component_model_name} capacity {site}: {e}")
         return component_capacity

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -2614,9 +2614,12 @@ class Slice:
         else:
             return True
 
-    def validate(self) -> Tuple[bool, Dict[str, str]]:
+    def validate(self, raise_exception: bool = True) -> Tuple[bool, Dict[str, str]]:
         """
         Validate the slice w.r.t available resources before submission
+
+        :param raise_exception: raise exception if validation fails
+        :type raise_exception: bool
 
         :return: Tuple indicating status for validation and dictionary of the errors corresponding to
                  each requested node
@@ -2629,5 +2632,10 @@ class Slice:
                 node=n, allocated=allocated
             )
             if not status:
-                errors[n.get_name()] = error
+                if raise_exception:
+                    print(f"{n.get_name()}: {error}")
+                else:
+                    errors[n.get_name()] = error
+        if raise_exception:
+            raise Exception("Slice validation failed!")
         return len(errors) == 0, errors

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1147,9 +1147,7 @@ class Slice:
                 node.delete()
                 node = None
                 if raise_exception:
-                    raise ValueError(
-                        f"{name} cannot be allocated as requested on site: {site}. Reason: {error}"
-                    )
+                    raise ValueError(error)
         return node
 
     def get_object_by_reservation(
@@ -2654,12 +2652,9 @@ class Slice:
             )
             if not status:
                 nodes_to_remove.append(n)
-                if raise_exception:
-                    print(f"{n.get_name()}: {error}")
-                else:
-                    errors[n.get_name()] = error
+                errors[n.get_name()] = error
         for n in nodes_to_remove:
             n.delete()
         if raise_exception and len(errors):
-            raise Exception("Slice validation failed!")
+            raise Exception(f"Slice validation failed - {errors}!")
         return len(errors) == 0, errors

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -56,7 +56,7 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple
 
 import pandas as pd
 from fss_utils.sshkey import FABRICSSHKey
@@ -2601,7 +2601,11 @@ class Slice:
         else:
             return True
 
-    def validate(self):
+    def validate(self) -> Tuple[bool, List[str]]:
         allocated = {}
+        errors = []
         for n in self.get_nodes():
-            self.get_fablib_manager().validate_node(node=n, allocated=allocated)
+            status, error = self.get_fablib_manager().validate_node(node=n, allocated=allocated)
+            if not status:
+                errors.append(error)
+        return len(errors) == 0, errors

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1062,6 +1062,7 @@ class Slice:
         host: str = None,
         user_data: dict = {},
         avoid: List[str] = [],
+        check: bool = True, remove: bool = True
     ) -> Node:
         """
         Creates a new node on this fablib slice.
@@ -1108,7 +1109,7 @@ class Slice:
         :return: a new node
         :rtype: Node
         """
-        node = Node.new_node(slice=self, name=name, site=site, avoid=avoid)
+        node = Node.new_node(slice=self, name=name, site=site, avoid=avoid, check=check, remove=remove)
 
         node.init_fablib_data()
 

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1133,8 +1133,9 @@ class Slice:
         self.interfaces = None
 
         if check:
-            if self.get_fablib_manager().validate(node=node):
+            if not self.get_fablib_manager().validate(node=node):
                 if remove:
+                    print(f"Removing: {node.get_name()} from the topology!")
                     node.delete()
                 else:
                     raise ValueError("Node cannot be added")

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1133,15 +1133,15 @@ class Slice:
         self.interfaces = None
 
         if check:
-            status, error = self.get_fablib_manager().validate(node=node)
+            status, error = self.get_fablib_manager().validate_node(node=node)
             if not status:
                 if remove:
-                    print(f"{node.get_name()} removed from the topology with reason: {error}!")
+                    print(f"{node.get_name()} removed from the topology. Reason: {error}!")
                     node.delete()
                     node = None
                 else:
                     raise ValueError(f"{node.get_name()} cannot be allocated as requested on site: "
-                                     f"{node.get_site()}, reason: {error}")
+                                     f"{node.get_site()}. Reason: {error}")
         return node
 
     def get_object_by_reservation(
@@ -2600,3 +2600,8 @@ class Slice:
             return False
         else:
             return True
+
+    def validate(self):
+        allocated = {}
+        for n in self.get_nodes():
+            self.get_fablib_manager().validate_node(node=n, allocated=allocated)

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1062,7 +1062,8 @@ class Slice:
         host: str = None,
         user_data: dict = {},
         avoid: List[str] = [],
-        check: bool = True, remove: bool = True
+        check: bool = False,
+        remove: bool = True
     ) -> Node:
         """
         Creates a new node on this fablib slice.
@@ -1105,6 +1106,12 @@ class Slice:
         :param avoid: (Optional) A list of sites to avoid is allowing
             random site.
         :type avoid: List[String]
+
+        :param check: Validate node can be allocated w.r.t available resources
+        :type check: bool
+
+        :param remove: Remove the node if validation w.r.t available resources fails
+        :type remove: bool
 
         :return: a new node
         :rtype: Node
@@ -2601,11 +2608,18 @@ class Slice:
         else:
             return True
 
-    def validate(self) -> Tuple[bool, List[str]]:
+    def validate(self) -> Tuple[bool, Dict[str, str]]:
+        """
+        Validate the slice w.r.t available resources before submission
+
+        :return: Tuple indicating status for validation and dictionary of the errors corresponding to
+                 each requested node
+        :rtype: Tuple[bool, Dict[str, str]]
+        """
         allocated = {}
-        errors = []
+        errors = {}
         for n in self.get_nodes():
             status, error = self.get_fablib_manager().validate_node(node=n, allocated=allocated)
             if not status:
-                errors.append(error)
+                errors[n.get_name()] = error
         return len(errors) == 0, errors

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1132,6 +1132,12 @@ class Slice:
         self.nodes = None
         self.interfaces = None
 
+        if check:
+            if self.get_fablib_manager().validate(node=node):
+                if remove:
+                    node.delete()
+                else:
+                    raise ValueError("Node cannot be added")
         return node
 
     def get_object_by_reservation(

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1146,6 +1146,7 @@ class Slice:
             if not status:
                 node.delete()
                 node = None
+                logging.warning(error)
                 if raise_exception:
                     raise ValueError(error)
         return node
@@ -2653,6 +2654,7 @@ class Slice:
             if not status:
                 nodes_to_remove.append(n)
                 errors[n.get_name()] = error
+                logging.warning(f"{n.get_name()} - {error}")
         for n in nodes_to_remove:
             n.delete()
         if raise_exception and len(errors):

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1133,12 +1133,15 @@ class Slice:
         self.interfaces = None
 
         if check:
-            if not self.get_fablib_manager().validate(node=node):
+            status, error = self.get_fablib_manager().validate(node=node)
+            if not status:
                 if remove:
-                    print(f"Removing: {node.get_name()} from the topology!")
+                    print(f"{node.get_name()} removed from the topology with reason: {error}!")
                     node.delete()
+                    node = None
                 else:
-                    raise ValueError("Node cannot be added")
+                    raise ValueError(f"{node.get_name()} cannot be allocated as requested on site: "
+                                     f"{node.get_site()}, reason: {error}")
         return node
 
     def get_object_by_reservation(

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -2010,7 +2010,7 @@ class Slice:
         :type progress: bool
 
         :param wait_jupyter: Special wait for jupyter notebooks.
-        :type wait_jupyter: bool
+        :type wait_jupyter: str
 
         :param post_boot_config:
         :type post_boot_config: bool

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1063,7 +1063,7 @@ class Slice:
         user_data: dict = {},
         avoid: List[str] = [],
         check: bool = False,
-        remove: bool = True
+        remove: bool = True,
     ) -> Node:
         """
         Creates a new node on this fablib slice.
@@ -1116,7 +1116,9 @@ class Slice:
         :return: a new node
         :rtype: Node
         """
-        node = Node.new_node(slice=self, name=name, site=site, avoid=avoid, check=check, remove=remove)
+        node = Node.new_node(
+            slice=self, name=name, site=site, avoid=avoid, check=check, remove=remove
+        )
 
         node.init_fablib_data()
 
@@ -1143,12 +1145,16 @@ class Slice:
             status, error = self.get_fablib_manager().validate_node(node=node)
             if not status:
                 if remove:
-                    print(f"{node.get_name()} removed from the topology. Reason: {error}!")
+                    print(
+                        f"{node.get_name()} removed from the topology. Reason: {error}!"
+                    )
                     node.delete()
                     node = None
                 else:
-                    raise ValueError(f"{node.get_name()} cannot be allocated as requested on site: "
-                                     f"{node.get_site()}. Reason: {error}")
+                    raise ValueError(
+                        f"{node.get_name()} cannot be allocated as requested on site: "
+                        f"{node.get_site()}. Reason: {error}"
+                    )
         return node
 
     def get_object_by_reservation(
@@ -2619,7 +2625,9 @@ class Slice:
         allocated = {}
         errors = {}
         for n in self.get_nodes():
-            status, error = self.get_fablib_manager().validate_node(node=n, allocated=allocated)
+            status, error = self.get_fablib_manager().validate_node(
+                node=n, allocated=allocated
+            )
             if not status:
                 errors[n.get_name()] = error
         return len(errors) == 0, errors


### PR DESCRIPTION
- Added validation to `add_node` and `add_component` to check if the requested node/component is feasible to provision based on available resources on the requested site. This check can be performed as nodes/components are added. By default, it is disabled for backward compatibility and due performance hit caused by `list_resources`. Check can be considered to be enabled by default in `1.7` if needed once perf improvements for `list_resources`

- Added `slice.validate()` call to check the slice at the end. Users can invoke this explicitly to verify if their configuration is a valid config.

**Code Snippet for Usage:**
**- Enable validation as nodes/components are added**
```
# Create a slice
slice = fablib.new_slice(name="MySlice")

# Add a node
node1 = slice.add_node(name="Node1", site="RENC", host="uky-w1.fabric-testbed.net", check=True)
# Here node1 is invalid request would be errored and removed from the slice

node2 = slice.add_node(name="Node2", site="RENC", check=True)
node2.add_component(model='NIC_Basic', name='nic2')
node2.add_component(model='GPU_RTX6000', name='gpu1')
node2.add_component(model='GPU_TeslaT4', name='gpu3')
# Here node2 is invalid request as you can not have T4 and RTX600 both on a single worker
```
**- Validate a slice**
```
# Create a slice
slice = fablib.new_slice(name="MySlice")

# Add a node
node1 = slice.add_node(name="Node1", site="RENC", host="uky-w1.fabric-testbed.net")
# Here node1 is invalid request would be errored and removed from the slice

node2 = slice.add_node(name="Node2", site="RENC")
node2.add_component(model='NIC_Basic', name='nic2')
node2.add_component(model='GPU_RTX6000', name='gpu1')
node2.add_component(model='GPU_TeslaT4', name='gpu3')
# Here node2 is invalid request as you can not have T4 and RTX600 both on a single worker

# This call will report both the errors identified above
slice.validate()
```