### PR TITLE
Bug Fixes - Changes requested for improving handling of temporary objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - node.execute() retry parameter is off-by-one (and/or misnamed) (Issue [#375](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/375))
 - FacilityPort.show() errors out (Issue [#346](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/346))
 - Add support for FPGA model SN1022 (Issue [#382](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/382))
+- Node objects returned from slice.get_node(name) are not the same as the node objects returned from slice.get_nodes() (Issue [#380](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/380))
+- Multiple calls to fablib.get_slice(name) in the same interpreter yield different objects (Issue [#379](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/379))
+- FablibManager.get_slices doesn't return unsubmitted slices created by new_slice() (Issue [#294](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/294))
 
 
 ## [1.7.3] - 08/05/2024

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -744,12 +744,20 @@ class FablibManager(Config):
         :type slice_object: Slice
         """
         with self.lock:
-            if slice_object.get_slice_id() and slice_object.get_slice_id() in self.__slices_by_id:
+            if (
+                slice_object.get_slice_id()
+                and slice_object.get_slice_id() in self.__slices_by_id
+            ):
                 self.__slices_by_id.pop(slice_object.get_slice_id())
-            if slice_object.get_name() and slice_object.get_name() in self.__slices_by_name:
+            if (
+                slice_object.get_name()
+                and slice_object.get_name() in self.__slices_by_name
+            ):
                 self.__slices_by_name.pop(slice_object.get_name())
 
-    def _get_slice_from_cache(self, slice_id: str = None, slice_name: str = None) -> Slice:
+    def _get_slice_from_cache(
+        self, slice_id: str = None, slice_name: str = None
+    ) -> Slice:
         """
         Retrieves a Slice object from the cache by its ID or name.
 
@@ -1986,7 +1994,7 @@ Host * !bastion.fabric-testbed.net
         filter_function=None,
         pretty_names=True,
         user_only: bool = True,
-        show_un_submitted: bool = False
+        show_un_submitted: bool = False,
     ):
         """
         Lists all the slices created by a user.
@@ -2026,7 +2034,9 @@ Host * !bastion.fabric-testbed.net
         :rtype: Object
         """
         table = []
-        for slice in self.get_slices(excludes=excludes, user_only=user_only, show_un_submitted=show_un_submitted):
+        for slice in self.get_slices(
+            excludes=excludes, user_only=user_only, show_un_submitted=show_un_submitted
+        ):
             table.append(slice.toDict())
 
         if pretty_names:
@@ -2053,7 +2063,7 @@ Host * !bastion.fabric-testbed.net
         quiet=False,
         pretty_names=True,
         user_only: bool = True,
-        show_un_submitted: bool = False
+        show_un_submitted: bool = False,
     ):
         """
         Show a table with all the properties of a specific site
@@ -2089,7 +2099,12 @@ Host * !bastion.fabric-testbed.net
         :rtype: Object
         """
 
-        slice = self.get_slice(name=name, slice_id=id, user_only=user_only, show_un_submitted=show_un_submitted)
+        slice = self.get_slice(
+            name=name,
+            slice_id=id,
+            user_only=user_only,
+            show_un_submitted=show_un_submitted,
+        )
 
         return slice.show(
             output=output, fields=fields, quiet=quiet, pretty_names=pretty_names
@@ -2207,7 +2222,7 @@ Host * !bastion.fabric-testbed.net
                 excludes=[SliceState.Dead, SliceState.Closing],
                 slice_name=name,
                 user_only=user_only,
-                show_un_submitted=show_un_submitted
+                show_un_submitted=show_un_submitted,
             )
 
             if len(slices) > 0:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -726,7 +726,7 @@ class FablibManager(Config):
             if slice_id:
                 return self.__slices_by_id.get(slice_id)
             elif slice_name:
-                return self.__slices_by_name.get(slice_id)
+                return self.__slices_by_name.get(slice_name)
 
     def validate_config(self):
         """

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -715,13 +715,13 @@ class FablibManager(Config):
         self.__slices_by_name = {}
         self.__slices_by_id = {}
 
-    def _cache_slice(self, slice_object: Slice):
+    def cache_slice(self, slice_object: Slice):
         with self.lock:
             self.__slices_by_name[slice_object.get_name()] = slice_object
             if slice_object.get_slice_id():
                 self.__slices_by_id[slice_object.get_slice_id()] = slice_object
 
-    def _remove_slice_from_cache(self, slice_object: Slice):
+    def remove_slice_from_cache(self, slice_object: Slice):
         with self.lock:
             if slice_object.get_slice_id() and slice_object.get_slice_id() in self.__slices_by_id:
                 self.__slices_by_id.pop(slice_object.get_slice_id())
@@ -1829,7 +1829,6 @@ Host * !bastion.fabric-testbed.net
         """
         # fabric = fablib()
         new_slice = Slice.new_slice(self, name=name)
-        self._cache_slice(slice_object=new_slice)
         return new_slice
 
     def get_site_advertisement(self, site: str) -> FimNode:
@@ -2127,7 +2126,6 @@ Host * !bastion.fabric-testbed.net
                 slice_object = Slice.get_slice(
                     self, sm_slice=slice, user_only=user_only
                 )
-                self._cache_slice(slice_object=slice_object)
                 return_slices.append(slice_object)
         else:
             raise Exception(f"Failed to get slices: {slices}")
@@ -2203,7 +2201,6 @@ Host * !bastion.fabric-testbed.net
         """
         slice = self.get_slice(slice_name, show_un_submitted=True)
         slice.delete()
-        self._remove_slice_from_cache(slice_object=slice)
 
     def delete_all(self, progress: bool = True):
         """
@@ -2219,7 +2216,6 @@ Host * !bastion.fabric-testbed.net
                 if progress:
                     print(f"Deleting slice {slice.get_name()}", end="")
                 slice.delete()
-                self._remove_slice_from_cache(slice_object=slice)
                 if progress:
                     print(f", Success!")
             except Exception as e:

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -130,10 +130,10 @@ class Slice:
         :rtype: String
         """
         table = [
-            ["Slice Name", self.sm_slice.name],
-            ["Slice ID", self.sm_slice.slice_id],
-            ["Slice State", self.sm_slice.state],
-            ["Lease End", self.sm_slice.lease_end_time],
+            ["Slice Name", self.get_name()],
+            ["Slice ID", self.get_slice_id()],
+            ["Slice State", self.get_state()],
+            ["Lease End", self.get_lease_end()],
         ]
 
         return tabulate(table)
@@ -913,7 +913,8 @@ class Slice:
         :return: project id
         :rtype: String
         """
-        return self.sm_slice.project_id
+        if self.sm_slice:
+            return self.sm_slice.project_id
 
     def add_port_mirror_service(
         self,

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -708,7 +708,7 @@ class Slice:
         except Exception as e:
             logging.warning(f"slice.update_slivers failed: {e}")
 
-        #self.nodes = None
+        # self.nodes = None
         self.interfaces = None
         self.update_topology()
 
@@ -1465,7 +1465,11 @@ class Slice:
         current_node_names = set(current_topology_nodes.keys())
 
         # Identify and remove nodes that are not in the current topology
-        nodes_to_remove = [node_name for node_name in self.nodes.keys() if node_name not in current_node_names]
+        nodes_to_remove = [
+            node_name
+            for node_name in self.nodes.keys()
+            if node_name not in current_node_names
+        ]
 
         for node_name in nodes_to_remove:
             self.nodes.pop(node_name)

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -444,6 +444,8 @@ class Slice:
         """
         slice = Slice(fablib_manager=fablib_manager, name=name)
         slice.topology = ExperimentTopology()
+        if fablib_manager:
+            fablib_manager.cache_slice(slice_object=slice)
         return slice
 
     @staticmethod
@@ -469,6 +471,8 @@ class Slice:
         slice.slice_id = sm_slice.slice_id
         slice.slice_name = sm_slice.name
         slice.user_only = user_only
+        if fablib_manager:
+            fablib_manager.cache_slice(slice_object=slice)
 
         try:
             slice.update_topology()
@@ -1659,6 +1663,9 @@ class Slice:
 
         :raises Exception: if deleting the slice fails
         """
+        if self.get_fablib_manager():
+            self.get_fablib_manager().remove_slice_from_cache(slice_object=self)
+
         if not self.sm_slice:
             self.topology = None
             return

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -622,6 +622,9 @@ class Slice:
 
         :raises Exception: if topology could not be gotten from slice manager
         """
+        if not self.sm_slice:
+            return
+
         self.update_topology_count += 1
         logging.info(
             f"update_topology: {self.get_name()}, count: {self.update_topology_count}"
@@ -655,13 +658,14 @@ class Slice:
 
         :raises Exception: if topology could not be gotten from slice manager
         """
+        if self.sm_slice is None:
+            return
+
         self.update_slivers_count += 1
         logging.debug(
             f"update_slivers: {self.get_name()}, count: {self.update_slivers_count}"
         )
 
-        if self.sm_slice is None:
-            return
         status, slivers = self.fablib_manager.get_manager().slivers(
             slice_object=self.sm_slice, as_self=self.user_only
         )

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1439,6 +1439,8 @@ class Slice:
         - After processing, it removes any nodes from self.nodes that
           are no longer present in the current topology.
 
+        https://github.com/fabric-testbed/fabrictestbed-extensions/issues/380
+
         :raises: Logs an exception if an error occurs during initialization.
         """
         # Initialize nodes dictionary if not already present

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -1447,6 +1447,10 @@ class Slice:
         :rtype: Node
         """
         try:
+            if self.nodes and len(self.nodes):
+                for n in self.nodes:
+                    if n.get_name() == name:
+                        return n
             return Node.get_node(self, self.get_fim_topology().nodes[name])
         except Exception as e:
             logging.info(e, exc_info=True)
@@ -1640,6 +1644,7 @@ class Slice:
             end = datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S %z")
             days = (end - datetime.now(timezone.utc)).days
 
+        # Directly pass the kwargs to submit
         self.submit(lease_in_days=days, post_boot_config=False, **kwargs)
 
     def build_error_exception_string(self) -> str:
@@ -2172,7 +2177,6 @@ class Slice:
         lease_start_time: datetime = None,
         lease_in_days: int = None,
         validate: bool = False,
-        **kwargs,
     ) -> str:
         """
         Submits a slice request to FABRIC.
@@ -2220,21 +2224,6 @@ class Slice:
 
         :return: slice_id
         """
-        # Use kwargs to update only the arguments provided
-        options = locals().copy()
-        options.update(kwargs)
-
-        wait = options.get("wait", wait)
-        wait_timeout = options.get("wait_timeout", wait_timeout)
-        wait_interval = options.get("wait_interval", wait_interval)
-        progress = options.get("progress", progress)
-        wait_jupyter = options.get("wait_jupyter", wait_jupyter)
-        post_boot_config = options.get("post_boot_config", post_boot_config)
-        wait_ssh = options.get("wait_ssh", wait_ssh)
-        extra_ssh_keys = options.get("extra_ssh_keys", extra_ssh_keys)
-        lease_start_time = options.get("lease_start_time", lease_start_time)
-        lease_in_days = options.get("lease_in_days", lease_in_days)
-        validate = options.get("validate", validate)
         slice_reservations = None
 
         if not wait:


### PR DESCRIPTION
#380 - `get_node()` updated to maintain Node objects across calls instead of creating temporary objects
#379 - `fablib` updated to maintain the slice objects it creates and returns the same object on multiple invocations of `get_slice`
#294 `get_slice()` also updated to return un_submitted slices when user passes `show_un_submitted=True`