### PR TITLE
Add missng docstrings in resources module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Artifact Manager Support (Issue [#358](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/358))
 - FabNet user specified subnets (Issue [#361](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/361))
 - Print a hint when bastion probe fails (Issue [#363](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/363))
+- Missing docstrings in resources module (Issue [#313](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/315))
 
 ## [1.7.3] - 08/05/2024
 ### Fixed

--- a/docs/source/network_service.rst
+++ b/docs/source/network_service.rst
@@ -6,5 +6,5 @@ network_service
 
 .. autoclass:: fabrictestbed_extensions.fablib.network_service.NetworkService
    :members:
-   :no-index:      
+   :no-index:
    :special-members: __str__

--- a/docs/source/resources.rst
+++ b/docs/source/resources.rst
@@ -6,12 +6,15 @@ resources
 
 .. autoclass:: fabrictestbed_extensions.fablib.resources.Resources
    :members:
+   :no-index:
    :special-members: __str__
 
 .. autoclass:: fabrictestbed_extensions.fablib.resources.Links
    :members:
+   :no-index:
    :special-members: __str__
 
 .. autoclass:: fabrictestbed_extensions.fablib.resources.FacilityPorts
    :members:
+   :no-index:
    :special-members: __str__

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1728,7 +1728,9 @@ Host * !bastion.fabric-testbed.net
 
         :param slice_manager: the slice manager to set
         :type slice_manager: SliceManager
-        .. deprecated:: 1.7.3 Use `set_manager()` instead.
+
+        .. deprecated:: 1.7.3
+           Use `set_manager()` instead.
         """
         self.set_manager(manager=slice_manager)
 
@@ -1736,13 +1738,14 @@ Host * !bastion.fabric-testbed.net
         """
         Not intended as API call
 
-
         Gets the slice manager of this fablib object.
 
         :return: the slice manager on this fablib object
         :rtype: SliceManager
-        .. deprecated:: 1.7.3 Use `get_manager()` instead.
-        """
+
+        .. deprecated:: 1.7.3
+           Use `get_manager()` instead.
+       """
         return self.get_manager()
 
     def set_manager(self, manager: FabricManager):

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1745,7 +1745,7 @@ Host * !bastion.fabric-testbed.net
 
         .. deprecated:: 1.7.3
            Use `get_manager()` instead.
-       """
+        """
         return self.get_manager()
 
     def set_manager(self, manager: FabricManager):

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -45,6 +45,9 @@ from fabrictestbed_extensions.fablib.site import ResourceConstants, Site
 
 
 class Resources:
+    """
+    A class for working with FABRIC resources.
+    """
     def __init__(
         self,
         fablib_manager,
@@ -832,6 +835,10 @@ class Resources:
 
 
 class Links(Resources):
+    """
+    A class for working with network links.
+    """
+    
     link_pretty_names = {
         "site_names": "Sites",
         "node_id": "Link Name",
@@ -933,6 +940,10 @@ class Links(Resources):
 
 
 class FacilityPorts(Resources):
+    """
+    A class for working with FABRIC facility ports.
+    """
+    
     link_pretty_names = {
         "name": "Name",
         "site_name": "Site",

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -48,6 +48,7 @@ class Resources:
     """
     A class for working with FABRIC resources.
     """
+
     def __init__(
         self,
         fablib_manager,
@@ -838,7 +839,7 @@ class Links(Resources):
     """
     A class for working with network links.
     """
-    
+
     link_pretty_names = {
         "site_names": "Sites",
         "node_id": "Link Name",
@@ -943,7 +944,7 @@ class FacilityPorts(Resources):
     """
     A class for working with FABRIC facility ports.
     """
-    
+
     link_pretty_names = {
         "name": "Name",
         "site_name": "Site",


### PR DESCRIPTION
Addresses #315. 

These docstrings are kind of silly and probably not very useful, but I would like to check that box off in #308.  This PR addresses some warnings when building docs with `sphinx-build -W`, so that might be useful.