### PR TITLE
Add find_resource_slot with slice support and find-slot CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `find_resource_slot()` to FablibManager for finding time windows where specific resources are simultaneously available
+- Add resources_calendar() to FablibManager for querying resource availability over time
 
 ### Changed
 - Remove unused dependencies: `numpy`, `recordclass`, duplicate `ipycytoscape`

--- a/fabrictestbed_extensions/cli/cli.py
+++ b/fabrictestbed_extensions/cli/cli.py
@@ -1731,8 +1731,14 @@ def facility_ports(
     default="all",
     help="Token scope",
 )
-@click.option("--start", required=True, help="Start date (ISO 8601, e.g. 2025-07-01T00:00:00+00:00)")
-@click.option("--end", required=True, help="End date (ISO 8601, e.g. 2025-07-04T00:00:00+00:00)")
+@click.option(
+    "--start",
+    required=True,
+    help="Start date (ISO 8601, e.g. 2025-07-01T00:00:00+00:00)",
+)
+@click.option(
+    "--end", required=True, help="End date (ISO 8601, e.g. 2025-07-04T00:00:00+00:00)"
+)
 @click.option(
     "--interval",
     type=click.Choice(["hour", "day", "week"], case_sensitive=False),
@@ -1816,14 +1822,34 @@ def calendar(
     default="all",
     help="Token scope",
 )
-@click.option("--start", required=True, help="Start date (ISO 8601, e.g. 2025-07-01T00:00:00+00:00)")
-@click.option("--end", required=True, help="End date (ISO 8601, e.g. 2025-07-04T00:00:00+00:00)")
+@click.option(
+    "--start",
+    required=True,
+    help="Start date (ISO 8601, e.g. 2025-07-01T00:00:00+00:00)",
+)
+@click.option(
+    "--end", required=True, help="End date (ISO 8601, e.g. 2025-07-04T00:00:00+00:00)"
+)
 @click.option("--duration", required=True, type=int, help="Consecutive hours needed")
-@click.option("--resources", "resources_json", required=True,
-              help='JSON array of resource requests, e.g. \'[{"type":"compute","site":"RENC","cores":2,"ram":8,"disk":10}]\'')
-@click.option("--max-results", type=int, default=1, help="Maximum number of windows to return (default: 1)")
-@click.option("--live", "use_live_data", is_flag=True, default=False,
-              help="Use live orchestrator data instead of Reports API")
+@click.option(
+    "--resources",
+    "resources_json",
+    required=True,
+    help='JSON array of resource requests, e.g. \'[{"type":"compute","site":"RENC","cores":2,"ram":8,"disk":10}]\'',
+)
+@click.option(
+    "--max-results",
+    type=int,
+    default=1,
+    help="Maximum number of windows to return (default: 1)",
+)
+@click.option(
+    "--live",
+    "use_live_data",
+    is_flag=True,
+    default=False,
+    help="Use live orchestrator data instead of Reports API",
+)
 @click.pass_context
 def find_slot(
     ctx,

--- a/fabrictestbed_extensions/cli/cli.py
+++ b/fabrictestbed_extensions/cli/cli.py
@@ -1716,6 +1716,172 @@ def facility_ports(
         raise click.ClickException(str(e))
 
 
+@resources.command()
+@click.option("--cmhost", help="Credential Manager host", default=None)
+@click.option("--ochost", help="Orchestrator host", default=None)
+@click.option(
+    "--location",
+    help="Path to token JSON file (defaults to $FABRIC_TOKEN_LOCATION or ~/work/fabric_config/id_token.json)",
+    default=None,
+)
+@click.option("--projectid", default=None, help="Project UUID")
+@click.option(
+    "--scope",
+    type=click.Choice(["cf", "mf", "all"], case_sensitive=False),
+    default="all",
+    help="Token scope",
+)
+@click.option("--start", required=True, help="Start date (ISO 8601, e.g. 2025-07-01T00:00:00+00:00)")
+@click.option("--end", required=True, help="End date (ISO 8601, e.g. 2025-07-04T00:00:00+00:00)")
+@click.option(
+    "--interval",
+    type=click.Choice(["hour", "day", "week"], case_sensitive=False),
+    default="day",
+    help="Time slot granularity (default: day)",
+)
+@click.option("--site", multiple=True, help="Include site (repeatable)")
+@click.option("--host", multiple=True, help="Include host (repeatable)")
+@click.option("--exclude-site", multiple=True, help="Exclude site (repeatable)")
+@click.option("--exclude-host", multiple=True, help="Exclude host (repeatable)")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output JSON instead of table",
+)
+@click.pass_context
+def calendar(
+    ctx,
+    cmhost: str,
+    ochost: str,
+    location: str,
+    projectid: str,
+    scope: str,
+    start: str,
+    end: str,
+    interval: str,
+    site: tuple,
+    host: tuple,
+    exclude_site: tuple,
+    exclude_host: tuple,
+    as_json: bool,
+):
+    """Resource availability calendar
+
+    Show resource capacity, allocation, and availability per site/host
+    over time slots. Use --interval to control granularity.
+    """
+    try:
+        from datetime import datetime, timezone
+
+        start_dt = datetime.fromisoformat(start)
+        end_dt = datetime.fromisoformat(end)
+
+        fablib = __get_fablib_manager(
+            cm_host=cmhost,
+            oc_host=ochost,
+            project_id=projectid,
+            scope=scope,
+            token_location=location,
+        )
+        fablib.resources_calendar(
+            start=start_dt,
+            end=end_dt,
+            interval=interval,
+            site=list(site) or None,
+            host=list(host) or None,
+            exclude_site=list(exclude_site) or None,
+            exclude_host=list(exclude_host) or None,
+            output="json" if as_json else "text",
+        )
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(str(e))
+
+
+@resources.command(name="find-slot")
+@click.option("--cmhost", help="Credential Manager host", default=None)
+@click.option("--ochost", help="Orchestrator host", default=None)
+@click.option(
+    "--location",
+    help="Path to token JSON file (defaults to $FABRIC_TOKEN_LOCATION or ~/work/fabric_config/id_token.json)",
+    default=None,
+)
+@click.option("--projectid", default=None, help="Project UUID")
+@click.option(
+    "--scope",
+    type=click.Choice(["cf", "mf", "all"], case_sensitive=False),
+    default="all",
+    help="Token scope",
+)
+@click.option("--start", required=True, help="Start date (ISO 8601, e.g. 2025-07-01T00:00:00+00:00)")
+@click.option("--end", required=True, help="End date (ISO 8601, e.g. 2025-07-04T00:00:00+00:00)")
+@click.option("--duration", required=True, type=int, help="Consecutive hours needed")
+@click.option("--resources", "resources_json", required=True,
+              help='JSON array of resource requests, e.g. \'[{"type":"compute","site":"RENC","cores":2,"ram":8,"disk":10}]\'')
+@click.option("--max-results", type=int, default=1, help="Maximum number of windows to return (default: 1)")
+@click.option("--live", "use_live_data", is_flag=True, default=False,
+              help="Use live orchestrator data instead of Reports API")
+@click.pass_context
+def find_slot(
+    ctx,
+    cmhost: str,
+    ochost: str,
+    location: str,
+    projectid: str,
+    scope: str,
+    start: str,
+    end: str,
+    duration: int,
+    resources_json: str,
+    max_results: int,
+    use_live_data: bool,
+):
+    """Find available time slots
+
+    Find time windows where all requested resources are simultaneously
+    available. Use --live for real-time data from the orchestrator instead
+    of the Reports API.
+    """
+    try:
+        import json as json_mod
+        from datetime import datetime, timezone
+
+        start_dt = datetime.fromisoformat(start)
+        end_dt = datetime.fromisoformat(end)
+
+        try:
+            resources_list = json_mod.loads(resources_json)
+        except json_mod.JSONDecodeError as exc:
+            raise click.ClickException(f"Invalid JSON for --resources: {exc}")
+
+        if not isinstance(resources_list, list):
+            raise click.ClickException("--resources must be a JSON array")
+
+        fablib = __get_fablib_manager(
+            cm_host=cmhost,
+            oc_host=ochost,
+            project_id=projectid,
+            scope=scope,
+            token_location=location,
+        )
+        result = fablib.find_resource_slot(
+            start=start_dt,
+            end=end_dt,
+            duration=duration,
+            resources=resources_list,
+            max_results=max_results,
+            use_live_data=use_live_data,
+        )
+        click.echo(json_mod.dumps(result, indent=2))
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(str(e))
+
+
 @click.group()
 @click.pass_context
 def configure(ctx):

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1498,6 +1498,7 @@ Host * !bastion.fabric-testbed.net
         slice: Optional["Slice"] = None,
         resources: Optional[List[Dict[str, Any]]] = None,
         max_results: int = 1,
+        use_live_data: bool = False,
     ) -> Dict[str, Any]:
         """
         Find time windows where requested resources are simultaneously available.
@@ -1519,6 +1520,8 @@ Host * !bastion.fabric-testbed.net
             to resource requirements automatically
         :param resources: list of resource requirement dicts (advanced usage)
         :param max_results: maximum number of slots to return
+        :param use_live_data: when True, use live orchestrator data instead of
+            Reports API for more accurate, real-time availability
         :return: dict with slot results
         :raises ValueError: if both or neither of ``slice`` and ``resources``
             are provided
@@ -1534,12 +1537,101 @@ Host * !bastion.fabric-testbed.net
         if start and end and (end - start) < datetime.timedelta(minutes=60):
             raise Exception("Time range should be at least 60 minutes long!")
 
+        if start and end and (end - start).days > 30:
+            raise Exception("Search range must not exceed 30 days")
+
         return self.get_manager().find_resource_slot(
             start=start,
             end=end,
             duration=duration,
             resources=resources,
             max_results=max_results,
+            use_live_data=use_live_data,
+        )
+
+    def resources_calendar(
+        self,
+        start: datetime.datetime,
+        end: datetime.datetime,
+        interval: str = "day",
+        site: Optional[List[str]] = None,
+        host: Optional[List[str]] = None,
+        exclude_site: Optional[List[str]] = None,
+        exclude_host: Optional[List[str]] = None,
+        output: Optional[str] = None,
+        fields: Optional[List[str]] = None,
+        quiet: bool = False,
+        filter_function=None,
+    ):
+        """
+        Fetch and display resource availability calendar over time slots.
+
+        There are several output options: ``"text"``, ``"pandas"``, and
+        ``"json"`` that determine the format of the output that is
+        returned and (optionally) displayed/printed.
+
+        output:  ``'text'``: string formatted with tabulate
+                 ``'pandas'``: pandas dataframe (default in Jupyter)
+                 ``'json'``: string in json format
+                 ``'list'``: raw list of dicts
+
+        fields: list of columns to include in the output table.
+
+        Example: ``fields=['Date', 'Site', 'Cores (avail/cap)', 'RAM GB (avail/cap)']``
+
+        filter_function: A lambda to filter the flattened rows.
+
+        Example: ``filter_function=lambda r: r['Site'] == 'RENC'``
+
+        :param start: start of the calendar window (UTC)
+        :type start: datetime.datetime
+        :param end: end of the calendar window (UTC)
+        :type end: datetime.datetime
+        :param interval: time slot granularity: hour, day, or week
+        :type interval: str
+        :param site: list of site names to include
+        :type site: list[str]
+        :param host: list of host names to include
+        :type host: list[str]
+        :param exclude_site: list of site names to exclude
+        :type exclude_site: list[str]
+        :param exclude_host: list of host names to exclude
+        :type exclude_host: list[str]
+        :param output: output format
+        :type output: str
+        :param fields: list of fields (table columns) to show
+        :type fields: list[str]
+        :param quiet: True to suppress printing/display
+        :type quiet: bool
+        :param filter_function: lambda function to filter rows
+        :type filter_function: callable
+        :return: table in format specified by output parameter
+        """
+        if start and end and start >= end:
+            raise ValueError("start must be before end")
+
+        if start and end and (end - start) < datetime.timedelta(minutes=60):
+            raise Exception("Time range should be at least 60 minutes long!")
+
+        if start and end and (end - start).days > 30:
+            raise Exception("Search range must not exceed 30 days")
+
+        calendar_data = self.get_manager().resources_calendar(
+            start=start,
+            end=end,
+            interval=interval,
+            site=site,
+            host=host,
+            exclude_site=exclude_site,
+            exclude_host=exclude_host,
+        )
+
+        return Utils.show_calendar(
+            calendar_data,
+            fields=fields,
+            output=output,
+            quiet=quiet,
+            filter_function=filter_function,
         )
 
     def get_random_site(

--- a/fabrictestbed_extensions/utils/utils.py
+++ b/fabrictestbed_extensions/utils/utils.py
@@ -717,6 +717,85 @@ class Utils:
         return table
 
     @staticmethod
+    def calendar_to_rows(
+        calendar_data: Dict[str, Any],
+    ) -> List[Dict[str, str]]:
+        """
+        Flatten a ``resources_calendar()`` response into tabular rows.
+
+        Each row represents one (time-slot, site) pair with columns for
+        date, site name, cores, ram, disk (as ``"available/capacity"``),
+        and one column per component type.
+
+        :param calendar_data: The dict returned by
+            ``fablib.resources_calendar()`` or the orchestrator.
+        :return: A list of row dicts suitable for :py:meth:`list_table`.
+        :rtype: list[dict]
+        """
+        interval = calendar_data.get("interval", "day")
+        rows: List[Dict[str, str]] = []
+        for slot in calendar_data.get("data", []):
+            start = slot.get("start", "")
+            end = slot.get("end", "")
+            # Show date only for day/week, datetime for hour
+            if interval in ("day", "week"):
+                slot_label = start[:10] if len(start) >= 10 else start
+            else:
+                slot_label = start[:16] if len(start) >= 16 else start
+
+            for site in slot.get("sites", []):
+                row: Dict[str, str] = {
+                    "Date": slot_label,
+                    "Site": site.get("name", ""),
+                    "Cores (avail/cap)": f"{site.get('cores_available', '—')}/{site.get('cores_capacity', '—')}",
+                    "RAM GB (avail/cap)": f"{site.get('ram_available', '—')}/{site.get('ram_capacity', '—')}",
+                    "Disk GB (avail/cap)": f"{site.get('disk_available', '—')}/{site.get('disk_capacity', '—')}",
+                }
+                for comp_name, comp in site.get("components", {}).items():
+                    cap = comp.get("capacity", 0)
+                    if cap and cap > 0:
+                        row[comp_name] = f"{comp.get('available', 0)}/{cap}"
+                rows.append(row)
+        return rows
+
+    @staticmethod
+    def show_calendar(
+        calendar_data: Dict[str, Any],
+        fields: Union[List[str], None] = None,
+        output: Union[str, None] = None,
+        quiet: bool = False,
+        filter_function: Union[Callable[[Iterable], bool], None] = None,
+    ):
+        """
+        Display a resource calendar as a formatted table.
+
+        Converts the ``resources_calendar()`` response into rows and
+        renders them using :py:meth:`list_table`.
+
+        :param calendar_data: The dict returned by
+            ``fablib.resources_calendar()``.
+        :param fields: Columns to include.  ``None`` means all.
+        :param output: Output format (``"text"``, ``"json"``,
+            ``"pandas"``, ``"list"``).  Auto-detected if ``None``.
+        :param quiet: Suppress printing when ``True``.
+        :param filter_function: A lambda to filter the flattened rows.
+        :return: Formatted table.
+        """
+        rows = Utils.calendar_to_rows(calendar_data)
+        interval = calendar_data.get("interval", "day")
+        q_start = calendar_data.get("query_start", "")[:10]
+        q_end = calendar_data.get("query_end", "")[:10]
+        title = f"Resource Calendar ({interval} interval, {q_start} to {q_end})"
+        return Utils.list_table(
+            data=rows,
+            fields=fields,
+            title=title,
+            output=output,
+            quiet=quiet,
+            filter_function=filter_function,
+        )
+
+    @staticmethod
     def _determine_output_type(output: Union[str, None]) -> str:
         """
         Determine the output format based on the running environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "ipywidgets",
     "ipyleaflet",
     "tabulate",
-    "fabrictestbed==2.0.5",
+    "fabrictestbed==2.0.6",
     "paramiko",
     "jinja2>=3.0.0",
     "pandas",

--- a/tests/unit/test_find_resource_slot.py
+++ b/tests/unit/test_find_resource_slot.py
@@ -393,7 +393,8 @@ class TestFindResourceSlotManagerCall(FindResourceSlotTestBase):
             )
 
         mock_manager.find_resource_slot.assert_called_once_with(
-            start=start, end=end, duration=2, resources=resources, max_results=3
+            start=start, end=end, duration=2, resources=resources, max_results=3,
+            use_live_data=False,
         )
         self.assertEqual(result, expected)
 

