### PR TITLE
Add missing docstrings to `fablib` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Missing docstrings in resources module (Issue [#315](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/315))
 - Missing docstrings in slice module (Issue [#316](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/316))
 - Missing docstrings in component module (Issue [#317](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/317))
+- Missing docstrings in fablib module (Issue [#319](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/319))
 
 ## [1.7.3] - 08/05/2024
 ### Fixed

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -47,6 +48,11 @@ exclude_patterns = []
 # Use __init__ method’s docstrings in class docs.  Other options are
 # "class" and "both".
 autoclass_content = "init"
+
+# Link to Python stdlib docs when possible.
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.autodoc",
     "sphinx_autodoc_typehints",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinx.ext.duration",
     "sphinx.ext.doctest",
     "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/fablib.rst
+++ b/docs/source/fablib.rst
@@ -6,4 +6,5 @@ fablib
 
 .. autoclass:: fabrictestbed_extensions.fablib.fablib.FablibManager
    :members:
+   :no-index:
    :special-members: __str__

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -586,6 +586,10 @@ class fablib:
 
 
 class FablibManager(Config):
+    """
+    The main class to use when interacting with the testbed.
+    """
+
     FABNETV4_SUBNET = IPv4Network("10.128.0.0/10")
     FABNETV6_SUBNET = IPv6Network("2602:FCFB:00::/40")
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2498,7 +2498,18 @@ Host * !bastion.fabric-testbed.net
         return printable_table
 
     @staticmethod
-    def list_table_json(data, quiet=False):
+    def list_table_json(data: List[Dict[str, str]], quiet: bool = False):
+        """
+        Return a JSON representation of table data.
+
+        This is a helper method called by :py:meth:`list_table()`; you
+        should use that method instead of invoking this directly.
+
+        :param data: Data to be formatted as JSON.
+        :param quiet: Prints the JSON string when ``False``.
+
+        :return: Some JSON.
+        """
         json_str = json.dumps(data, indent=4)
 
         if not quiet:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2272,6 +2272,19 @@ Host * !bastion.fabric-testbed.net
 
     @staticmethod
     def show_table_json(data, quiet=False):
+        """
+        Make a table in JSON format.
+
+        You normally will not use this method directly; you should
+        rather use :py:meth:`show_table()`.
+
+        :param data: A list of lists.
+        :param quiet: Setting this to `False` causes the JSON string
+            to be printed.
+
+        :return: Table in JSON format.
+        :rtype: str
+        """
         json_str = json.dumps(data, indent=4)
 
         if not quiet:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -82,7 +82,7 @@ warnings.filterwarnings("always", category=DeprecationWarning)
 
 from concurrent.futures import ThreadPoolExecutor
 from ipaddress import IPv4Network, IPv6Network
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 import pandas as pd
 import paramiko
@@ -2315,22 +2315,22 @@ Host * !bastion.fabric-testbed.net
 
     def show_table(
         self,
-        data,
-        fields=None,
-        title="",
-        title_font_size="1.25em",
-        output=None,
-        quiet=False,
-        pretty_names_dict={},
+        data: List[List[Any]],
+        fields: List[str] = None,
+        title: str = "",
+        title_font_size: str = "1.25em",
+        output: str = None,
+        quiet: bool = False,
+        pretty_names_dict: Dict[str, str] = {},
     ):
         """
         Format and optionally display a table.
 
-        :param data: The table data, probably a list of lists.
-        :type data:
+        :param data: Data to be presented in the table.
+        :type data: List[List]
 
         :param fields: Table headers, as a list of strings.
-        :type fields:
+        :type fields: List[str]
 
         :param title: Table title.
         :type title: str

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2180,6 +2180,19 @@ Host * !bastion.fabric-testbed.net
 
     @staticmethod
     def show_table_text(table, quiet=False):
+        """
+        Make a table in text form suitable for terminal.
+
+        You normally will not use this method directly; you should
+        rather use :py:meth:`show_table()`.
+
+        :param table: A list of lists.
+        :param quiet: Setting this to `False` causes the table to be
+            printed.
+
+        :return: A table formatted by tabulate library.
+        :rtype: str
+        """
         printable_table = tabulate(table)
 
         if not quiet:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -582,6 +582,9 @@ class fablib:
 
     @staticmethod
     def is_jupyter_notebook() -> bool:
+        """
+        Check if we're running inside a Jupyter notebook.
+        """
         return fablib.get_default_fablib_manager().is_jupyter_notebook()
 
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2586,7 +2586,7 @@ Host * !bastion.fabric-testbed.net
         data: Dict[str, Any],
         fields: Union[List[str], None] = None,
         pretty_names_dict: dict[str, str] = {},
-    ) -> List[[Any, Any]]:
+    ) -> List[List[str]]:
         """
         Form a table that we can display.
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -275,6 +275,9 @@ class fablib:
 
     @staticmethod
     def show_config():
+        """
+        Show current FABlib configuration parameters.
+        """
         return fablib.get_default_fablib_manager().show_config()
 
     @staticmethod

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -82,7 +82,7 @@ warnings.filterwarnings("always", category=DeprecationWarning)
 
 from concurrent.futures import ThreadPoolExecutor
 from ipaddress import IPv4Network, IPv6Network
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 
 import pandas as pd
 import paramiko
@@ -2552,7 +2552,24 @@ Host * !bastion.fabric-testbed.net
         return table
 
     @staticmethod
-    def create_show_table(data, fields=None, pretty_names_dict={}):
+    def create_show_table(
+        data: Dict[str, Any],
+        fields: Union[List[str], None] = None,
+        pretty_names_dict: dict[str, str] = {},
+    ) -> List[[Any, Any]]:
+        """
+        Form a table that we can display.
+
+        You should not have to use this method directly; this is used
+        by :py:meth:`show_table()`.
+
+        :param data: Input data.
+        :param fields: List of column field names.
+        :param pretty_names_dict: Mapping from non-pretty to pretty
+            names, to be used as column labels.
+
+        :return: A list that can be formatted as a table.
+        """
         table = []
         if fields is None:
             for key, value in data.items():

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2294,6 +2294,20 @@ Host * !bastion.fabric-testbed.net
 
     @staticmethod
     def show_table_dict(data, quiet=False):
+        """
+        Show the table.
+
+        You normally will not use this method directly; you should
+        rather use :py:meth:`show_table()`.
+
+        :param data: The table as a Python object; likely a list of
+            lists.
+        :param quiet: Setting this to `False` causes the table to be
+            printed.
+
+        :return: The table as a Python object.
+        :rtype: str
+        """
         if not quiet:
             print(f"{data}")
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2327,33 +2327,26 @@ Host * !bastion.fabric-testbed.net
         Format and optionally display a table.
 
         :param data: Data to be presented in the table.
-        :type data: List[List]
 
         :param fields: Table headers, as a list of strings.
-        :type fields: List[str]
 
         :param title: Table title.
-        :type title: str
 
         :param title_font_size: Font size to use in table title, when
             displaying the table in a Jupyter notebook.
-        :type title_font_size: str
 
-        :param output: The table format.  Options are: "text" (or
-            "default"), or "json", or "dict", or "pandas" (or
-            "jupyter_default").
-        :type output: str
+        :param output: The table format.  Options are: ``"text"`` (or
+            ``"default"``), or ``"json"``, or ``"dict"``, or
+            ``"pandas"`` (or ``"jupyter_default"``).
 
         :param quiet: Display the table, in addition to returning a
             table in the required `output` format.
-        :type quiet: bool
 
         :param pretty_names_dict: A mapping from non-pretty names to
             pretty names to use in table headers.
-        :type pretty_names_dict: Dict[str,str]
 
         :return: Input :py:obj:`data` formatted as a table.
-        :rtype: Depends on `output` parameter.
+        :rtype: Depends on :py:obj:`output` parameter.
         """
         if output is None:
             output = self.output.lower()

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2315,11 +2315,11 @@ Host * !bastion.fabric-testbed.net
 
     def show_table(
         self,
-        data: List[List[Any]],
-        fields: List[str] = None,
+        data: Dict[str, Any],
+        fields: Union[List[str], None] = None,
         title: str = "",
         title_font_size: str = "1.25em",
-        output: str = None,
+        output: Union[str, None] = None,
         quiet: bool = False,
         pretty_names_dict: Dict[str, str] = {},
     ):

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2373,7 +2373,23 @@ Host * !bastion.fabric-testbed.net
             logging.error(f"Unknown output type: {output}")
 
     @staticmethod
-    def list_table_text(table, headers=None, quiet=False):
+    def list_table_text(
+        table: List[List[Any]],
+        headers: Union[List[str], None] = None,
+        quiet: bool = False,
+    ):
+        """
+        Format a table as text.
+
+        This is a helper method called by :py:meth:`list_table()`; you
+        should use that method instead of invoking this directly.
+
+        :param table: A list that :py:func:`tabulate()` can use.
+        :param headers: List of column headers.
+        :param quiet: Print the table when ``False``.
+
+        :return: A table-formatted string.
+        """
         if headers is not None:
             printable_table = tabulate(table, headers=headers)
         else:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2323,6 +2323,38 @@ Host * !bastion.fabric-testbed.net
         quiet=False,
         pretty_names_dict={},
     ):
+        """
+        Format and optionally display a table.
+
+        :param data: The table data, probably a list of lists.
+        :type data:
+
+        :param fields: Table headers, as a list of strings.
+        :type fields:
+
+        :param title: Table title.
+        :type title: str
+
+        :param title_font_size: Font size to use in table title, when
+            displaying the table in a Jupyter notebook.
+        :type title_font_size: str
+
+        :param output: The table format.  Options are: "text" (or
+            "default"), or "json", or "dict", or "pandas" (or
+            "jupyter_default").
+        :type output: str
+
+        :param quiet: Display the table, in addition to returning a
+            table in the required `output` format.
+        :type quiet: bool
+
+        :param pretty_names_dict: A mapping of non-pretty names to
+            pretty names to use in table headers.
+        :type pretty_names_dict: dict
+
+        :return: Depends on `output` parameter.
+        :rtype: Depends on `output` parameter.
+        """
         if output is None:
             output = self.output.lower()
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1050,6 +1050,9 @@ Host * !bastion.fabric-testbed.net
         os.chmod(public_file_path, 0o644)
 
     def get_ssh_thread_pool_executor(self) -> ThreadPoolExecutor:
+        """
+        Get :py:class:`ThreadPoolExecutor` that runs SSH commands.
+        """
         return self.ssh_thread_pool_executor
 
     def __build_manager(self) -> FabricManager:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2402,13 +2402,27 @@ Host * !bastion.fabric-testbed.net
 
     @staticmethod
     def list_table_jupyter(
-        table,
-        headers=None,
-        title="",
-        title_font_size="1.25em",
+        table: List[List[Any]],
+        headers: Union[List[str], None] = None,
+        title: str = "",
+        title_font_size: str = "1.25em",
         output=None,
-        quiet=False,
+        quiet: bool = False,
     ):
+        """
+        Format a table as a Pandas DataFrame.
+
+        This is a helper method called by :py:meth:`list_table()`; you
+        should use that method instead of invoking this directly.
+
+        :param table: A list that :py:func:`tabulate()` can use.
+        :param headers: List of column headers.
+        :param title: Table title, set as caption for the DataFrame.
+        :param output: Unused.
+        :param quiet: Display the table when ``False``.
+
+        :return: A Pandas DataFrame.
+        """
         if len(table) == 0:
             return None
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -82,7 +82,7 @@ warnings.filterwarnings("always", category=DeprecationWarning)
 
 from concurrent.futures import ThreadPoolExecutor
 from ipaddress import IPv4Network, IPv6Network
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Tuple, Union
 
 import pandas as pd
 import paramiko
@@ -2485,15 +2485,32 @@ Host * !bastion.fabric-testbed.net
 
     def list_table(
         self,
-        data,
-        fields=None,
-        title="",
-        title_font_size="1.25em",
-        output=None,
-        quiet=False,
-        filter_function=None,
-        pretty_names_dict={},
+        data: List[Dict[str, str]],
+        fields: Union[List[str], None] = None,
+        title: str = "",
+        title_font_size: str = "1.25em",
+        output: Union[str, None] = None,
+        quiet: bool = False,
+        filter_function: Union[Callable[[Iterable], bool], None] = None,
+        pretty_names_dict: Dict[str, str] = {},
     ):
+        """
+        Format a list into a table that we can display.
+
+        :param data: Data to be formatted.
+        :param fields: List of column headings.
+        :param title: Table title.
+        :param title_font_size: Font size of the table title.
+        :param output: Output format, which can be one of ``"text"``,
+            ``"json"``, ``"list"``, or ``"pandas"``.
+        :param quiet: Prints the table when ``True``.
+        :param filter_function: A lambda that can be used to filter
+            the input data.
+        :param pretty_names_dict: A mapping from non-pretty names to
+            pretty names, used in column headings.
+
+        :return: Input :py:obj:`data` formatted as a table.
+        """
         if filter_function:
             data = list(filter(filter_function, data))
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2204,6 +2204,21 @@ Host * !bastion.fabric-testbed.net
     def show_table_jupyter(
         table, headers=None, title="", title_font_size="1.25em", quiet=False
     ):
+        """
+        Make a table in text form suitable for Jupyter notebooks.
+
+        You normally will not use this method directly; you should
+        rather use :py:meth:`show_table()`.
+
+        :param table: A list of lists.
+        :param title: The table title.
+        :param title_font_size: Font size to use for the table title.
+        :param quiet: Setting this to `False` causes the table to be
+            displayed.
+
+        :return: a Pandas dataframe.
+        :rtype: pd.DataFrame
+        """
         printable_table = pd.DataFrame(table)
 
         properties = {

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2348,11 +2348,11 @@ Host * !bastion.fabric-testbed.net
             table in the required `output` format.
         :type quiet: bool
 
-        :param pretty_names_dict: A mapping of non-pretty names to
+        :param pretty_names_dict: A mapping from non-pretty names to
             pretty names to use in table headers.
-        :type pretty_names_dict: dict
+        :type pretty_names_dict: Dict[str,str]
 
-        :return: Depends on `output` parameter.
+        :return: Input :py:obj:`data` formatted as a table.
         :rtype: Depends on `output` parameter.
         """
         if output is None:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2558,7 +2558,20 @@ Host * !bastion.fabric-testbed.net
             logging.error(f"Unknown output type: {output}")
 
     @staticmethod
-    def create_list_table(data, fields=None):
+    def create_list_table(
+        data: List[Dict[str, str]], fields: Union[List[str], None] = None
+    ):
+        """
+        Format a list as a table.
+
+        This method is used by :py:meth:`list_table()`; you do not
+        have to use this directly.
+
+        :param data: Data to be formatted.
+        :param fields: List of column titles.
+
+        :return: Tabular data.
+        """
         table = []
         for entry in data:
             row = []

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -114,6 +114,9 @@ class fablib:
 
     @staticmethod
     def get_default_fablib_manager():
+        """
+        Get or create an internal :py:class:`FablibManager` instance.
+        """
         if fablib.default_fablib_manager is None:
             fablib.default_fablib_manager = FablibManager()
 

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1623,8 +1623,13 @@ Host * !bastion.fabric-testbed.net
         :rtype: List[Sting]
         """
 
-        # Always filter out sites in maintenance and sites that can't support any VMs
         def combined_filter_function(site):
+            """
+            Filter out "impossible" sites.
+
+            Always filter out sites in maintenance and sites that
+            can't support any VMs.
+            """
             if filter_function is None:
                 if site["state"] == "Active" and site["hosts"] > 0:
                     return True

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -2500,7 +2500,7 @@ Host * !bastion.fabric-testbed.net
     @staticmethod
     def list_table_json(data: List[Dict[str, str]], quiet: bool = False):
         """
-        Return a JSON representation of table data.
+        Return a JSON representation of tabular data.
 
         This is a helper method called by :py:meth:`list_table()`; you
         should use that method instead of invoking this directly.
@@ -2518,7 +2518,18 @@ Host * !bastion.fabric-testbed.net
         return json_str
 
     @staticmethod
-    def list_table_list(data, quiet=False):
+    def list_table_list(data: List[Dict[str, str]], quiet: bool = False):
+        """
+        Return text representation of tabular data.
+
+        This is a helper method called by :py:meth:`list_table()`; you
+        should use that method instead of invoking this directly.
+
+        :param data: Data to be formatted.
+        :param quiet: Prints the string when ``False``.
+
+        :return: A table-formatted string.
+        """
         if not quiet:
             print(f"{data}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ ChangeLog = "https://github.com/fabric-testbed/fabrictestbed-extensions/blob/mai
 [project.optional-dependencies]
 doc = [
   "sphinx",
-  "furo"
+  "sphinx-autodoc-typehints",
+  "furo",
 ]
 test = [
   "black==24.*",

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ commands =
 # An environment for generanting docs.
 deps =
      sphinx
+     sphinx-autodoc-typehints
      furo
 
 commands =


### PR DESCRIPTION
Resolves #319 by adding some docstrings and some hopefully correct type hints to `fablib` module.  Also adding some extra changes that should be useful:

- Enable [sphinx-autodoc-typehints](https://github.com/tox-dev/sphinx-autodoc-typehints) extension, so that type hints are automatically included in the generated API docs.
- Enable Sphinx [viewcode](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html) extension so that will "source" link will be added to API docs. This way we can quickly refer to the sources from the API docs.
- Enable Sphinx [intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html) extension so that API docs can link to other projects' documentation, such as Python stdlib.