### PR TITLE
Meta data pullable from Github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 1.9.0 - TODO
 - Simplifying FPGA Flash workflow - PCI Rescan (Issue [#421](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/421))
 - Support Explicit Route Objects (ERO) with Guaranteed QoS in FABlib (Issue [#422](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/422))
+- Store policies, images, PTP availability and other transient bits in a pullable file. (Issue [#425](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/425))
 
 ## 1.8.2
 

--- a/fabrictestbed_extensions/fablib/config/config.py
+++ b/fabrictestbed_extensions/fablib/config/config.py
@@ -868,7 +868,7 @@ class Config:
             response = requests.get(remote_url, timeout=5)
             response.raise_for_status()
             data = response.json()
-            with open(local_file, "w") as f:
+            with atomic_write(local_file, overwrite=True) as f:
                 json.dump(data, f, indent=2)
             return data
         except Exception:

--- a/fabrictestbed_extensions/fablib/config/config.py
+++ b/fabrictestbed_extensions/fablib/config/config.py
@@ -26,9 +26,12 @@ import json
 import logging
 import os
 import re
+import time
+from functools import lru_cache
 from pathlib import Path
 from typing import Dict, List, Union
 
+import requests
 import yaml
 from atomicwrites import atomic_write
 
@@ -123,6 +126,10 @@ class Config:
             Constants.ENV_VAR: Constants.FABRIC_BASTION_SSH_CONFIG_FILE,
             Constants.DEFAULT: Constants.DEFAULT_FABRIC_BASTION_SSH_CONFIG_FILE,
         },
+        Constants.FABRIC_METADATA_TAG: {
+            Constants.ENV_VAR: Constants.FABRIC_METADATA_TAG,
+            Constants.DEFAULT: Constants.DEFAULT_FABRIC_METADATA_TAG
+        }
     }
 
     REQUIRED_ATTRS_PRETTY_NAMES = {
@@ -148,6 +155,8 @@ class Config:
         Constants.SSH_COMMAND_LINE: "SSH Command Line",
         Constants.BASTION_SSH_CONFIG_FILE: "Bastion SSH Config File",
     }
+
+    os.makedirs(Constants.LOCAL_CACHE_DIR, exist_ok=True)
 
     def __init__(
         self,
@@ -740,14 +749,14 @@ class Config:
         return None
 
     @staticmethod
-    def get_image_names() -> List[str]:
+    def get_image_names() -> dict[str, dict]:
         """
         Gets a list of available image names.
 
         This is statically defined for now. Eventually, images will be managed dynamically.
 
         :return: list of image names as strings
-        :rtype: list[str]
+        :rtype: dict[str, dict]
         """
         return Constants.IMAGE_NAMES
 
@@ -810,6 +819,93 @@ class Config:
                 format="[%(asctime)s] {%(pathname)s:%(lineno)d} %(levelname)s - %(message)s",
                 datefmt="%H:%M:%S",
             )
+
+    @staticmethod
+    def get_metadata_tag() -> str:
+        """
+        Get the metadata tag used to fetch remote configuration files.
+
+        This tag determines which version or branch (e.g., "main", "v1.0.0")
+        of the metadata directory is used.
+
+        :return: Metadata tag string.
+        :rtype: str
+        """
+        return os.environ.get(Constants.FABRIC_METADATA_TAG, Constants.DEFAULT_FABRIC_METADATA_TAG)
+
+    @staticmethod
+    def _fetch_or_load_json(name: str, ttl: int = 86400, fallback_default: dict | None = None) -> dict:
+        """
+        Fetch a JSON file from a remote URL, using local caching with time-based invalidation,
+        and fall back to a default if the fetch or cache read fails.
+
+        If a valid cached file exists within the TTL, it is used.
+        If not, the method tries to fetch from the remote GitHub metadata URL.
+        If the fetch fails, it returns either the cached file (if available) or the fallback default.
+
+        :param name: Name of the metadata file (without .json extension).
+        :type name: str
+        :param ttl: Time-to-live for cache in seconds (default is 86400 = 1 day).
+        :type ttl: int
+        :param fallback_default: Default dictionary to use if remote and cached fetches fail.
+        :type fallback_default: dict or None
+        :return: The loaded JSON data.
+        :rtype: dict
+        :raises RuntimeError: If no valid data can be fetched or loaded and no fallback is provided.
+        """
+        remote_url = Constants.FABRIC_METADATA_URL.format(Config.get_metadata_tag())
+        remote_url += f"/{name}.json"
+        local_file = os.path.join(Constants.LOCAL_CACHE_DIR, f"{name}.json")
+
+        # Check if cache file is fresh
+        if os.path.exists(local_file):
+            age = time.time() - os.path.getmtime(local_file)
+            if age < ttl:
+                with open(local_file, "r") as f:
+                    return json.load(f)
+
+        try:
+            response = requests.get(remote_url, timeout=5)
+            response.raise_for_status()
+            data = response.json()
+            with open(local_file, "w") as f:
+                json.dump(data, f, indent=2)
+            return data
+        except Exception:
+            if os.path.exists(local_file):
+                with open(local_file, "r") as f:
+                    return json.load(f)
+            elif fallback_default is not None:
+                return fallback_default
+            else:
+                raise RuntimeError(f"Could not retrieve or load {name}.json")
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def get_os_images() -> dict:
+        """
+        Get a dictionary of supported OS images from cached metadata.
+
+        The data is fetched from a remote GitHub metadata source or returned from local cache.
+        Falls back to a static default (Constants.IMAGE_NAMES) if both fail.
+
+        :return: Dictionary of image metadata.
+        :rtype: dict
+        """
+        return Config._fetch_or_load_json("os_images", fallback_default=Constants.IMAGE_NAMES)
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def get_facility_port_details() -> dict:
+        """
+        Get the facility port metadata including descriptions and mappings.
+
+        Uses remote metadata cache if available, falling back to an empty dictionary.
+
+        :return: Dictionary of facility port details.
+        :rtype: dict
+        """
+        return Config._fetch_or_load_json("facility_ports", fallback_default={})
 
 
 if __name__ == "__main__":

--- a/fabrictestbed_extensions/fablib/config/config.py
+++ b/fabrictestbed_extensions/fablib/config/config.py
@@ -128,8 +128,8 @@ class Config:
         },
         Constants.FABRIC_METADATA_TAG: {
             Constants.ENV_VAR: Constants.FABRIC_METADATA_TAG,
-            Constants.DEFAULT: Constants.DEFAULT_FABRIC_METADATA_TAG
-        }
+            Constants.DEFAULT: Constants.DEFAULT_FABRIC_METADATA_TAG,
+        },
     }
 
     REQUIRED_ATTRS_PRETTY_NAMES = {
@@ -831,10 +831,14 @@ class Config:
         :return: Metadata tag string.
         :rtype: str
         """
-        return os.environ.get(Constants.FABRIC_METADATA_TAG, Constants.DEFAULT_FABRIC_METADATA_TAG)
+        return os.environ.get(
+            Constants.FABRIC_METADATA_TAG, Constants.DEFAULT_FABRIC_METADATA_TAG
+        )
 
     @staticmethod
-    def _fetch_or_load_json(name: str, ttl: int = 86400, fallback_default: dict | None = None) -> dict:
+    def _fetch_or_load_json(
+        name: str, ttl: int = 86400, fallback_default: dict | None = None
+    ) -> dict:
         """
         Fetch a JSON file from a remote URL, using local caching with time-based invalidation,
         and fall back to a default if the fetch or cache read fails.
@@ -892,7 +896,9 @@ class Config:
         :return: Dictionary of image metadata.
         :rtype: dict
         """
-        return Config._fetch_or_load_json("os_images", fallback_default=Constants.IMAGE_NAMES)
+        return Config._fetch_or_load_json(
+            "os_images", fallback_default=Constants.IMAGE_NAMES
+        )
 
     @staticmethod
     @lru_cache(maxsize=1)

--- a/fabrictestbed_extensions/fablib/constants.py
+++ b/fabrictestbed_extensions/fablib/constants.py
@@ -43,6 +43,8 @@ class Constants:
     DEFAULT_SLICE_PUBLIC_KEY_FILE = f"{DEFAULT_SLICE_PRIVATE_KEY_FILE}.pub"
     DEFAULT_BASTION_KEY_LOCATION = f"{DEFAULT_FABRIC_CONFIG_DIR}/fabric_bastion_key"
     DEFAULT_FABRIC_BASTION_SSH_CONFIG_FILE = f"{DEFAULT_FABRIC_CONFIG_DIR}/ssh_config"
+    DEFAULT_FABRIC_METADATA_TAG = "main"
+
     DEFAULT_FABRIC_SSH_COMMAND_LINE = (
         "ssh -i {{ _self_.private_ssh_key_file }} -F "
         + DEFAULT_FABRIC_BASTION_SSH_CONFIG_FILE
@@ -67,6 +69,7 @@ class Constants:
     FABRIC_SSH_COMMAND_LINE = "FABRIC_SSH_COMMAND_LINE"
     FABLIB_VERSION = "fablib_version"
     FABRIC_BASTION_SSH_CONFIG_FILE = "FABRIC_BASTION_SSH_CONFIG_FILE"
+    FABRIC_METADATA_TAG = "FABRIC_METADATA_TAG"
 
     FABRIC_PRIMARY = "#27aae1"
     FABRIC_PRIMARY_LIGHT = "#cde4ef"
@@ -127,30 +130,94 @@ class Constants:
     SLICE_PUBLIC_KEY = "slice_public_key"
     SLICE_PRIVATE_KEY_PASSPHRASE = "slice_private_key_passphrase"
     BASTION_SSH_CONFIG_FILE = "bastion_ssh_config_file"
+    METADATA_TAG = "metadata_tag"
 
-    IMAGE_NAMES = [
-        "default_centos8_stream",
-        "default_centos9_stream",
-        "default_centos_7",
-        "default_centos_8",
-        "default_debian_11",
-        "default_debian_12",
-        "default_fedora_39",
-        "default_fedora_40",
-        "default_freebsd_13_zfs",
-        "default_freebsd_14_zfs",
-        "default_kali",
-        "default_openbsd_7",
-        "default_rocky_8",
-        "default_rocky_9",
-        "default_ubuntu_20",
-        "default_ubuntu_22",
-        "default_ubuntu_24",
-        "docker_rocky_8",
-        "docker_rocky_9",
-        "docker_ubuntu_20",
-        "docker_ubuntu_22",
-    ]
+    IMAGE_NAMES = {
+        "default_centos8_stream": {
+            "description": "CentOS 8 Stream (non-stream)",
+            "default_user": "centos"
+        },
+        "default_centos9_stream": {
+            "description": "CentOS 9 Stream (default install)",
+            "default_user": "cloud-user"
+        },
+        "default_centos10_stream": {
+            "description": "CentOS 10 Stream (default install)",
+            "default_user": "cloud-user"
+        },
+        "default_debian_11": {
+            "description": "Debian 11 Bullseye",
+            "default_user": "debian"
+        },
+        "default_debian_12": {
+            "description": "Debian 12 Bookworm",
+            "default_user": "debian"
+        },
+        "default_fedora_39": {
+            "description": "Fedora 39",
+            "default_user": "fedora"
+        },
+        "default_fedora_40": {
+            "description": "Fedora 40",
+            "default_user": "fedora"
+        },
+        "default_freebsd_13_zfs": {
+            "description": "FreeBSD 13 with ZFS",
+            "default_user": "freebsd"
+        },
+        "default_freebsd_14_zfs": {
+            "description": "FreeBSD 14 with ZFS",
+            "default_user": "freebsd"
+        },
+        "default_kali": {
+            "description": "Kali Linux (for penetration testing)",
+            "default_user": "kali"
+        },
+        "default_openbsd_7": {
+            "description": "OpenBSD 7",
+            "default_user": "openbsd"
+        },
+        "default_rocky_8": {
+            "description": "Rocky Linux 8",
+            "default_user": "rocky"
+        },
+        "default_rocky_9": {
+            "description": "Rocky Linux 9",
+            "default_user": "rocky"
+        },
+        "default_ubuntu_20": {
+            "description": "Ubuntu 20.04 LTS Focal Fossa",
+            "default_user": "ubuntu"
+        },
+        "default_ubuntu_22": {
+            "description": "Ubuntu 22.04 LTS Jammy Jellyfish",
+            "default_user": "ubuntu"
+        },
+        "default_ubuntu_24": {
+            "description": "Ubuntu 24.04 LTS Noble Numbat",
+            "default_user": "ubuntu"
+        },
+        "docker_rocky_8": {
+            "description": "Rocky Linux 8 Docker image",
+            "default_user": "rocky"
+        },
+        "docker_rocky_9": {
+            "description": "Rocky Linux 9 Docker image",
+            "default_user": "rocky"
+        },
+        "docker_ubuntu_20": {
+            "description": "Ubuntu 20.04 LTS Docker image",
+            "default_user": "ubuntu"
+        },
+        "docker_ubuntu_22": {
+            "description": "Ubuntu 22.04 LTS Docker image",
+            "default_user": "ubuntu"
+        },
+        "attestable_bmv2_v1_ubuntu_20": {
+            "description": "Ubuntu 20.04 LTS Focal Fossa with BMv2 essentials",
+            "default_user": "ubuntu"
+        }
+    }
 
     ENV_VAR = "env_var"
     DEFAULT = "default"
@@ -209,3 +276,5 @@ class Constants:
     P4_DedicatedPort = "P4_DedicatedPort"
 
     FABRIC_USER = "fabric"
+    FABRIC_METADATA_URL = "https://raw.githubusercontent.com/fabric-testbed/fabric-global-metadata/{}/metadata"
+    LOCAL_CACHE_DIR = os.path.expanduser("~/.fabric/cache")

--- a/fabrictestbed_extensions/fablib/constants.py
+++ b/fabrictestbed_extensions/fablib/constants.py
@@ -135,88 +135,73 @@ class Constants:
     IMAGE_NAMES = {
         "default_centos8_stream": {
             "description": "CentOS 8 Stream (non-stream)",
-            "default_user": "centos"
+            "default_user": "centos",
         },
         "default_centos9_stream": {
             "description": "CentOS 9 Stream (default install)",
-            "default_user": "cloud-user"
+            "default_user": "cloud-user",
         },
         "default_centos10_stream": {
             "description": "CentOS 10 Stream (default install)",
-            "default_user": "cloud-user"
+            "default_user": "cloud-user",
         },
         "default_debian_11": {
             "description": "Debian 11 Bullseye",
-            "default_user": "debian"
+            "default_user": "debian",
         },
         "default_debian_12": {
             "description": "Debian 12 Bookworm",
-            "default_user": "debian"
+            "default_user": "debian",
         },
-        "default_fedora_39": {
-            "description": "Fedora 39",
-            "default_user": "fedora"
-        },
-        "default_fedora_40": {
-            "description": "Fedora 40",
-            "default_user": "fedora"
-        },
+        "default_fedora_39": {"description": "Fedora 39", "default_user": "fedora"},
+        "default_fedora_40": {"description": "Fedora 40", "default_user": "fedora"},
         "default_freebsd_13_zfs": {
             "description": "FreeBSD 13 with ZFS",
-            "default_user": "freebsd"
+            "default_user": "freebsd",
         },
         "default_freebsd_14_zfs": {
             "description": "FreeBSD 14 with ZFS",
-            "default_user": "freebsd"
+            "default_user": "freebsd",
         },
         "default_kali": {
             "description": "Kali Linux (for penetration testing)",
-            "default_user": "kali"
+            "default_user": "kali",
         },
-        "default_openbsd_7": {
-            "description": "OpenBSD 7",
-            "default_user": "openbsd"
-        },
-        "default_rocky_8": {
-            "description": "Rocky Linux 8",
-            "default_user": "rocky"
-        },
-        "default_rocky_9": {
-            "description": "Rocky Linux 9",
-            "default_user": "rocky"
-        },
+        "default_openbsd_7": {"description": "OpenBSD 7", "default_user": "openbsd"},
+        "default_rocky_8": {"description": "Rocky Linux 8", "default_user": "rocky"},
+        "default_rocky_9": {"description": "Rocky Linux 9", "default_user": "rocky"},
         "default_ubuntu_20": {
             "description": "Ubuntu 20.04 LTS Focal Fossa",
-            "default_user": "ubuntu"
+            "default_user": "ubuntu",
         },
         "default_ubuntu_22": {
             "description": "Ubuntu 22.04 LTS Jammy Jellyfish",
-            "default_user": "ubuntu"
+            "default_user": "ubuntu",
         },
         "default_ubuntu_24": {
             "description": "Ubuntu 24.04 LTS Noble Numbat",
-            "default_user": "ubuntu"
+            "default_user": "ubuntu",
         },
         "docker_rocky_8": {
             "description": "Rocky Linux 8 Docker image",
-            "default_user": "rocky"
+            "default_user": "rocky",
         },
         "docker_rocky_9": {
             "description": "Rocky Linux 9 Docker image",
-            "default_user": "rocky"
+            "default_user": "rocky",
         },
         "docker_ubuntu_20": {
             "description": "Ubuntu 20.04 LTS Docker image",
-            "default_user": "ubuntu"
+            "default_user": "ubuntu",
         },
         "docker_ubuntu_22": {
             "description": "Ubuntu 22.04 LTS Docker image",
-            "default_user": "ubuntu"
+            "default_user": "ubuntu",
         },
         "attestable_bmv2_v1_ubuntu_20": {
             "description": "Ubuntu 20.04 LTS Focal Fossa with BMv2 essentials",
-            "default_user": "ubuntu"
-        }
+            "default_user": "ubuntu",
+        },
     }
 
     ENV_VAR = "env_var"

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -780,6 +780,7 @@ class Node:
         if self.get_fim_node().type == NodeType.Switch and not username:
             self.username = Constants.FABRIC_USER
             return
+        username = self.get_fablib_manager().get_os_images().get(self.get_image())
         if username is not None:
             self.username = username
         elif "default_centos10_stream" == self.get_image():

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -963,6 +963,7 @@ class FacilityPorts(Resources):
         "local_name": "Local Name",
         "device_name": "Device Name",
         "region": "Region",
+        "description": "Description"
     }
 
     def __init__(self, fablib_manager):
@@ -1019,6 +1020,7 @@ class FacilityPorts(Resources):
                 "local_name",
                 "device_name",
                 "region",
+                "description"
             ],
         )
 
@@ -1055,6 +1057,7 @@ class FacilityPorts(Resources):
             vlan_range = "N/A"
 
         label_allocations = iface.get_property("label_allocations")
+        fp_details = self.get_fablib_manager().get_facility_port_details()
         return {
             "name": name,
             "site_name": site,
@@ -1068,6 +1071,7 @@ class FacilityPorts(Resources):
             "region": (
                 iface.labels.region if iface.labels and iface.labels.region else "N/A"
             ),
+            "description": fp_details.get(name, {}).get("description", "N/A")
         }
 
     def list_facility_ports(

--- a/fabrictestbed_extensions/fablib/resources.py
+++ b/fabrictestbed_extensions/fablib/resources.py
@@ -963,7 +963,7 @@ class FacilityPorts(Resources):
         "local_name": "Local Name",
         "device_name": "Device Name",
         "region": "Region",
-        "description": "Description"
+        "description": "Description",
     }
 
     def __init__(self, fablib_manager):
@@ -1020,7 +1020,7 @@ class FacilityPorts(Resources):
                 "local_name",
                 "device_name",
                 "region",
-                "description"
+                "description",
             ],
         )
 
@@ -1071,7 +1071,7 @@ class FacilityPorts(Resources):
             "region": (
                 iface.labels.region if iface.labels and iface.labels.region else "N/A"
             ),
-            "description": fp_details.get(name, {}).get("description", "N/A")
+            "description": fp_details.get(name, {}).get("description", "N/A"),
         }
 
     def list_facility_ports(


### PR DESCRIPTION
We need to enhance fablib to reliably fetch metadata files (e.g., os_images.json and facility_ports.json) from the fabric-global-metadata repository. This implementation should:

Use a configurable metadata tag (FABRIC_METADATA_TAG) to control which version/branch is fetched.

Cache metadata locally under ~/.fabric/cache for fast reuse and to reduce GitHub traffic.

Refresh the cache automatically after a configurable TTL (default 1 day).

Provide a static fallback dictionary if fetching and cache loading fail.

Use @staticmethod and @lru_cache decorators to avoid repeated loads within the same process.

#425 