### PR TITLE
Add some deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 ### Fixed
+- Emit deprecation warnings from deprecated methods (Issue
+  [#239](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/239))
 - Add Facility Port to allow adding multiple interfaces (Issue [#289](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/289))
 - validate_config errors out when config directory does not exist (Issue [#299](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/299)
 - create_ssh_config adds extra indentation (Issue [#300](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/300)

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -340,8 +340,6 @@ class Interface:
     @deprecated(version="1.3.2", reason="Use get_device_name() instead.")
     def get_os_interface(self) -> str:
         """
-        Deprecated: see interface.get_device_name()
-
         Gets a name of the interface the operating system uses for this
         FABLib interface.
 

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -36,6 +36,7 @@ from ipaddress import IPv4Address
 from typing import TYPE_CHECKING, Any, Union
 
 import jinja2
+from deprecated.sphinx import deprecated
 from fabrictestbed.slice_editor import Flags
 from tabulate import tabulate
 
@@ -336,6 +337,7 @@ class Interface:
 
         return os_iface
 
+    @deprecated(version="1.3.2", reason="Use get_device_name() instead.")
     def get_os_interface(self) -> str:
         """
         Deprecated: see interface.get_device_name()

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -60,6 +60,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 import jinja2
 import paramiko
+from deprecated.sphinx import deprecated
 from fabric_cf.orchestrator.orchestrator_proxy import Status
 from IPython.core.display_functions import display
 from tabulate import tabulate
@@ -2550,6 +2551,7 @@ class Node:
             logging.warning(f"Failed to down link: {e}")
             raise e
 
+    @deprecated(version="1.1.3")
     def set_ip_os_interface(
         self,
         os_iface: str = None,
@@ -2558,9 +2560,6 @@ class Node:
         cidr: str = None,
         mtu: str = None,
     ):
-        """
-        .. deprecated:: 1.1.3.
-        """
         # TODO: Add docstring after doc networking classes
         if cidr:
             cidr = str(cidr)
@@ -2649,6 +2648,7 @@ class Node:
         command = f"sudo ip link del link {link} name {os_iface}"
         stdout, stderr = self.execute(command, quiet=True)
 
+    @deprecated(version="1.1.3")
     def add_vlan_os_interface(
         self,
         os_iface: str = None,
@@ -2658,9 +2658,6 @@ class Node:
         mtu: str = None,
         interface: str = None,
     ):
-        """
-        .. deprecated:: 1.1.3.
-        """
         # TODO: Add docstring after doc networking classes
 
         if vlan:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "numpy",
     "ipython>=8.12.0",
     "fabric_fss_utils>=1.5.1",
-    "atomicwrites"
+    "atomicwrites",
+    "deprecated>=1.2.14",
     ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "ipython>=8.12.0",
     "fabric_fss_utils>=1.5.1",
     "atomicwrites",
-    "deprecated>=1.2.14",
+    "deprecated",
     ]
 
 classifiers = [

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# Copyright (c) 2024 FABRIC Testbed
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import unittest
+
+from fabrictestbed_extensions.fablib.interface import Interface
+from fabrictestbed_extensions.fablib.node import Node
+
+
+class FablibDeprecationTests(unittest.TestCase):
+    """
+    Test that deprecation warnings are emitted.
+    """
+
+    def test_interface_deprecations(self):
+        """
+        Test DeprecationWarnings from Interface module.
+        """
+        with self.assertWarns(DeprecationWarning):
+            Interface().get_os_interface()
+
+    def test_node_deprecations(self):
+        """
+        Test DeprecationWarnings from Node module.
+        """
+        with self.assertWarns(DeprecationWarning):
+            try:
+                Node(slice=None, node=None).set_ip_os_interface()
+            except Exception:
+                pass
+
+        with self.assertWarns(DeprecationWarning):
+            try:
+                Node(slice=None, node=None).add_vlan_os_interface()
+            except Exception:
+                pass


### PR DESCRIPTION
Resolves #293.  Changes: 

- Uses `@deprecated` decorator from [deprecated](https://deprecated.readthedocs.io/en/latest/api.html) library. This is a small library with a single dependency, and the ability to add deprecation notices to Sphinx-generated docs is a fairly good justification for adding a dependency.
- Adds a couple of unit tests.