### PR TITLE
293.remove usage of deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Unreleased
 
 ### Fixed
+- Avoid use of deprecated methods internally (Issue
+  [#239](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/239))
 - Emit deprecation warnings from deprecated methods (Issue
   [#239](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/239))
 - Add Facility Port to allow adding multiple interfaces (Issue [#289](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/289))

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -259,32 +259,6 @@ class Component:
             fields=fields, output=output, quiet=quiet, filter_function=filter_function
         )
 
-    # def list_interfaces(self) -> List[str]:
-    #     """
-    #     Creates a tabulated string describing all components in the slice.
-    #
-    #     Intended for printing a list of all components.
-    #
-    #     :return: Tabulated srting of all components information
-    #     :rtype: String
-    #     """
-    #     table = []
-    #     for iface in self.get_interfaces():
-    #         network_name = ""
-    #         if iface.get_network():
-    #             network_name = iface.get_network().get_name()
-    #
-    #         table.append( [     iface.get_name(),
-    #                             network_name,
-    #                             iface.get_bandwidth(),
-    #                             iface.get_vlan(),
-    #                             iface.get_mac(),
-    #                             iface.get_physical_os_interface_name(),
-    #                             iface.get_os_interface(),
-    #                             ] )
-    #
-    #     return tabulate(table, headers=["Name", "Network", "Bandwidth", "VLAN", "MAC", "Physical OS Interface", "OS Interface" ])
-
     @staticmethod
     def calculate_name(node: Node = None, name: str = None) -> str:
         """

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -112,7 +112,7 @@ class Interface:
             ["VLAN", self.get_vlan()],
             ["MAC", self.get_mac()],
             ["Physical Device", self.get_physical_os_interface_name()],
-            ["Device", self.get_os_interface()],
+            ["Device", self.get_device_name()],
             ["Address", self.get_ip_addr()],
             ["Numa Node", self.get_numa_node()],
         ]
@@ -178,7 +178,7 @@ class Interface:
         if self.get_node() and str(self.get_node().get_reservation_state()) == "Active":
             mac = str(self.get_mac())
             physical_dev = str(self.get_physical_os_interface_name())
-            dev = str(self.get_os_interface())
+            dev = str(self.get_device_name())
             ip_addr = str(self.get_ip_addr())
         else:
             mac = ""
@@ -719,7 +719,7 @@ class Interface:
 
             links = json.loads(stdout)
 
-            dev = self.get_os_interface()
+            dev = self.get_device_name()
             if dev == None:
                 return links
 
@@ -733,7 +733,7 @@ class Interface:
     def get_ip_addr_show(self, dev=None):
         try:
             if not dev:
-                dev = self.get_os_interface()
+                dev = self.get_device_name()
 
             stdout, stderr = self.get_node().execute(
                 f"ip -j addr show {dev}", quiet=True
@@ -757,7 +757,7 @@ class Interface:
 
             addrs = json.loads(stdout)
 
-            dev = self.get_os_interface()
+            dev = self.get_device_name()
             # print(f"dev: {dev}")
 
             if dev is None:
@@ -782,7 +782,7 @@ class Interface:
         """
         return_ips = []
         try:
-            dev = self.get_os_interface()
+            dev = self.get_device_name()
 
             ip_addr = self.get_ip_addr()
 

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -382,9 +382,7 @@ class Slice:
                 iface.get_physical_os_interface_name
             )
 
-            logging.info(
-                f"Starting get get_device_name for iface {iface.get_name()} "
-            )
+            logging.info(f"Starting get get_device_name for iface {iface.get_name()} ")
             os_interface_threads[iface.get_name()] = executor.submit(
                 iface.get_device_name
             )

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -383,7 +383,7 @@ class Slice:
             )
 
             logging.info(
-                f"Starting get get_os_interface_threads for iface {iface.get_name()} "
+                f"Starting get get_device_name for iface {iface.get_name()} "
             )
             os_interface_threads[iface.get_name()] = executor.submit(
                 iface.get_device_name


### PR DESCRIPTION
Follow-up to #306, which added deprecation warnings to three methods, but we've been calling those allegedly deprecated methods internally. I failed to check for those usages, so I'm going around looking for where we've been using them. 

1. [`Interface.get_os_interface()`](https://github.com/fabric-testbed/fabrictestbed-extensions/blob/47df32e2e681305741e4d0cdc6bfc7bb68a36315/fabrictestbed_extensions/fablib/interface.py#L341), which has a simple replacement in `get_device_name()`, so I replaced all calls accordingly.  Haven't actually tested this from a notebook, because I'm unsure what the replacements for the other two should be.

2. [`Node.set_ip_os_interface()`](https://github.com/fabric-testbed/fabrictestbed-extensions/blob/47df32e2e681305741e4d0cdc6bfc7bb68a36315/fabrictestbed_extensions/fablib/node.py#L2555) is called by [`Interface.set_ip()`](https://github.com/fabric-testbed/fabrictestbed-extensions/blob/47df32e2e681305741e4d0cdc6bfc7bb68a36315/fabrictestbed_extensions/fablib/interface.py#L444), which itself should be deprecated.  I did not catch it in the previous pass because of the typo in comment ("Depricated" instead of "deprecated"), and I'm not sure what should replace either of these methods.

3. [`Node.add_vlan_os_interface()`](https://github.com/fabric-testbed/fabrictestbed-extensions/blob/47df32e2e681305741e4d0cdc6bfc7bb68a36315/fabrictestbed_extensions/fablib/node.py#L2555) is called by [`Interface.config_vlan_interface()`](https://github.com/fabric-testbed/fabrictestbed-extensions/blob/47df32e2e681305741e4d0cdc6bfc7bb68a36315/fabrictestbed_extensions/fablib/interface.py#L433) (which is not intended for API use), which is called by [`Slice.post_boot_config()`](https://github.com/fabric-testbed/fabrictestbed-extensions/blob/47df32e2e681305741e4d0cdc6bfc7bb68a36315/fabrictestbed_extensions/fablib/slice.py#L1672).  Again, I'm not sure what should replace `Node.add_vlan_os_interface()`.

Help, @kthare10 and @paul-ruth? :-)
