### PR TITLE
Fix `Node.get_interface` not returning from name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - urllib3 deprecated warning (Issue [#397](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/397))
 - Improvements for get_interfaces and get_components (Issue [#378](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/378))
 - TypeError: Switch.get_interfaces() got an unexpected keyword argument 'output' (Issue([#405](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/405)))
+- Exception: Interface not found using Node.get_interface(name) (Issue[#407](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/407))
 
 ### Added
 - Add support for BlueField NICs (Issue [#399](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/399))

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1128,7 +1128,9 @@ class Node:
         :rtype: Interface
         """
         if name is not None:
-            self.get_interfaces(refresh=refresh, output="dict").get(name)
+            interface = self.get_interfaces(refresh=refresh, output="dict").get(name)
+            if interface is not None:
+                return interface
         elif network_name is not None:
             for interface in self.get_interfaces(refresh=refresh):
                 if (


### PR DESCRIPTION
When supplied with an interface name, `get_interface` would find the interface but not return it, instead triggering the later Exception for Interface not found. This adds the missing return, behind a None check so it triggers the exception.

Fixes https://github.com/fabric-testbed/fabrictestbed-extensions/issues/407