### PR TITLE
Add a hint to the `SSHException` thrown when bastion probe fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing docstrings in network_service module (Issue [#313](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/314))
 - Artifact Manager Support (Issue [#358](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/358))
 - FabNet user specified subnets (Issue [#361](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/361))
+- Print a hint when bastion probe fails (Issue [#363](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/363))
 
 ## [1.7.3] - 08/05/2024
 ### Fixed

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -640,7 +640,7 @@ class FablibManager(Config):
             https://cm.fabric-testbed.net/, usually via FABRIC portal.
         :param bastion_username: Your username on FABRIC bastion host,
             obtained from FABRIC portal.
-        :param bastion_key_filename: Path to your bastion SSH key.
+        :param bastion_key_location: Path to your bastion SSH key.
         :param log_file: Path where fablib logs are written; defaults
             to ``"/tmp/fablib/fablib.log"``.
         :param log_level: Level of detail in the logs written.

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1693,9 +1693,9 @@ Host * !bastion.fabric-testbed.net
                 return True
 
         except paramiko.SSHException as e:
+            note = "Hint: check your bastion key. Is it valid? Is it expired?"
             logging.error(
-                f"Error connecting to bastion host {bastion_host} "
-                f"(hint: check your bastion key setup?): {e}"
+                f"Error connecting to bastion host {bastion_host}: {e} ({note})"
             )
 
             # Since Python 3.11, we have BaseException.add_note(),
@@ -1707,11 +1707,9 @@ Host * !bastion.fabric-testbed.net
             # With Python versions prior to that, we just append a
             # hint to BaseException.args tuple.
             if sys.version_info.minor >= 11:
-                e.add_note("Hint: check your bastion key. Is it valid? Is it expired?")
+                e.add_note(note)
             else:
-                e.args = e.args + (
-                    "Hint: check your bastion key. Is it valid? Is it expired?",
-                )
+                e.args = e.args + (note,)
 
             raise e
         except Exception as e:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -68,6 +68,7 @@ import json
 import logging
 import os
 import random
+import sys
 import traceback
 import warnings
 
@@ -1696,6 +1697,22 @@ Host * !bastion.fabric-testbed.net
                 f"Error connecting to bastion host {bastion_host} "
                 f"(hint: check your bastion key setup?): {e}"
             )
+
+            # Since Python 3.11, we have BaseException.add_note(),
+            # which is a nicer way of adding some extra information to
+            # the exception.
+            #
+            # https://docs.python.org/3.11/whatsnew/3.11.html#pep-678-exceptions-can-be-enriched-with-notes
+            #
+            # With Python versions prior to that, we just append a
+            # hint to BaseException.args tuple.
+            if sys.version_info.minor >= 11:
+                e.add_note("Hint: check your bastion key. Is it valid? Is it expired?")
+            else:
+                e.args = e.args + (
+                    "Hint: check your bastion key. Is it valid? Is it expired?",
+                )
+
             raise e
         except Exception as e:
             logging.error(f"Error connecting to bastion host {bastion_host}: {e}")

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -691,9 +691,10 @@ class FablibManager(Config):
         self.auto_token_refresh = auto_token_refresh
         self.last_resources_filtered_by_time = False
 
+        self.setup_logging()
+
         if not offline:
             self.ssh_thread_pool_executor = ThreadPoolExecutor(execute_thread_pool_size)
-            self.setup_logging()
             self.__build_manager()
         self.required_check()
 

--- a/tests/integration/test_bastion_ssh.py
+++ b/tests/integration/test_bastion_ssh.py
@@ -34,7 +34,7 @@ class BastionHostTests(unittest.TestCase):
         """
         keyfile = tempfile.NamedTemporaryFile()
 
-        fm = FablibManager(offline=True, bastion_key_filename=keyfile.name)
+        fm = FablibManager(offline=True, bastion_key_location=keyfile.name)
         self.assertRaises(paramiko.ssh_exception.SSHException, fm.probe_bastion_host)
 
     def test_probe_bastion_host_bad_key(self):
@@ -46,5 +46,5 @@ class BastionHostTests(unittest.TestCase):
         rsa_key = paramiko.RSAKey.generate(bits=2048)
         rsa_key.write_private_key_file(keyfile.name)
 
-        fm = FablibManager(offline=True, bastion_key_filename=keyfile.name)
+        fm = FablibManager(offline=True, bastion_key_location=keyfile.name)
         self.assertRaises(paramiko.ssh_exception.SSHException, fm.probe_bastion_host)

--- a/tests/integration/test_bastion_ssh.py
+++ b/tests/integration/test_bastion_ssh.py
@@ -26,6 +26,7 @@ class BastionHostTests(unittest.TestCase):
         Test bastion with an empty username.
         """
         fm = FablibManager(offline=True, bastion_username="")
+        self.assertEqual(fm.get_bastion_username(), "")
         self.assertRaises(paramiko.ssh_exception.SSHException, fm.probe_bastion_host)
 
     def test_probe_bastion_host_empty_key(self):
@@ -35,6 +36,7 @@ class BastionHostTests(unittest.TestCase):
         keyfile = tempfile.NamedTemporaryFile()
 
         fm = FablibManager(offline=True, bastion_key_location=keyfile.name)
+        self.assertEqual(fm.get_bastion_key_location(), keyfile.name)
         self.assertRaises(paramiko.ssh_exception.SSHException, fm.probe_bastion_host)
 
     def test_probe_bastion_host_bad_key(self):
@@ -47,4 +49,5 @@ class BastionHostTests(unittest.TestCase):
         rsa_key.write_private_key_file(keyfile.name)
 
         fm = FablibManager(offline=True, bastion_key_location=keyfile.name)
+        self.assertEqual(fm.get_bastion_key_location(), keyfile.name)
         self.assertRaises(paramiko.ssh_exception.SSHException, fm.probe_bastion_host)


### PR DESCRIPTION
Resolves #363.  Here we add a hint to the exception thrown when `FablibManager.probe_bastion_host()` fails.  With Python < 3.11, this exception will look like:

```
SSHException: ('Invalid Key', 'Hint: check your bastion key. Is it valid? Is it expired?')
```

With Python >= 3.11, we use the newly introduced `BaseException.add_note()` so the message will look a tad bit nicer (in my opinion, anyway):

```
SSHException: Invalid key
Hint: check your bastion key. Is it valid? Is it expired?
```

Currently the message is merely `SSHException: Invalid key` which is not super helpful.

Other changes:

- Update the tests so that they continue to work.  The change from `bastion_key_filename` to `bastion_key_location` had caused them to stop working.  Since `FablibManager` has a `**kwargs` parameter, `bastion_key_filename` was being silently ignored.
- Set up logging regardless of the status of `offline` flag.  This is useful when debugging test failures.