### PR TITLE
Add host support and show filter to resource calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `find_resource_slot()` to FablibManager for finding time windows where specific resources are simultaneously available
 - Add resources_calendar() to FablibManager for querying resource availability over time
+- Add host support to resource calendar with `show` parameter to filter by sites, hosts, or all
 
 ### Changed
 - Remove unused dependencies: `numpy`, `recordclass`, duplicate `ipycytoscape`

--- a/fabrictestbed_extensions/cli/cli.py
+++ b/fabrictestbed_extensions/cli/cli.py
@@ -1750,6 +1750,12 @@ def facility_ports(
 @click.option("--exclude-site", multiple=True, help="Exclude site (repeatable)")
 @click.option("--exclude-host", multiple=True, help="Exclude host (repeatable)")
 @click.option(
+    "--show",
+    type=click.Choice(["all", "sites", "hosts"], case_sensitive=False),
+    default="all",
+    help="Show sites, hosts, or all (default: all)",
+)
+@click.option(
     "--json",
     "as_json",
     is_flag=True,
@@ -1771,6 +1777,7 @@ def calendar(
     host: tuple,
     exclude_site: tuple,
     exclude_host: tuple,
+    show: str,
     as_json: bool,
 ):
     """Resource availability calendar
@@ -1799,6 +1806,7 @@ def calendar(
             host=list(host) or None,
             exclude_site=list(exclude_site) or None,
             exclude_host=list(exclude_host) or None,
+            show=show,
             output="json" if as_json else "text",
         )
     except click.ClickException:

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -1558,6 +1558,7 @@ Host * !bastion.fabric-testbed.net
         host: Optional[List[str]] = None,
         exclude_site: Optional[List[str]] = None,
         exclude_host: Optional[List[str]] = None,
+        show: str = "all",
         output: Optional[str] = None,
         fields: Optional[List[str]] = None,
         quiet: bool = False,
@@ -1577,11 +1578,11 @@ Host * !bastion.fabric-testbed.net
 
         fields: list of columns to include in the output table.
 
-        Example: ``fields=['Date', 'Site', 'Cores (avail/cap)', 'RAM GB (avail/cap)']``
+        Example: ``fields=['Date', 'Name', 'Cores (avail/cap)', 'RAM GB (avail/cap)']``
 
         filter_function: A lambda to filter the flattened rows.
 
-        Example: ``filter_function=lambda r: r['Site'] == 'RENC'``
+        Example: ``filter_function=lambda r: r['Name'] == 'RENC'``
 
         :param start: start of the calendar window (UTC)
         :type start: datetime.datetime
@@ -1597,6 +1598,9 @@ Host * !bastion.fabric-testbed.net
         :type exclude_site: list[str]
         :param exclude_host: list of host names to exclude
         :type exclude_host: list[str]
+        :param show: which resource types to display: ``"sites"``,
+            ``"hosts"``, or ``"all"`` (default)
+        :type show: str
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
@@ -1628,6 +1632,7 @@ Host * !bastion.fabric-testbed.net
 
         return Utils.show_calendar(
             calendar_data,
+            show=show,
             fields=fields,
             output=output,
             quiet=quiet,

--- a/fabrictestbed_extensions/utils/utils.py
+++ b/fabrictestbed_extensions/utils/utils.py
@@ -719,20 +719,26 @@ class Utils:
     @staticmethod
     def calendar_to_rows(
         calendar_data: Dict[str, Any],
+        show: str = "all",
     ) -> List[Dict[str, str]]:
         """
         Flatten a ``resources_calendar()`` response into tabular rows.
 
-        Each row represents one (time-slot, site) pair with columns for
-        date, site name, cores, ram, disk (as ``"available/capacity"``),
+        Each row represents one (time-slot, site/host) pair with columns for
+        date, site or host name, cores, ram, disk (as ``"available/capacity"``),
         and one column per component type.
 
         :param calendar_data: The dict returned by
             ``fablib.resources_calendar()`` or the orchestrator.
+        :param show: Which resource types to include: ``"sites"``,
+            ``"hosts"``, or ``"all"`` (default).
+        :type show: str
         :return: A list of row dicts suitable for :py:meth:`list_table`.
         :rtype: list[dict]
         """
         interval = calendar_data.get("interval", "day")
+        include_sites = show in ("all", "sites")
+        include_hosts = show in ("all", "hosts")
         rows: List[Dict[str, str]] = []
         for slot in calendar_data.get("data", []):
             start = slot.get("start", "")
@@ -743,24 +749,43 @@ class Utils:
             else:
                 slot_label = start[:16] if len(start) >= 16 else start
 
-            for site in slot.get("sites", []):
-                row: Dict[str, str] = {
-                    "Date": slot_label,
-                    "Site": site.get("name", ""),
-                    "Cores (avail/cap)": f"{site.get('cores_available', '—')}/{site.get('cores_capacity', '—')}",
-                    "RAM GB (avail/cap)": f"{site.get('ram_available', '—')}/{site.get('ram_capacity', '—')}",
-                    "Disk GB (avail/cap)": f"{site.get('disk_available', '—')}/{site.get('disk_capacity', '—')}",
-                }
-                for comp_name, comp in site.get("components", {}).items():
-                    cap = comp.get("capacity", 0)
-                    if cap and cap > 0:
-                        row[comp_name] = f"{comp.get('available', 0)}/{cap}"
-                rows.append(row)
+            if include_sites:
+                for site in slot.get("sites", []):
+                    row: Dict[str, str] = {
+                        "Date": slot_label,
+                        "Type": "site",
+                        "Name": site.get("name", ""),
+                        "Cores (avail/cap)": f"{site.get('cores_available', '—')}/{site.get('cores_capacity', '—')}",
+                        "RAM GB (avail/cap)": f"{site.get('ram_available', '—')}/{site.get('ram_capacity', '—')}",
+                        "Disk GB (avail/cap)": f"{site.get('disk_available', '—')}/{site.get('disk_capacity', '—')}",
+                    }
+                    for comp_name, comp in site.get("components", {}).items():
+                        cap = comp.get("capacity", 0)
+                        if cap and cap > 0:
+                            row[comp_name] = f"{comp.get('available', 0)}/{cap}"
+                    rows.append(row)
+
+            if include_hosts:
+                for host in slot.get("hosts", []):
+                    row: Dict[str, str] = {
+                        "Date": slot_label,
+                        "Type": "host",
+                        "Name": host.get("name", ""),
+                        "Cores (avail/cap)": f"{host.get('cores_available', '—')}/{host.get('cores_capacity', '—')}",
+                        "RAM GB (avail/cap)": f"{host.get('ram_available', '—')}/{host.get('ram_capacity', '—')}",
+                        "Disk GB (avail/cap)": f"{host.get('disk_available', '—')}/{host.get('disk_capacity', '—')}",
+                    }
+                    for comp_name, comp in host.get("components", {}).items():
+                        cap = comp.get("capacity", 0)
+                        if cap and cap > 0:
+                            row[comp_name] = f"{comp.get('available', 0)}/{cap}"
+                    rows.append(row)
         return rows
 
     @staticmethod
     def show_calendar(
         calendar_data: Dict[str, Any],
+        show: str = "all",
         fields: Union[List[str], None] = None,
         output: Union[str, None] = None,
         quiet: bool = False,
@@ -774,6 +799,9 @@ class Utils:
 
         :param calendar_data: The dict returned by
             ``fablib.resources_calendar()``.
+        :param show: Which resource types to include: ``"sites"``,
+            ``"hosts"``, or ``"all"`` (default).
+        :type show: str
         :param fields: Columns to include.  ``None`` means all.
         :param output: Output format (``"text"``, ``"json"``,
             ``"pandas"``, ``"list"``).  Auto-detected if ``None``.
@@ -781,7 +809,7 @@ class Utils:
         :param filter_function: A lambda to filter the flattened rows.
         :return: Formatted table.
         """
-        rows = Utils.calendar_to_rows(calendar_data)
+        rows = Utils.calendar_to_rows(calendar_data, show=show)
         interval = calendar_data.get("interval", "day")
         q_start = calendar_data.get("query_start", "")[:10]
         q_end = calendar_data.get("query_end", "")[:10]

--- a/tests/unit/test_resources_calendar.py
+++ b/tests/unit/test_resources_calendar.py
@@ -1,0 +1,310 @@
+"""
+Unit tests for FablibManager.resources_calendar().
+"""
+
+import datetime
+import os
+import pathlib
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fabrictestbed_extensions.fablib.fablib import FablibManager
+
+# A minimal calendar response that Utils.show_calendar can process
+EMPTY_CALENDAR = {
+    "data": [],
+    "interval": "day",
+    "query_start": "",
+    "query_end": "",
+    "total": 0,
+}
+
+SAMPLE_CALENDAR = {
+    "data": [
+        {
+            "start": "2025-07-01T00:00:00+00:00",
+            "end": "2025-07-02T00:00:00+00:00",
+            "sites": [
+                {
+                    "name": "RENC",
+                    "cores_available": 100,
+                    "cores_capacity": 128,
+                    "ram_available": 400,
+                    "ram_capacity": 512,
+                    "disk_available": 5000,
+                    "disk_capacity": 10000,
+                    "components": {},
+                }
+            ],
+            "hosts": [
+                {
+                    "name": "renc-w1.fabric-testbed.net",
+                    "cores_available": 32,
+                    "cores_capacity": 64,
+                    "ram_available": 200,
+                    "ram_capacity": 256,
+                    "disk_available": 2000,
+                    "disk_capacity": 5000,
+                    "components": {
+                        "GPU Tesla T4": {"available": 2, "capacity": 4},
+                    },
+                }
+            ],
+            "links": [],
+            "facility_ports": [],
+        }
+    ],
+    "interval": "day",
+    "query_start": "2025-07-01T00:00:00+00:00",
+    "query_end": "2025-07-02T00:00:00+00:00",
+    "total": 1,
+}
+
+
+class CalendarTestBase(unittest.TestCase):
+    """Common setup: create an offline FablibManager instance."""
+
+    DUMMY_TOKEN_LOCATION = str(
+        pathlib.Path(__file__).parent / "data" / "dummy-token.json"
+    )
+    FABRIC_RC_LOCATION = str(pathlib.Path(__file__).parent / "data" / "dummy_fabric_rc")
+
+    def setUp(self):
+        os.environ.clear()
+        self.fablib = FablibManager(
+            token_location=self.DUMMY_TOKEN_LOCATION,
+            offline=True,
+            project_id="DUMMY_PROJECT_ID",
+            bastion_username="DUMMY_BASTION_USER",
+            fabric_rc=self.FABRIC_RC_LOCATION,
+        )
+
+
+class TestResourcesCalendarValidation(CalendarTestBase):
+    """Test input validation in resources_calendar()."""
+
+    def _times(self, hours=2):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(hours=hours)
+        return start, end
+
+    def test_raises_when_start_equals_end(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        with self.assertRaises(ValueError) as ctx:
+            self.fablib.resources_calendar(start=start, end=start)
+        self.assertIn("start must be before end", str(ctx.exception))
+
+    def test_raises_when_start_after_end(self):
+        start = datetime.datetime(2025, 7, 2, 0, 0, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        with self.assertRaises(ValueError) as ctx:
+            self.fablib.resources_calendar(start=start, end=end)
+        self.assertIn("start must be before end", str(ctx.exception))
+
+    def test_raises_when_time_range_too_short(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(minutes=30)
+        with self.assertRaises(Exception) as ctx:
+            self.fablib.resources_calendar(start=start, end=end)
+        self.assertIn("at least 60 minutes", str(ctx.exception))
+
+    def test_exactly_60_minutes_does_not_raise(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(minutes=60)
+        mock_manager = MagicMock()
+        mock_manager.resources_calendar.return_value = EMPTY_CALENDAR
+
+        with patch.object(self.fablib, "get_manager", return_value=mock_manager):
+            # Should not raise; output format doesn't matter for this test
+            self.fablib.resources_calendar(
+                start=start, end=end, output="list", quiet=True
+            )
+
+
+class TestResourcesCalendarManagerCall(CalendarTestBase):
+    """Test that resources_calendar() correctly calls the manager."""
+
+    def test_default_params_forwarded(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(hours=4)
+
+        mock_manager = MagicMock()
+        mock_manager.resources_calendar.return_value = EMPTY_CALENDAR
+
+        with patch.object(self.fablib, "get_manager", return_value=mock_manager):
+            self.fablib.resources_calendar(
+                start=start, end=end, output="list", quiet=True
+            )
+
+        mock_manager.resources_calendar.assert_called_once_with(
+            start=start,
+            end=end,
+            interval="day",
+            site=None,
+            host=None,
+            exclude_site=None,
+            exclude_host=None,
+        )
+
+    def test_all_params_forwarded(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(hours=24)
+
+        mock_manager = MagicMock()
+        mock_manager.resources_calendar.return_value = SAMPLE_CALENDAR
+
+        with patch.object(self.fablib, "get_manager", return_value=mock_manager):
+            self.fablib.resources_calendar(
+                start=start,
+                end=end,
+                interval="hour",
+                site=["RENC"],
+                host=["host1"],
+                exclude_site=["UCSD"],
+                exclude_host=["host2"],
+                output="list",
+                quiet=True,
+            )
+
+        mock_manager.resources_calendar.assert_called_once_with(
+            start=start,
+            end=end,
+            interval="hour",
+            site=["RENC"],
+            host=["host1"],
+            exclude_site=["UCSD"],
+            exclude_host=["host2"],
+        )
+
+    def test_interval_week_forwarded(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(days=14)
+
+        mock_manager = MagicMock()
+        mock_manager.resources_calendar.return_value = EMPTY_CALENDAR
+
+        with patch.object(self.fablib, "get_manager", return_value=mock_manager):
+            self.fablib.resources_calendar(
+                start=start,
+                end=end,
+                interval="week",
+                output="list",
+                quiet=True,
+            )
+
+        call_kwargs = mock_manager.resources_calendar.call_args[1]
+        self.assertEqual(call_kwargs["interval"], "week")
+
+    def test_output_list_returns_rows(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(hours=24)
+
+        mock_manager = MagicMock()
+        mock_manager.resources_calendar.return_value = SAMPLE_CALENDAR
+
+        with patch.object(self.fablib, "get_manager", return_value=mock_manager):
+            result = self.fablib.resources_calendar(
+                start=start,
+                end=end,
+                output="list",
+                quiet=True,
+            )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        # First row is the site
+        self.assertEqual(result[0]["Type"], "site")
+        self.assertEqual(result[0]["Name"], "RENC")
+        self.assertEqual(result[0]["Cores (avail/cap)"], "100/128")
+        # Second row is the host
+        self.assertEqual(result[1]["Type"], "host")
+        self.assertEqual(result[1]["Name"], "renc-w1.fabric-testbed.net")
+        self.assertEqual(result[1]["Cores (avail/cap)"], "32/64")
+        self.assertEqual(result[1]["GPU Tesla T4"], "2/4")
+
+    def test_filter_function_applied(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(hours=24)
+
+        mock_manager = MagicMock()
+        mock_manager.resources_calendar.return_value = SAMPLE_CALENDAR
+
+        with patch.object(self.fablib, "get_manager", return_value=mock_manager):
+            result = self.fablib.resources_calendar(
+                start=start,
+                end=end,
+                output="list",
+                quiet=True,
+                filter_function=lambda r: r["Name"] == "NONEXISTENT",
+            )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 0)
+
+    def test_show_sites_only(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(hours=24)
+
+        mock_manager = MagicMock()
+        mock_manager.resources_calendar.return_value = SAMPLE_CALENDAR
+
+        with patch.object(self.fablib, "get_manager", return_value=mock_manager):
+            result = self.fablib.resources_calendar(
+                start=start,
+                end=end,
+                show="sites",
+                output="list",
+                quiet=True,
+            )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["Type"], "site")
+        self.assertEqual(result[0]["Name"], "RENC")
+
+    def test_show_hosts_only(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(hours=24)
+
+        mock_manager = MagicMock()
+        mock_manager.resources_calendar.return_value = SAMPLE_CALENDAR
+
+        with patch.object(self.fablib, "get_manager", return_value=mock_manager):
+            result = self.fablib.resources_calendar(
+                start=start,
+                end=end,
+                show="hosts",
+                output="list",
+                quiet=True,
+            )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["Type"], "host")
+        self.assertEqual(result[0]["Name"], "renc-w1.fabric-testbed.net")
+
+    def test_show_all_returns_both(self):
+        start = datetime.datetime(2025, 7, 1, 0, 0, tzinfo=datetime.timezone.utc)
+        end = start + datetime.timedelta(hours=24)
+
+        mock_manager = MagicMock()
+        mock_manager.resources_calendar.return_value = SAMPLE_CALENDAR
+
+        with patch.object(self.fablib, "get_manager", return_value=mock_manager):
+            result = self.fablib.resources_calendar(
+                start=start,
+                end=end,
+                show="all",
+                output="list",
+                quiet=True,
+            )
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+        types = [r["Type"] for r in result]
+        self.assertIn("site", types)
+        self.assertIn("host", types)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resource calendar now displays hosts alongside sites, with a new 'show' parameter (sites/hosts/all) to let users control which resource types appear in the output.