### PR TITLE
Allow users to request specific subnets for FabNetv* or FabNetv6Ext when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 - Missing docstrings in network_service module (Issue [#313](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/314))
 - Artifact Manager Support (Issue [#358](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/358))
-
+- FabNet user specified subnets (Issue [#361](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/361))
 
 ## [1.7.3] - 08/05/2024
 ### Fixed

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -755,12 +755,15 @@ class Interface:
         :return: the model of this interface's component
         :rtype: str
         """
-        if self.model:
-            return self.model
-        elif self.node:
-            return self.node.get_model()
-        else:
-            return self.get_component().get_model()
+        try:
+            if self.model:
+                return self.model
+            elif self.node:
+                return self.node.get_model()
+            else:
+                return self.get_component().get_model()
+        except Exception:
+            return ""
 
     def get_site(self) -> str:
         """

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -522,10 +522,12 @@ class NetworkService:
         )
 
         if subnet:
-            if nstype ==  ServiceType.FABNetv4:
-                fim_network_service.gateway = Gateway(lab=Labels(ipv4_subnet=subnet.with_prefixlen))
-            elif nstype in  [ServiceType.FABNetv6, ServiceType.FABNetv6Ext]:
-                fim_network_service.gateway = Gateway(lab=Labels(ipv6_subnet=subnet.with_prefixlen))
+            if nstype == ServiceType.FABNetv4:
+                fim_network_service.gateway = Gateway(lab=Labels(ipv4_subnet=subnet.with_prefixlen,
+                                                                 ipv4=str(next(subnet.hosts()))))
+            elif nstype in [ServiceType.FABNetv6, ServiceType.FABNetv6Ext]:
+                fim_network_service.gateway = Gateway(lab=Labels(ipv6_subnet=subnet.with_prefixlen,
+                                                                 ipv6=str(next(subnet.hosts()))))
 
         network_service = NetworkService(
             slice=slice, fim_network_service=fim_network_service

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -399,7 +399,7 @@ class NetworkService:
             interfaces=interfaces,
             user_data=user_data,
             technology=technology,
-            subnet=subnet
+            subnet=subnet,
         )
 
     @staticmethod
@@ -523,11 +523,19 @@ class NetworkService:
 
         if subnet:
             if nstype == ServiceType.FABNetv4:
-                fim_network_service.gateway = Gateway(lab=Labels(ipv4_subnet=subnet.with_prefixlen,
-                                                                 ipv4=str(next(subnet.hosts()))))
+                fim_network_service.gateway = Gateway(
+                    lab=Labels(
+                        ipv4_subnet=subnet.with_prefixlen,
+                        ipv4=str(next(subnet.hosts())),
+                    )
+                )
             elif nstype in [ServiceType.FABNetv6, ServiceType.FABNetv6Ext]:
-                fim_network_service.gateway = Gateway(lab=Labels(ipv6_subnet=subnet.with_prefixlen,
-                                                                 ipv6=str(next(subnet.hosts()))))
+                fim_network_service.gateway = Gateway(
+                    lab=Labels(
+                        ipv6_subnet=subnet.with_prefixlen,
+                        ipv6=str(next(subnet.hosts())),
+                    )
+                )
 
         network_service = NetworkService(
             slice=slice, fim_network_service=fim_network_service
@@ -1108,13 +1116,13 @@ class NetworkService:
                     )
                 except:
                     logging.warning(f"interface not found: {interface.name}")
-                    ''' Commenting this code as not sure why this was added for now.
+                    """ Commenting this code as not sure why this was added for now.
                     from fabrictestbed_extensions.fablib.interface import Interface
 
                     self.interfaces.append(
                         Interface(fim_interface=interface, node=self)
                     )
-                    '''
+                    """
 
         return self.interfaces
 

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -1108,11 +1108,13 @@ class NetworkService:
                     )
                 except:
                     logging.warning(f"interface not found: {interface.name}")
+                    ''' Commenting this code as not sure why this was added for now.
                     from fabrictestbed_extensions.fablib.interface import Interface
 
                     self.interfaces.append(
                         Interface(fim_interface=interface, node=self)
                     )
+                    '''
 
         return self.interfaces
 

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -59,7 +59,7 @@ from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Tuple
 
 import pandas as pd
-from fim.user import Capacities, Labels, NodeType
+from fim.user import Labels
 from fss_utils.sshkey import FABRICSSHKey
 from IPython.core.display_functions import display
 
@@ -1022,6 +1022,7 @@ class Slice:
         type: str = "IPv4",
         user_data: dict = {},
         technology: str = None,
+        subnet: ipaddress.ip_network = None,
     ) -> NetworkService:
         """
         Adds a new L3 network service to this slice.
@@ -1069,10 +1070,14 @@ class Slice:
         :type type: String
 
         :param user_data
-
         :type user_data: dict
+
         :param technology: Specify the technology used should be set to AL2S when using for AL2S peering; otherwise None
         :type technology: str
+
+        :param subnet: Request a specific subnet for FabNetv4, FabNetv6 or FabNetv6Ext services.
+                       It's ignored for any other services.
+        :type ipaddress.ip_network
 
         :return: a new L3 network service
         :rtype: NetworkService
@@ -1087,6 +1092,7 @@ class Slice:
             type=type,
             user_data=user_data,
             technology=technology,
+            subnet=subnet
         )
 
     def add_facility_port(

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1092,7 +1092,7 @@ class Slice:
             type=type,
             user_data=user_data,
             technology=technology,
-            subnet=subnet
+            subnet=subnet,
         )
 
     def add_facility_port(


### PR DESCRIPTION
Allow users to request specific subnets for FabNetv* or FabNetv6Ext when available
This is a request from Tom to enable users who have slice that needs a valid certificate, so would like to be able to get the same address every time they instantiate the slice.