### PR TITLE
list_nodes does not show P4 switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## TODO
+- List Nodes fails to list P4 switches (Issue [#436](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/436))
+
 ## 1.9.1
 - `get_interfaces()` and `get_interface()` behavior for `NetworkService` and `Node` (Issue [#434](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/434))
 

--- a/fabrictestbed_extensions/fablib/switch.py
+++ b/fabrictestbed_extensions/fablib/switch.py
@@ -395,5 +395,5 @@ class Switch(Node):
         :rtype: Node
         """
         ret_val = Switch(slice, node)
-        ret_val.get_interface()
+        ret_val.get_interfaces()
         return ret_val

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,4 @@ omit-covered-files = true
 verbose = 0
 fail-under = 92.6
 exclude = ["tests", "fabrictestbed_extensions/editors"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,4 +87,3 @@ omit-covered-files = true
 verbose = 0
 fail-under = 92.6
 exclude = ["tests", "fabrictestbed_extensions/editors"]
-


### PR DESCRIPTION
list_nodes does not show P4 switches

Issue was introduced by a typo of loading interfaces instead of single interface on creation of Switch Node