### PR TITLE
bugfix: new slices not running post_boot_config() on submit

### DIFF
--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -2297,7 +2297,7 @@ class Slice:
                 else:
                     print("Running post boot config ... ", end="")
 
-            if advance_allocation and post_boot_config:
+            if not advance_allocation and post_boot_config:
                 self.post_boot_config()
         else:
             self.update()


### PR DESCRIPTION
Looks like a simple logic bug, the original code was gating `post_boot_config()` behind `advance_allocation` instead of `not advance_allocation`