### PR TITLE
Add missing docstrings to `node` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - create_ssh_config adds extra indentation (Issue [#300](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/300))
 - Remove duplicate Node.delete() method (Issue [#321](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/321))
 
+## Added
+- Missing docstrings in node module (Issue [#318](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/318))
+
 ## [1.6.4] - 2024-03-05
 
 ### Fixed

--- a/docs/source/node.rst
+++ b/docs/source/node.rst
@@ -6,4 +6,5 @@ node
 
 .. autoclass:: fabrictestbed_extensions.fablib.node.Node
    :members:
+   :no-index:
    :special-members: __str__

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -676,27 +676,30 @@ class FablibManager(Config):
 
     def validate_config(self):
         """
-        Validate and create Fablib config - checks if all the required configuration exists for slice
-        provisioning to work successfully
+        Validate and create Fablib config - checks if all the required
+        configuration exists for slice provisioning to work
+        successfully
 
-        - Checks Credential Manager Host is configured properly
+            - Checks Credential Manager Host is configured properly
 
-        - Checks Orchestrator Host is configured properly
+            - Checks Orchestrator Host is configured properly
 
-        - Checks Core API Host is configured properly
+            - Checks Core API Host is configured properly
 
-        - Checks Bastion Host is configured properly
+            - Checks Bastion Host is configured properly
 
-        - Check Sliver keys exist; create sliver keys if they do not exist
+            - Check Sliver keys exist; create sliver keys if they do
+              not exist
 
-        - Check Bastion keys exist and are not expired; update/create bastion keys if expired or do not exist
+            - Check Bastion keys exist and are not expired;
+              update/create bastion keys if expired or do not exist
 
-        - Check Bastion Username is configured
+            - Check Bastion Username is configured
 
-        - Check Project Id is configured
+            - Check Project Id is configured
 
-        .. deprecated:: 1.6.5
-           Use `verify_and_configure()` instead.
+        .. deprecated:: 1.6.5 Use `verify_and_configure()` instead.
+
         @raises Exception if the configuration is invalid
         """
         warnings.warn(

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2780,6 +2780,11 @@ class Node:
             return {}
 
     def delete(self):
+        """
+        TODO: another delete()?
+
+        https://github.com/fabric-testbed/fabrictestbed-extensions/issues/321
+        """
         for component in self.get_components():
             component.delete()
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1217,6 +1217,16 @@ class Node:
     def get_paramiko_key(
         self, private_key_file: str = None, get_private_key_passphrase: str = None
     ) -> paramiko.PKey:
+        """
+        Get SSH pubkey for internal use.
+
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+
+        :return: an SSH pubkey.
+        :rtype: paramiko.PKey
+        """
         # TODO: This is a bit of a hack and should probably test he keys for their types
         # rather than relying on execptions
         if get_private_key_passphrase:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2775,9 +2775,7 @@ class Node:
 
     def delete(self):
         """
-        TODO: another delete()?
-
-        https://github.com/fabric-testbed/fabrictestbed-extensions/issues/321
+        Remove the node, including components connected to it.
         """
         for component in self.get_components():
             component.delete()

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2939,12 +2939,22 @@ class Node:
             return []
 
     def get_routes(self):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         try:
             return self.get_fablib_data()["routes"]
         except Exception as e:
             return []
 
     def config_routes(self):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         routes = self.get_routes()
 
         for route in routes:
@@ -2970,6 +2980,11 @@ class Node:
             self.ip_route_add(subnet=ipaddress.ip_network(subnet), gateway=next_hop)
 
     def run_post_boot_tasks(self, log_dir: str = "."):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         logging.debug(f"run_post_boot_tasks: {self.get_name()}")
         fablib_data = self.get_fablib_data()
         if "post_boot_tasks" in fablib_data:
@@ -3004,6 +3019,11 @@ class Node:
                 logging.error(f"Invalid post boot command: {command}")
 
     def run_post_update_commands(self, log_dir: str = "."):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         fablib_data = self.get_fablib_data()
         if "post_update_commands" in fablib_data:
             commands = fablib_data["post_update_commands"]
@@ -3016,6 +3036,11 @@ class Node:
             )
 
     def is_instantiated(self):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         fablib_data = self.get_fablib_data()
         if "instantiated" not in fablib_data:
             logging.debug(
@@ -3035,11 +3060,21 @@ class Node:
             return False
 
     def set_instantiated(self, instantiated: bool = True):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         fablib_data = self.get_fablib_data()
         fablib_data["instantiated"] = str(instantiated)
         self.set_fablib_data(fablib_data)
 
     def run_update_commands(self):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         fablib_data = self.get_fablib_data()
         if fablib_data["run_update_commands"] == "True":
             return True

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -331,6 +331,9 @@ class Node:
         return output_string
 
     def delete(self):
+        """
+        Remove the node.
+        """
         self.get_slice().get_fim_topology().remove_node(name=self.get_name())
 
     def show(

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3069,9 +3069,7 @@ class Node:
 
     def run_update_commands(self):
         """
-        .. warning::
-
-            This method is for fablib internal use, and will be made private in the future.
+        Returns `True` if `run_update_commands` flag is set.
         """
         fablib_data = self.get_fablib_data()
         if fablib_data["run_update_commands"] == "True":

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2981,9 +2981,10 @@ class Node:
 
     def run_post_boot_tasks(self, log_dir: str = "."):
         """
-        .. warning::
+        Run post-boot tasks.  Called by :py:meth:`config()`.
 
-            This method is for fablib internal use, and will be made private in the future.
+        Post-boot tasks are list of commands associated with
+        `post_boot_tasks` in fablib data.
         """
         logging.debug(f"run_post_boot_tasks: {self.get_name()}")
         fablib_data = self.get_fablib_data()

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3020,9 +3020,10 @@ class Node:
 
     def run_post_update_commands(self, log_dir: str = "."):
         """
-        .. warning::
+        Run post-update commands.  Called by :py:meth:`config()`.
 
-            This method is for fablib internal use, and will be made private in the future.
+        Post-update commands are list of commands associated with
+        `post_update_commands` in fablib data.
         """
         fablib_data = self.get_fablib_data()
         if "post_update_commands" in fablib_data:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2769,11 +2769,19 @@ class Node:
         return self.get_fim_node()
 
     def set_user_data(self, user_data: dict):
+        """
+        Set user data.
+
+        :param user_data: a `dict`.
+        """
         self.get_fim().set_property(
             pname="user_data", pval=UserData(json.dumps(user_data))
         )
 
     def get_user_data(self):
+        """
+        Get user data.
+        """
         try:
             return json.loads(str(self.get_fim().get_property(pname="user_data")))
         except:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1218,11 +1218,7 @@ class Node:
         self, private_key_file: str = None, get_private_key_passphrase: str = None
     ) -> paramiko.PKey:
         """
-        Get SSH pubkey for internal use.
-
-        .. warning::
-
-            This method is for fablib internal use, and will be made private in the future.
+        Get SSH pubkey, for internal use.
 
         :return: an SSH pubkey.
         :rtype: paramiko.PKey

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -662,6 +662,9 @@ class Node:
         )
 
     def get_networks(self):
+        """
+        Get a list of networks attached to the node.
+        """
         networks = []
         for interface in self.get_interfaces():
             networks.append(interface.get_network())

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3037,9 +3037,7 @@ class Node:
 
     def is_instantiated(self):
         """
-        .. warning::
-
-            This method is for fablib internal use, and will be made private in the future.
+        Returns `True` if the node has been instantiated.
         """
         fablib_data = self.get_fablib_data()
         if "instantiated" not in fablib_data:

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2766,6 +2766,9 @@ class Node:
         return Component.new_storage(node=self, name=name, auto_mount=auto_mount)
 
     def get_fim(self):
+        """
+        Get FABRIC Information Model (fim) object for the node.
+        """
         return self.get_fim_node()
 
     def set_user_data(self, user_data: dict):

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2790,9 +2790,7 @@ class Node:
 
     def init_fablib_data(self):
         """
-        .. warning::
-
-            This method is for fablib internal use, and will be made private in the future.
+        Initialize fablib data.  Called by :py:meth:`new_node()`.
         """
         fablib_data = {
             "instantiated": "False",
@@ -2804,9 +2802,7 @@ class Node:
 
     def get_fablib_data(self):
         """
-        .. warning::
-
-            This method is for fablib internal use, and will be made private in the future.
+        Get fablib data. Usually used internally.
         """
         try:
             return self.get_user_data()["fablib_data"]
@@ -2815,9 +2811,7 @@ class Node:
 
     def set_fablib_data(self, fablib_data: dict):
         """
-        .. warning::
-
-            This method is for fablib internal use, and will be made private in the future.
+        Set fablib data. Usually used internally.
         """
         user_data = self.get_user_data()
         user_data["fablib_data"] = fablib_data

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3059,9 +3059,7 @@ class Node:
 
     def set_instantiated(self, instantiated: bool = True):
         """
-        .. warning::
-
-            This method is for fablib internal use, and will be made private in the future.
+        Mark node as instantiated. Called by :py:meth:`config()`.
         """
         fablib_data = self.get_fablib_data()
         fablib_data["instantiated"] = str(instantiated)

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -233,6 +233,11 @@ class Node:
 
     @staticmethod
     def get_pretty_name_dict():
+        """
+        Return mappings from non-pretty names to pretty names.
+
+        Pretty names are in table headers.
+        """
         return {
             "id": "ID",
             "name": "Name",

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -2793,6 +2793,11 @@ class Node:
         self.get_slice().get_fim_topology().remove_node(name=self.get_name())
 
     def init_fablib_data(self):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         fablib_data = {
             "instantiated": "False",
             "run_update_commands": "False",
@@ -2802,12 +2807,22 @@ class Node:
         self.set_fablib_data(fablib_data)
 
     def get_fablib_data(self):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         try:
             return self.get_user_data()["fablib_data"]
         except:
             return {}
 
     def set_fablib_data(self, fablib_data: dict):
+        """
+        .. warning::
+
+            This method is for fablib internal use, and will be made private in the future.
+        """
         user_data = self.get_user_data()
         user_data["fablib_data"] = fablib_data
         self.set_user_data(user_data)

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -83,6 +83,10 @@ from fabrictestbed_extensions.fablib.interface import Interface
 
 
 class Node:
+    """
+    A class for working with FABRIC nodes.
+    """
+
     default_cores = 2
     default_ram = 8
     default_disk = 10

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -121,6 +121,9 @@ class Node:
         logging.getLogger("paramiko").setLevel(logging.WARNING)
 
     def get_fablib_manager(self):
+        """
+        Get a reference to :py:class:`.FablibManager`.
+        """
         return self.slice.get_fablib_manager()
 
     def __str__(self):

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3078,6 +3078,9 @@ class Node:
             return False
 
     def set_run_update_commands(self, run_update_commands: bool = True):
+        """
+        Set `run_update_commands` flag.
+        """
         fablib_data = self.get_fablib_data()
         fablib_data["run_update_commands"] = str(run_update_commands)
         self.set_fablib_data(fablib_data)

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -923,36 +923,51 @@ class Slice:
 
         L2 networks types include:
 
-        - L2Bridge: a local Ethernet on a single site with unlimited interfaces.
-        - L2STS: a wide-area Ethernet on exactly two sites with unlimited interfaces.
-            Includes best effort performance and cannot, yet, support Basic NICs
-            residing on a single physical.
-        - L2PTP: a wide-area Ethernet on exactly two sites with exactly two interfaces.
-            QoS performance guarantees (coming soon!). Does not support Basic NICs.
-            Traffic arrives with VLAN tag and requires the node OS to configure
-            a VLAN interface.
+            - L2Bridge: a local Ethernet on a single site with
+              unlimited interfaces.
 
-        If the type argument is not set, FABlib will automatically choose the
-        L2 network type for you. In most cases the automatic network type is
-        the one you want. You can force a specific network type by setting the
-        type parameter to "L2Bridge", "L2STS", or "L2PTP".
+            - L2STS: a wide-area Ethernet on exactly two sites with
+              unlimited interfaces.  Includes best effort performance
+              and cannot, yet, support Basic NICs residing on a single
+              physical.
 
-        An exception will be raised if the set interfaces is not compatible
-        with the specified network type or if there is not compatible network
-        type for the given interface list.
+            - L2PTP: a wide-area Ethernet on exactly two sites with
+              exactly two interfaces.  QoS performance guarantees
+              (coming soon!).  Does not support Basic NICs.  Traffic
+              arrives with VLAN tag and requires the node OS to
+              configure a VLAN interface.
+
+        If the type argument is not set, FABlib will automatically
+        choose the L2 network type for you.  In most cases the
+        automatic network type is the one you want.  You can force a
+        specific network type by setting the type parameter to
+        "L2Bridge", "L2STS", or "L2PTP".
+
+        An exception will be raised if the set interfaces is not
+        compatible with the specified network type or if there is not
+        compatible network type for the given interface list.
 
         :param name: the name of the network service
         :type name: String
-        :param interfaces: a list of interfaces to build the network with
+
+        :param interfaces: a list of interfaces to build the network
+            with
         :type interfaces: List[Interface]
-        :param type: optional L2 network type "L2Bridge", "L2STS", or "L2PTP"
+
+        :param type: optional L2 network type "L2Bridge", "L2STS", or
+            "L2PTP"
         :type type: String
+
         :param subnet:
         :type subnet: ipaddress
+
         :param gateway:
         :type gateway: ipaddress
+
         :param user_data
+
         :type user_data: dict
+
         :return: a new L2 network service
         :rtype: NetworkService
         """

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -996,40 +996,48 @@ class Slice:
 
         L3 networks types include:
 
-        - IPv4: An IPv4 network on the FABNetv4 internet
-        - IPv6: An IPv6 network on the FABNetv6 internet
+            - IPv4: An IPv4 network on the FABNetv4 internet
+
+            - IPv6: An IPv6 network on the FABNetv6 internet
 
         The FABNet networks are internal IP internets that span the
-        FABRIC testbed.  Adding a new L3 network to your FABRIC slice creates
-        an isolated network at a single site.  FABRIC issues each isolated
-        L3 network with an IP subnet (either IPv4 or IPv6) and a gateway used
-        to route traffic to the FABNet internet.
+        FABRIC testbed.  Adding a new L3 network to your FABRIC slice
+        creates an isolated network at a single site.  FABRIC issues
+        each isolated L3 network with an IP subnet (either IPv4 or
+        IPv6) and a gateway used to route traffic to the FABNet
+        internet.
 
-        Like the public Internet, all FABNet networks can send traffic to all
-        other FABnet networks of the same type. In other words, FABNet networks
-        can be used to communicate between your slices and slices owned by
-        other users.
+        Like the public Internet, all FABNet networks can send traffic
+        to all other FABnet networks of the same type.  In other
+        words, FABNet networks can be used to communicate between your
+        slices and slices owned by other users.
 
-        An exception will be raised if the set interfaces is not from a single
-        FABRIC site.  If you want to use L3 networks to connect slices that
-        are distributed across many site, you need to create a separate L3
-        network for each site.
+        An exception will be raised if the set interfaces is not from
+        a single FABRIC site.  If you want to use L3 networks to
+        connect slices that are distributed across many site, you need
+        to create a separate L3 network for each site.
 
-        It is important to note that by all nodes come with a default gateway
-        on a management network that use used to access your nodes (i.e. to
-        accept ssh connections).  To use an L3 dataplane network, you will need
-        to add routes to your nodes that selectively route traffic across the
-        new dataplane network. You must be careful to maintain the default
-        gateway settings if you want to be able to access the node using the
+        It is important to note that by all nodes come with a default
+        gateway on a management network that use used to access your
+        nodes (i.e. to accept ssh connections).  To use an L3
+        dataplane network, you will need to add routes to your nodes
+        that selectively route traffic across the new dataplane
+        network.  You must be careful to maintain the default gateway
+        settings if you want to be able to access the node using the
         management network.
 
         :param name: the name of the network service
         :type name: String
-        :param interfaces: a list of interfaces to build the network with
+
+        :param interfaces: a list of interfaces to build the network
+            with
         :type interfaces: List[Interface]
+
         :param type: L3 network type "IPv4" or "IPv6"
         :type type: String
+
         :param user_data
+
         :type user_data: dict
 
         :return: a new L3 network service


### PR DESCRIPTION
Addresses #318.  Adds some docstrings to `fablib.node.Node` methods.

I'm not familiar with the usage of  `Node.generate_template_context()`, `Node.get_template_context()`, and `Node.render_template()`, so leaving that out for a later round.

Also re-formats docstrings in `fablib` and `slice` modules so that `tox -e docs` will work. Tox `docs` environment is set up to treat warnings as errors.