### PR TITLE
Fixing undesirable behavior in local jupyter notebook SSH command template

### DIFF
--- a/fabrictestbed_extensions/fablib/config/config.py
+++ b/fabrictestbed_extensions/fablib/config/config.py
@@ -223,10 +223,10 @@ class Config:
         if data_dir is not None:
             self.set_data_dir(data_dir=data_dir)
 
-        if self.get_ssh_command_line() is None:
-            self.set_ssh_command_line(
-                ssh_command_line=Constants.DEFAULT_FABRIC_SSH_COMMAND_LINE
-            )
+#        if self.get_ssh_command_line() is None:
+#            self.set_ssh_command_line(
+#                ssh_command_line=Constants.DEFAULT_FABRIC_SSH_COMMAND_LINE
+#            )
 
         self.required_check(partial=True)
 


### PR DESCRIPTION
if I create a fabric_rc with SSH connection template that points to my local fabric SSH config file, and source this file, this setting doesn't take effect if I just do
```
fablib = fablib_manager()             
fablib.show_config();
```
(it keeps pointing to what would be my jupyter hub work directory) . I have to do
```
fablib = fablib_manager(fabric_rc='/path/to/fabric_rc')             
fablib.show_config();
```
for it to work.I think the attached patch fixes this behavior.