### PR TITLE
Fix: fall back to sliver info for management IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Update to logging in the dependencies
+
+### Fixed
+- Fall back to sliver info (`mgmt_ip`) for node management IP when FIM topology does not have it populated
 - Add `find_resource_slot()` to FablibManager for finding time windows where specific resources are simultaneously available
 - Add resources_calendar() to FablibManager for querying resource availability over time
 - Add host support to resource calendar with `show` parameter to filter by sites, hosts, or all

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -1115,21 +1115,33 @@ class Node(TemplateMixin):
         """
         Gets the management IP of the node (IPv6).
 
+        First attempts to read from the FIM topology. If the topology
+        does not have the IP populated, falls back to the sliver info
+        returned by the orchestrator.
+
         Results are cached for performance.
 
         :return: management IP
         :rtype: String
         """
         if self._cached_management_ip is None:
+            # Try FIM topology first
             try:
-                self._cached_management_ip = str(self.fim_node.management_ip)
+                ip = self.fim_node.management_ip
+                if ip is not None:
+                    self._cached_management_ip = str(ip)
             except Exception:
-                self._cached_management_ip = None
-        return (
-            self._cached_management_ip
-            if self._cached_management_ip is not None
-            else None
-        )
+                pass
+
+            # Fall back to sliver info from orchestrator
+            if self._cached_management_ip is None:
+                try:
+                    if self.sliver is not None and self.sliver.mgmt_ip:
+                        self._cached_management_ip = str(self.sliver.mgmt_ip)
+                except Exception:
+                    pass
+
+        return self._cached_management_ip
 
     def get_username(self) -> str:
         """


### PR DESCRIPTION
## Summary
- `get_management_ip()` in `Node` now falls back to `SliverDTO.mgmt_ip` from the orchestrator when the FIM topology does not have the management IP populated
- Avoids returning `None` in cases where the topology has not been updated yet but the sliver info already has the IP
- No extra API calls — uses the sliver already fetched during node init

## Test plan
- [x] Verify `get_management_ip()` returns IP from FIM topology when available (existing behavior)
- [x] Verify fallback to `sliver.mgmt_ip` when `fim_node.management_ip` is `None`
- [x] Verify `None` is returned when neither source has the IP
- [x] Run integration test with a live slice to confirm SSH connectivity still works