### PR TITLE
Update black

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install black==23.* isort==5.*
+          python -m pip install black==24.* isort==5.*
 
       - name: Run "black --check"
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,13 @@ $ pip install -e .[test]
 $ pytest -s tests/integration/test_hello_fabric.py
 ```
 
+If you want to format code with [black] and [isort]:
+
+```
+$ tox -e format
+```
+
+
 ## Documenting FABlib
 
 FABlib uses Sphinx to generate API documentation from Python

--- a/fabrictestbed_extensions/editors/geo_topology_editor.py
+++ b/fabrictestbed_extensions/editors/geo_topology_editor.py
@@ -1460,9 +1460,9 @@ class GeoTopologyEditor(AbcTopologyEditor):
             self.current_node = node
 
             self.dashboards["node_dashboard"]["node_name_widget"].value = node_name
-            self.dashboards["node_dashboard"][
-                "site_name_widget"
-            ].value = node.get_property(pname="site")
+            self.dashboards["node_dashboard"]["site_name_widget"].value = (
+                node.get_property(pname="site")
+            )
             self.dashboards["node_dashboard"]["core_slider"].value = int(
                 self.get_capacity_value(node, "core")
             )
@@ -1475,9 +1475,9 @@ class GeoTopologyEditor(AbcTopologyEditor):
             self.dashboards["node_dashboard"]["image_widget"].value = node.get_property(
                 pname="image_ref"
             )
-            self.dashboards["node_dashboard"][
-                "image_type_widget"
-            ].value = node.get_property(pname="image_type")
+            self.dashboards["node_dashboard"]["image_type_widget"].value = (
+                node.get_property(pname="image_type")
+            )
 
             # TODO: LOAD Components
 

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1200,9 +1200,9 @@ class Slice:
             notices[node.get_reservation_id()] = node.get_error_message()
 
         for network_service in self.get_network_services():
-            notices[
-                network_service.get_reservation_id()
-            ] = network_service.get_error_message()
+            notices[network_service.get_reservation_id()] = (
+                network_service.get_error_message()
+            )
 
         for component in self.get_components():
             notices[component.get_reservation_id()] = component.get_error_message()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,6 @@ test = [
 branch = true
 omit = ["fabrictestbed_extensions/tests/*"]
 
-[tool.black]
-src_paths = ["fabrictestbed_extensions", "docs/source/conf.py", "tests"]
-
 [tool.isort]
 profile = "black"
 src_paths = ["fabrictestbed_extensions", "docs/source/conf.py", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ doc = [
   "furo"
 ]
 test = [
-  "black==23.*",
+  "black==24.*",
   "isort==5.*",
   "tox==4.*",
   "pytest",

--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,15 @@ deps =
 
 commands =
     sphinx-build -W -b html {toxinidir}/docs/source/ {toxinidir}/docs/build/html
+
+[testenv:format]
+# An environment for formatting code.
+deps =
+    black==24.*
+    isort==5.*
+
+skip_install = True
+
+commands =
+    black fabrictestbed_extensions tests
+    isort fabrictestbed_extensions tests


### PR DESCRIPTION
Minor housekeeping stuff: the new major version of black has been out for a while. Let us not get stuck with the old one.

Changes:

- Updates dependencies and CI checks to use black 24.*.
- Re-formats code with the new black.
- Adds a tox environment so that we can run `tox -e format` to run black and isort.