--- a/tests/unit/test_find_resource_slot.py
+++ b/tests/unit/test_find_resource_slot.py
@@ -393,7 +393,11 @@ class TestFindResourceSlotManagerCall(FindResourceSlotTestBase):
             )
 
         mock_manager.find_resource_slot.assert_called_once_with(
-            start=start, end=end, duration=2, resources=resources, max_results=3,
+            start=start,
+            end=end,
+            duration=2,
+            resources=resources,
+            max_results=3,
             use_live_data=False,
         )
         self.assertEqual(result, expected)


### PR DESCRIPTION
## Summary
- Add `find_resource_slot()` to `FablibManager` accepting either a Slice object or raw resource dicts to find available time windows
- Automatically extract resource requirements (compute, components, links, facility ports) from unsubmitted Slice objects via `_slice_to_resources()`
- Normalize component keys between fablib format (e.g., `NIC_ConnectX_5`) and DB format (e.g., `SmartNIC-ConnectX-5`)
- Add `resources_calendar()` to `FablibManager` for querying resource availability over time
- Add `fabric-cli resources find-slot` and `fabric-cli resources calendar` CLI commands
- Support `use_live_data` parameter for real-time availability
- Update FIM dependency

## Test plan
- [ ] Run `pytest tests/unit/test_find_resource_slot.py` for unit tests
- [ ] Run `pytest tests/integration/test_find_resource_slot.py` against live testbed
- [ ] Test `fabric-cli resources find-slot` with various parameters
- [ ] Test `fabric-cli resources calendar` with day/hour/week intervals
- [ ] Verify slice-based find-slot correctly identifies resources from topology