### PR TITLE
Remove redundant `Node.delete()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Add Facility Port to allow adding multiple interfaces (Issue [#289](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/289))
-- validate_config errors out when config directory does not exist (Issue [#299](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/299)
-- create_ssh_config adds extra indentation (Issue [#300](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/300)
+- validate_config errors out when config directory does not exist (Issue [#299](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/299))
+- create_ssh_config adds extra indentation (Issue [#300](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/300))
 - Remove duplicate Node.delete() method (Issue [#321](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/321))
 
 ## [1.6.4] - 2024-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Facility Port to allow adding multiple interfaces (Issue [#289](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/289))
 - validate_config errors out when config directory does not exist (Issue [#299](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/299)
 - create_ssh_config adds extra indentation (Issue [#300](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/300)
+- Remove duplicate Node.delete() method (Issue [#321](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/321))
 
 ## [1.6.4] - 2024-03-05
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -322,9 +322,6 @@ class Node:
 
         return output_string
 
-    def delete(self):
-        self.get_slice().get_fim_topology().remove_node(name=self.get_name())
-
     def show(
         self, fields=None, output=None, quiet=False, colors=False, pretty_names=True
     ):


### PR DESCRIPTION
Resolves #321. Keeping the second `Node.delete()`, because I'm pretty sure the first one was never called.

Here's a quick test, since writing a whole test for the actual fablib code would be a chore: running the below snippet with `python test.py | uniq` only produces `delete #2`.  It appears that the second `delete()` method shadowed the first.

```python
class Test:
    def delete(self):
        print("delete #1")

    def delete(self):
        print("delete #2")

for i in range(1000):
    t = Test()
    t.delete()

t = Test()
for i in range(1000):
    t.delete()
```