### PR TITLE
Add ruff linting and modernize type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add ruff linter configuration with `E`, `F`, `W`, `I`, `UP` rule sets (Issue [#73](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/73))
+- Add `[testenv:lint]` tox environment for ruff linting checks (Issue [#73](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/73))
+- Add gradual mypy configuration in `pyproject.toml` (Issue [#73](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/73))
+
+### Changed
+- Replace black + isort with ruff for code formatting and import sorting (Issue [#73](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/73))
+- Modernize type annotations: `List[X]` → `list[X]`, `Dict[K,V]` → `dict[K,V]`, `Tuple[...]` → `tuple[...]`, `Optional[X]` → `X | None`, `Union[A, B]` → `A | B` across all fablib source files (Issue [#372](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/372))
+- Add `from __future__ import annotations` to `config/config.py` (Issue [#372](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/372))
+
 ## 2.0.4
 
 ### Added

--- a/fabrictestbed_extensions/editors/abc_topology_editor.py
+++ b/fabrictestbed_extensions/editors/abc_topology_editor.py
@@ -27,12 +27,8 @@ import traceback
 from abc import ABC, abstractmethod
 from typing import List
 
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentCatalog,
-    ComponentType,
-    ExperimentTopology,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentCatalog,
+                                        ComponentType, ExperimentTopology)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
 
 

--- a/fabrictestbed_extensions/editors/cytoscape_topology_editor.py
+++ b/fabrictestbed_extensions/editors/cytoscape_topology_editor.py
@@ -31,14 +31,9 @@ import traceback
 from typing import List
 
 import ipycytoscape as cy
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentCatalog,
-    ComponentModelType,
-    ComponentType,
-    ExperimentTopology,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentCatalog,
+                                        ComponentModelType, ComponentType,
+                                        ExperimentTopology, ServiceType)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
 from IPython.display import display
 from ipywidgets import Output

--- a/fabrictestbed_extensions/editors/geo_topology_editor.py
+++ b/fabrictestbed_extensions/editors/geo_topology_editor.py
@@ -31,29 +31,13 @@ import traceback
 from typing import List
 
 import ipywidgets as widgets
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentCatalog,
-    ComponentModelType,
-    ComponentType,
-    ExperimentTopology,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentCatalog,
+                                        ComponentModelType, ComponentType,
+                                        ExperimentTopology, ServiceType)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
-from ipyleaflet import (
-    AntPath,
-    CircleMarker,
-    DrawControl,
-    FullScreenControl,
-    Icon,
-    LayerGroup,
-    Map,
-    Marker,
-    Rectangle,
-    WidgetControl,
-    ZoomControl,
-    basemaps,
-)
+from ipyleaflet import (AntPath, CircleMarker, DrawControl, FullScreenControl,
+                        Icon, LayerGroup, Map, Marker, Rectangle,
+                        WidgetControl, ZoomControl, basemaps)
 from ipywidgets import HTML, Layout
 
 from .. import images

--- a/fabrictestbed_extensions/fablib/attestable_switch.py
+++ b/fabrictestbed_extensions/fablib/attestable_switch.py
@@ -54,7 +54,7 @@ import json
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING
 
 from tabulate import tabulate
 
@@ -91,7 +91,7 @@ class Attestable_Switch(Node):
         node: FimNode,
         validate: bool = False,
         raise_exception: bool = False,
-        ports: List[str] = None,
+        ports: list[str] = None,
         from_raw_image=False,
         setup_and_configure=True,
     ):
@@ -111,7 +111,7 @@ class Attestable_Switch(Node):
         :type raise_exception: bool
 
         :param ports: names of ports that the switch will have.
-        :type ports: List[str]
+        :type ports: list[str]
 
         :param from_raw_image: start from a raw image and install all dependencies -- this takes longer.
         :type from_raw_image: bool
@@ -300,7 +300,7 @@ class Attestable_Switch(Node):
             result = as_name_prefix + orig_name
         return result
 
-    def get_name(self) -> Optional[str]:
+    def get_name(self) -> str | None:
         """
         Gets the name of the FABRIC node.
 
@@ -317,10 +317,10 @@ class Attestable_Switch(Node):
         slice: Slice = None,
         name: str = None,
         site: str = None,
-        avoid: List[str] = [],
+        avoid: list[str] = [],
         validate: bool = False,
         raise_exception: bool = False,
-        ports: List[str] = None,
+        ports: list[str] = None,
         from_raw_image=False,
         setup_and_configure=True,
     ):
@@ -339,7 +339,7 @@ class Attestable_Switch(Node):
         :type site: str
 
         :param avoid: a list of node names to avoid
-        :type avoid: List[str]
+        :type avoid: list[str]
 
         :param validate: Validate node can be allocated w.r.t available resources
         :type validate: bool
@@ -348,7 +348,7 @@ class Attestable_Switch(Node):
         :type raise_exception: bool
 
         :param ports: names of ports that the switch will have.
-        :type ports: List[str]
+        :type ports: list[str]
 
         :param from_raw_image: start from a raw image and install all dependencies -- this takes longer.
         :type from_raw_image: bool
@@ -438,7 +438,7 @@ class Attestable_Switch(Node):
 
             if not from_raw_image:
                 log.info(
-                    f"Image already contains Attestable Switch: skipping compilation."
+                    "Image already contains Attestable Switch: skipping compilation."
                 )
             else:
                 print(f"Compiling Attestable Switch {self.get_name()}, ", end="")
@@ -789,7 +789,7 @@ V1Switch(
         commands = [
             f"p4c --target bmv2 --arch v1model ~/{os.path.basename(filename)}",
             f'echo "load_new_config_file {output_file}" | simple_switch_CLI',
-            f'echo "swap_configs" | simple_switch_CLI',
+            'echo "swap_configs" | simple_switch_CLI',
         ]
 
         stdout = []
@@ -879,7 +879,7 @@ V1Switch(
         """
 
         commands = [
-            f"simple_switch -v",
+            "simple_switch -v",
         ]
 
         stdout = []

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -39,9 +39,8 @@ like so::
 
 from __future__ import annotations
 
-import json
 import time
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from fim.user import ComponentType
 
@@ -51,18 +50,16 @@ from fabrictestbed_extensions.fablib.exceptions import (
     SliceStateError,
 )
 from fabrictestbed_extensions.fablib.template_mixin import TemplateMixin
-from fabrictestbed_extensions.utils.utils import Utils
 
 if TYPE_CHECKING:
-    from fabrictestbed_extensions.fablib.slice import Slice
-    from fabrictestbed_extensions.fablib.node import Node
     from fabrictestbed_extensions.fablib.interface import Interface
+    from fabrictestbed_extensions.fablib.node import Node
+    from fabrictestbed_extensions.fablib.slice import Slice
 
 import logging
-from typing import List
 
 from fabrictestbed.slice_editor import Component as FimComponent
-from fabrictestbed.slice_editor import ComponentModelType, Flags, Labels, UserData
+from fabrictestbed.slice_editor import ComponentModelType, Flags, Labels
 from tabulate import tabulate
 
 log = logging.getLogger("fablib")
@@ -158,7 +155,7 @@ class Component(TemplateMixin):
             "numa": "Numa Node",
         }
 
-    def toDict(self, skip: Optional[List[str]] = None):
+    def toDict(self, skip: list[str] | None = None):
         """
         Returns the component attributes as a dictionary.
 
@@ -166,7 +163,7 @@ class Component(TemplateMixin):
         is called.
 
         :param skip: list of keys to exclude
-        :type skip: List[str]
+        :type skip: list[str]
         :return: component attributes as dictionary
         :rtype: dict
         """
@@ -192,7 +189,7 @@ class Component(TemplateMixin):
             return dict(self._cached_dict)
         return {k: v for k, v in self._cached_dict.items() if k not in skip}
 
-    def generate_template_context(self, skip: Optional[List[str]] = None):
+    def generate_template_context(self, skip: list[str] | None = None):
         """
         Generate the base template context for this component.
 
@@ -200,7 +197,7 @@ class Component(TemplateMixin):
         including component attributes and an empty interfaces list.
 
         :param skip: list of keys to exclude
-        :type skip: List[str]
+        :type skip: list[str]
         :return: Template context dictionary with component attributes
         :rtype: dict
         """
@@ -237,7 +234,7 @@ class Component(TemplateMixin):
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -341,18 +338,18 @@ class Component(TemplateMixin):
         }
 
         # V2 specific: cached FIM properties
-        self._cached_details: Optional[str] = None
-        self._cached_numa_node: Optional[str] = None
-        self._cached_disk: Optional[int] = None
-        self._cached_unit: Optional[int] = None
-        self._cached_bdf: Optional[str] = None
-        self._cached_fim_model: Optional[str] = None
-        self._cached_fim_type: Optional[str] = None
-        self._cached_device_name: Optional[str] = None
+        self._cached_details: str | None = None
+        self._cached_numa_node: str | None = None
+        self._cached_disk: int | None = None
+        self._cached_unit: int | None = None
+        self._cached_bdf: str | None = None
+        self._cached_fim_model: str | None = None
+        self._cached_fim_type: str | None = None
+        self._cached_device_name: str | None = None
 
     def _invalidate_cache(self):
         """Invalidate all cached properties."""
-        super(Component, self)._invalidate_cache()
+        super()._invalidate_cache()
 
         self._cached_details = None
         self._cached_numa_node = None
@@ -377,7 +374,7 @@ class Component(TemplateMixin):
             "numa": "",
         }
 
-    def update(self, fim_component: Optional[FimComponent] = None):
+    def update(self, fim_component: FimComponent | None = None):
         """
         Update the component with new FIM data.
 
@@ -391,7 +388,7 @@ class Component(TemplateMixin):
 
     def get_interfaces(
         self, include_subs: bool = True, refresh: bool = False, output: str = "list"
-    ) -> Union[dict[str, Interface], list[Interface]]:
+    ) -> dict[str, Interface] | list[Interface]:
         """
         Gets the interfaces attached to this fablib component's FABRIC component.
 
@@ -407,7 +404,7 @@ class Component(TemplateMixin):
         :type output: str
 
         :return: a list or dict of the interfaces on this component.
-        :rtype: Union[dict[str, Interface], list[Interface]]
+        :rtype: dict[str, Interface] | list[Interface]
         """
 
         from fabrictestbed_extensions.fablib.interface import Interface
@@ -432,7 +429,7 @@ class Component(TemplateMixin):
 
     def get_interface(
         self, name: str = None, network_name: str = None, refresh: bool = False
-    ) -> Optional[Interface]:
+    ) -> Interface | None:
         """
         Gets a particular interface attached to this component.
 
@@ -467,7 +464,7 @@ class Component(TemplateMixin):
 
         raise ResourceNotFoundError(f"Interface not found: {name or network_name}")
 
-    def get_slice(self) -> Optional[Slice]:
+    def get_slice(self) -> Slice | None:
         """
         Gets the fablib slice associated with this component's node.
 
@@ -631,7 +628,7 @@ class Component(TemplateMixin):
         else:
             raise ValueError(f"Unsupported component type: {component_type}")
 
-    def get_reservation_id(self) -> Optional[str]:
+    def get_reservation_id(self) -> str | None:
         """
         Get reservation ID for this component.
 
@@ -642,7 +639,7 @@ class Component(TemplateMixin):
             return self.get_node().get_reservation_id()
         return None
 
-    def get_reservation_state(self) -> Optional[str]:
+    def get_reservation_state(self) -> str | None:
         """
         Get reservation state for this component.
 
@@ -653,7 +650,7 @@ class Component(TemplateMixin):
             return self.get_node().get_reservation_state()
         return None
 
-    def get_error_message(self) -> Optional[str]:
+    def get_error_message(self) -> str | None:
         """
         Get error message for this component.
 
@@ -693,7 +690,7 @@ class Component(TemplateMixin):
                 self._cached_fim_type = None
         return self._cached_fim_type
 
-    def configure(self, commands: List[str] = []):
+    def configure(self, commands: list[str] = []):
         """
         Configure a component by executing a set of commands provided by the user or run any default commands.
 
@@ -794,7 +791,7 @@ class Component(TemplateMixin):
                 )
             )
             output.append(self.node.execute(f"df -h {mount_point}"))
-        except Exception as e:
+        except Exception:
             log.error(f"config_nvme Fail: {self.get_name()}:", exc_info=True)
             raise Exception(str(output))
 

--- a/fabrictestbed_extensions/fablib/component.py
+++ b/fabrictestbed_extensions/fablib/component.py
@@ -45,10 +45,8 @@ from typing import TYPE_CHECKING
 from fim.user import ComponentType
 
 from fabrictestbed_extensions.fablib.constants import Constants
-from fabrictestbed_extensions.fablib.exceptions import (
-    ResourceNotFoundError,
-    SliceStateError,
-)
+from fabrictestbed_extensions.fablib.exceptions import (ResourceNotFoundError,
+                                                        SliceStateError)
 from fabrictestbed_extensions.fablib.template_mixin import TemplateMixin
 
 if TYPE_CHECKING:

--- a/fabrictestbed_extensions/fablib/config/config.py
+++ b/fabrictestbed_extensions/fablib/config/config.py
@@ -22,6 +22,8 @@
 # SOFTWARE.
 #
 # Author: Komal Thareja (kthare10@renci.org)
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -29,8 +31,6 @@ import re
 import time
 from functools import lru_cache
 from logging.handlers import RotatingFileHandler
-from pathlib import Path
-from typing import Dict, List, Union
 
 import requests
 import yaml
@@ -318,7 +318,7 @@ class Config:
         :rtype bool
         """
         try:
-            with open(file_path, "r") as file:
+            with open(file_path) as file:
                 config = yaml.safe_load(file)
                 if (
                     isinstance(config, dict)
@@ -346,7 +346,7 @@ class Config:
         :rtype bool
         """
         ret_val = False
-        with open(file_path, "r") as file:
+        with open(file_path) as file:
             lines = file.readlines()
 
         export_pattern = re.compile(r"^export\s+([^=]+)=(.*)$", re.IGNORECASE)
@@ -405,13 +405,13 @@ class Config:
                 f"  Run 'fabric-cli configure setup' for interactive setup."
             )
 
-    def get_config(self) -> Dict[str, str]:
+    def get_config(self) -> dict[str, str]:
         """
         Gets a dictionary mapping keywords to configured FABRIC environment
         variable values.
 
         :return: dictionary mapping keywords to FABRIC values
-        :rtype: Dict[String, String]
+        :rtype: dict[String, String]
         """
         return self.runtime_config
 
@@ -617,7 +617,7 @@ class Config:
         """
         return self.runtime_config.get(Constants.BASTION_KEY_PASSPHRASE)
 
-    def get_bastion_key(self) -> Union[str, None]:
+    def get_bastion_key(self) -> str | None:
         """
         Reads the FABRIC Bastion private key file and returns the key.
 
@@ -630,7 +630,7 @@ class Config:
             return None
         return Utils.read_file_contents(file_path=self.get_bastion_key_location())
 
-    def get_bastion_public_key(self) -> Union[str, None]:
+    def get_bastion_public_key(self) -> str | None:
         """
         Reads the FABRIC Bastion public key file and returns the key.
 
@@ -737,7 +737,7 @@ class Config:
             return Constants.DEFAULT_LOG_PROPAGATE
         return bool(val)
 
-    def set_log_propagate(self, log_propagate: Union[bool, str, int]):
+    def set_log_propagate(self, log_propagate: bool | str | int):
         """
         Sets whether fablib logs propagate to the root logger.
 
@@ -801,7 +801,7 @@ class Config:
         """
         return self.runtime_config.get(Constants.AVOID)
 
-    def set_avoid(self, avoid: List[str]):
+    def set_avoid(self, avoid: list[str]):
         """
         Sets the avoid list
 
@@ -843,7 +843,7 @@ class Config:
 
         self.set_avoid(avoid)
 
-    def get_default_slice_private_key(self) -> Union[str, None]:
+    def get_default_slice_private_key(self) -> str | None:
         """
         Gets the current default_slice_keys as a dictionary containg the
         public and private slice keys.
@@ -852,7 +852,7 @@ class Config:
         functionality will likely change going forward.
 
         :return: default_slice_key dictionary from superclass
-        :rtype: Dict[String, String]
+        :rtype: dict[String, String]
         """
         if self.get_default_slice_private_key_file() is not None and os.path.exists(
             self.get_default_slice_private_key_file()
@@ -862,7 +862,7 @@ class Config:
             )
         return None
 
-    def get_default_slice_public_key(self) -> Union[str, None]:
+    def get_default_slice_public_key(self) -> str | None:
         """
         Gets the current default_slice_keys as a dictionary containg the
         public and private slice keys.
@@ -871,7 +871,7 @@ class Config:
         functionality will likely change going forward.
 
         :return: default_slice_key dictionary from superclass
-        :rtype: Dict[String, String]
+        :rtype: dict[String, String]
         """
         if self.get_default_slice_public_key_file() is not None and os.path.exists(
             self.get_default_slice_public_key_file()
@@ -893,12 +893,12 @@ class Config:
         """
         return Constants.IMAGE_NAMES
 
-    def get_config_pretty_names_dict(self) -> Dict[str, str]:
+    def get_config_pretty_names_dict(self) -> dict[str, str]:
         """
         Return PRETTY Names for the config
 
         :return: Dict of Pretty Names
-        :rtype: Dict[str, str]
+        :rtype: dict[str, str]
         """
         return self.REQUIRED_ATTRS_PRETTY_NAMES
 
@@ -955,7 +955,7 @@ class Config:
 
         if self.get_log_file() and RotatingFileHandler not in existing_handler_types:
             file_handler = RotatingFileHandler(
-                self.get_log_file(), backupCount=int(5), maxBytes=int(1024 * 1024 * 5)
+                self.get_log_file(), backupCount=5, maxBytes=int(1024 * 1024 * 5)
             )
             file_handler.setFormatter(
                 logging.Formatter(default_log_format, datefmt=default_date_format)
@@ -1012,7 +1012,7 @@ class Config:
         if os.path.exists(local_file):
             age = time.time() - os.path.getmtime(local_file)
             if age < ttl:
-                with open(local_file, "r") as f:
+                with open(local_file) as f:
                     return json.load(f)
 
         try:
@@ -1024,7 +1024,7 @@ class Config:
             return data
         except Exception:
             if os.path.exists(local_file):
-                with open(local_file, "r") as f:
+                with open(local_file) as f:
                     return json.load(f)
             elif fallback_default is not None:
                 return fallback_default

--- a/fabrictestbed_extensions/fablib/crease/crinkle.py
+++ b/fabrictestbed_extensions/fablib/crease/crinkle.py
@@ -1202,7 +1202,6 @@ class CrinkleSlice(Slice):
                 )
                 logging.error(e, exc_info=True)
 
-
         start = time.time()
 
         my_thread_pool_executor = futures.ThreadPoolExecutor(32)

--- a/fabrictestbed_extensions/fablib/crease/crinkle.py
+++ b/fabrictestbed_extensions/fablib/crease/crinkle.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 import enum
 import ipaddress
-import json
 import logging
-import random
 import re
-import shutil
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any
 
 from IPython.core.display_functions import display
 
@@ -17,7 +14,7 @@ if TYPE_CHECKING:
     from fabrictestbed_extensions.fablib.fablib import FablibManager
 
 from concurrent import futures
-from ipaddress import IPv6Address, ip_address
+from ipaddress import IPv6Address
 
 from fabrictestbed.slice_editor import ExperimentTopology
 from fabrictestbed.slice_editor import Node as FimNode
@@ -78,7 +75,7 @@ class CrinkleAnalyzer(Node):
         slice: Slice = None,
         name: str = None,
         site: str = None,
-        avoid: List[str] = [],
+        avoid: list[str] = [],
         validate: bool = False,
         raise_exception: bool = False,
     ):
@@ -98,7 +95,7 @@ class CrinkleAnalyzer(Node):
         :type site: str
 
         :param avoid: a list of node names to avoid
-        :type avoid: List[str]
+        :type avoid: list[str]
 
         :param validate: Validate node can be allocated w.r.t available resources
         :type validate: bool
@@ -169,7 +166,7 @@ class CrinkleMonitor(Node):
             net_name: str = None,
             net_type: str = None,
             cnet_iface: Interface = None,
-            iface_mappings: Dict[str, Tuple[str, Interface, bool, int]] = {},
+            iface_mappings: dict[str, tuple[str, Interface, bool, int]] = {},
             monitor_id: int = None,
         ):
             self.port_nums = port_nums
@@ -191,14 +188,14 @@ class CrinkleMonitor(Node):
             slice=slice, node=node, validate=validate, raise_exception=raise_exception
         )
         self.get_monitor_data()
-        self.creation_data: List[Tuple[str, str, str, bool, int]] = []  # see MonNetData
+        self.creation_data: list[tuple[str, str, str, bool, int]] = []  # see MonNetData
 
     @staticmethod
     def new_node(
         slice: Slice = None,
         name: str = None,
         site: str = None,
-        avoid: List[str] = [],
+        avoid: list[str] = [],
         validate: bool = False,
         raise_exception: bool = False,
     ):
@@ -287,7 +284,7 @@ class CrinkleMonitor(Node):
             logging.info(f"Retrieved monitor config as: {self.data.__dict__}")
         else:
             self.data = self.MonitorData()
-            logging.info(f"Did not retrieve stored monitor data, initializing")
+            logging.info("Did not retrieve stored monitor data, initializing")
 
     def set_monitor_data(self):
         """
@@ -335,10 +332,10 @@ class CrinkleSlice(Slice):
         analyzer_name: str = None,
     ):
         super().__init__(fablib_manager=fablib_manager, name=name, user_only=user_only)
-        self.monitors: Dict[str, CrinkleMonitor] = {}
+        self.monitors: dict[str, CrinkleMonitor] = {}
         self.analyzer: CrinkleAnalyzer = None
         self.analyzer_name: str = analyzer_name
-        self.cnets: Dict[str, NetworkService] = {}
+        self.cnets: dict[str, NetworkService] = {}
         self.analyzer_cnet: NetworkService = None
         self.analyzer_iface: Interface = None
         self.pcaps_dir = pcaps_dir
@@ -386,7 +383,7 @@ class CrinkleSlice(Slice):
         """
         Get slice-wide crinkle data.
         """
-        logging.info(f"get_crinkle_data()")
+        logging.info("get_crinkle_data()")
         if "crinkle_slice_config" in analyzer.get_user_data():
             data = self.analyzer.get_user_data()["crinkle_slice_config"]
             # data_iface_mappings = self.get_user_data()["iface_mappings"]
@@ -401,13 +398,13 @@ class CrinkleSlice(Slice):
                 f"Retrieved crinkle slice config as:\n{self.analyzer_name}\n{self.prefix}\n{self.monitor_string}"
             )
         else:
-            logging.info(f"Did not retrieve stored crinkle slice config")
+            logging.info("Did not retrieve stored crinkle slice config")
 
     def set_crinkle_data(self):
         """
         Set slice-wide crinkle data.
         """
-        logging.info(f"set_crinkle_data()")
+        logging.info("set_crinkle_data()")
         user_data = self.analyzer.get_user_data()
         data_dict = {
             "analyzer_name": self.analyzer_name,
@@ -508,7 +505,7 @@ class CrinkleSlice(Slice):
         instance_type: str = None,
         host: str = None,
         user_data: dict = {},
-        avoid: List[str] = [],
+        avoid: list[str] = [],
         validate: bool = False,
         raise_exception: bool = False,
     ) -> CrinkleAnalyzer:
@@ -545,7 +542,7 @@ class CrinkleSlice(Slice):
 
         :param avoid: (Optional) A list of sites to avoid is allowing
             random site.
-        :type avoid: List[String]
+        :type avoid: list[String]
 
         :param validate: Validate node can be allocated w.r.t available resources
         :type validate: bool
@@ -629,7 +626,7 @@ class CrinkleSlice(Slice):
         instance_type: str = None,
         host: str = None,
         user_data: dict = {},
-        avoid: List[str] = [],
+        avoid: list[str] = [],
         validate: bool = False,
         raise_exception: bool = False,
         net_name: str = None,
@@ -652,7 +649,7 @@ class CrinkleSlice(Slice):
         """
         if self.analyzer is None:
             raise Exception(
-                f"Analyzer must be created before adding monitors using add_analyzer()"
+                "Analyzer must be created before adding monitors using add_analyzer()"
             )
 
         monitor = CrinkleMonitor.new_node(
@@ -732,12 +729,12 @@ class CrinkleSlice(Slice):
     def add_monitored_l2network(
         self,
         name: str = None,
-        interfaces: List[Interface] = [],
+        interfaces: list[Interface] = [],
         type: str = None,
         subnet: ipaddress = None,
         gateway: ipaddress = None,
         user_data: dict = {},
-        sinks: List[Interface] = [],
+        sinks: list[Interface] = [],
         host: str = None,
         site: str = None,
         cores: int = CrinkleMonitor.default_cores,
@@ -758,7 +755,7 @@ class CrinkleSlice(Slice):
 
         :param interfaces: a list of interfaces to build the network
             with
-        :type interfaces: List[Interface]
+        :type interfaces: list[Interface]
 
         :param type: optional L2 network type "L2Bridge", "L2STS", or
             "L2PTP"
@@ -775,7 +772,7 @@ class CrinkleSlice(Slice):
 
         :param sinks: A set of interfaces which should have any Crinkle packet trailers
             stripped before entering.
-        :type sinks: List[Interface]
+        :type sinks: list[Interface]
 
         :return: a new CrinkleMonitor
         :rtype: CrinkleMonitor
@@ -884,11 +881,11 @@ class CrinkleSlice(Slice):
         logging.info(
             "Allocating Monitors and their connected Nodes to different worker hosts"
         )
-        sitenames_to_sites: Dict[str, Dict[str, Any]] = {}
-        sitenames_to_hosts: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        sitenames_to_sites: dict[str, dict[str, Any]] = {}
+        sitenames_to_hosts: dict[str, dict[str, dict[str, Any]]] = {}
         fablib = self.get_fablib_manager()
         fabresources = fablib.get_resources()
-        validated_nodes: Dict[str, bool] = {}
+        validated_nodes: dict[str, bool] = {}
 
         for node in self.get_all_nodes():
             host_name = node.get_host()
@@ -1008,7 +1005,7 @@ class CrinkleSlice(Slice):
 
         self.do_allocate_hosts = False
         self.set_crinkle_data()
-        logging.info(f"Hosts allocated")
+        logging.info("Hosts allocated")
         for host_name in allocated:
             site_name = host_name.split("-")[0].upper()
             site = sitenames_to_sites.setdefault(
@@ -1034,7 +1031,7 @@ class CrinkleSlice(Slice):
         wait_jupyter: str = "text",
         post_boot_config: bool = True,
         wait_ssh: bool = True,
-        extra_ssh_keys: List[str] = None,
+        extra_ssh_keys: list[str] = None,
         lease_start_time: datetime = None,
         lease_end_time: datetime = None,
         lease_in_hours: int = None,
@@ -1068,7 +1065,7 @@ class CrinkleSlice(Slice):
         :type wait_ssh: bool
 
         :param extra_ssh_keys: Optional list of additional SSH public keys to be installed in the slivers of this slice
-        :type extra_ssh_keys: List[str]
+        :type extra_ssh_keys: list[str]
 
         :param lease_start_time: Optional lease start time in UTC format: %Y-%m-%d %H:%M:%S %z.
                            Specifies the beginning of the time range to search for available resources valid for `lease_in_hours`.
@@ -1091,7 +1088,7 @@ class CrinkleSlice(Slice):
         logging.info("Crinkle submit()")
         if self.analyzer is None:
             raise Exception(
-                f"Analyzer must be added before Crinkle slice submission using add_analyzer()"
+                "Analyzer must be added before Crinkle slice submission using add_analyzer()"
             )
 
         if self.do_allocate_hosts:
@@ -1113,14 +1110,14 @@ class CrinkleSlice(Slice):
         )
 
     def setup_ptp(self):
-        prereq_cmd = f"sudo apt update && sudo apt install -y ansible git"
+        prereq_cmd = "sudo apt update && sudo apt install -y ansible git"
         git_cmd = (
             f"cd {REMOTEWORKDIR} && git clone https://github.com/fabric-testbed/ptp.git"
         )
         ansible_cmd = f"cd {REMOTEWORKDIR}/ptp/ansible && ansible-playbook --connection=local --inventory 127.0.0.1, --limit 127.0.0.1 playbook_fabric_experiment_ptp.yml"
         jobs = []
         site_ads = {}
-        logging.info(f"Setting up PTP on Crinkle nodes")
+        logging.info("Setting up PTP on Crinkle nodes")
         print("Setting up PTP on Crinkle nodes")
         jobs.append(
             self.analyzer.execute_thread(f"{prereq_cmd} && {git_cmd} && {ansible_cmd}")
@@ -1176,12 +1173,12 @@ class CrinkleSlice(Slice):
         # Make sure we have the latest topology
         self.update()
 
-        logging.info(f"post_boot_config: get_networks")
+        logging.info("post_boot_config: get_networks")
         for network in self.get_networks():
             logging.info(f"post_boot_config: network {network.get_name()}")
             network.config()
 
-        logging.info(f"post_boot_config: get_interfaces")
+        logging.info("post_boot_config: get_interfaces")
         for interface in self.get_all_interfaces():
             try:
                 logging.info(f"post_boot_config: interface {interface.get_name()}")
@@ -1190,7 +1187,7 @@ class CrinkleSlice(Slice):
                 logging.error(f"Interface: {interface.get_name()} failed to config")
                 logging.error(e, exc_info=True)
 
-        logging.info(f"post_boot_config: unmanage interfaces")
+        logging.info("post_boot_config: unmanage interfaces")
         for interface in self.get_all_interfaces():
             try:
                 logging.info(f"post_boot_config: unmanage {interface.get_name()}")
@@ -1205,7 +1202,6 @@ class CrinkleSlice(Slice):
                 )
                 logging.error(e, exc_info=True)
 
-        import time
 
         start = time.time()
 
@@ -1254,7 +1250,7 @@ class CrinkleSlice(Slice):
                 aswitch.switch_config()
 
         # Custom Crinkle logic
-        logging.info(f"Crinkle post_boot_config")
+        logging.info("Crinkle post_boot_config")
         if self.do_post_boot:
             self.analyzer = self.get_node(name=self.analyzer_name)
             site = self.analyzer.get_site()
@@ -1263,7 +1259,7 @@ class CrinkleSlice(Slice):
                 network_name=self.analyzer_cnet.get_name()
             )
             self.cnets[site] = self.analyzer_cnet
-            jobs: List[futures.Future] = []
+            jobs: list[futures.Future] = []
             counter = 0
             self.monitor_string = f"{self.analyzer_iface.get_device_name()} {self.analyzer.get_cores() - 1}"
             for key, monitor in self.monitors.items():
@@ -1337,14 +1333,14 @@ class CrinkleSlice(Slice):
                 self.monitors[key] = refreshed_monitor
                 refreshed_monitor.set_monitor_data()
                 counter += 1
-            logging.info(f"Crinkle post_boot_config waiting on jobs to finish")
+            logging.info("Crinkle post_boot_config waiting on jobs to finish")
             print("Configuring Crinkle Resources")
             ctr = 0
             for _ in futures.as_completed(jobs):
                 ctr += 1
                 logging.info(f"{ctr}/{len(jobs)} jobs finished")
                 print(f"{ctr}/{len(jobs)} jobs finished")
-            logging.info(f"Starting SPADE")
+            logging.info("Starting SPADE")
             self.analyzer.execute_thread(f"./{REMOTEWORKDIR}/SPADE/bin/spade debug")
             time.sleep(5)
             spade_control_commands = (
@@ -1365,26 +1361,26 @@ class CrinkleSlice(Slice):
             self.analyzer.execute_thread(
                 f"sudo ./{REMOTEWORKDIR}/spade_reader.py {self.monitor_string}"
             )
-            logging.info(f"Saving slice data before rebooting monitors")
+            logging.info("Saving slice data before rebooting monitors")
             print("Saving slice data before rebooting monitors")
             self.do_post_boot = False
             if self.do_ptp_setup:
                 self.setup_ptp()
-            logging.info(f"Saving Crinkle Data")
+            logging.info("Saving Crinkle Data")
             self.set_crinkle_data()
             self.submit(
                 wait=True, progress=False, post_boot_config=False, wait_ssh=False
             )
             self.update()
 
-            logging.info(f"Rebooting Crinkle monitors")
+            logging.info("Rebooting Crinkle monitors")
             print("Rebooting Crinkle Resources")
             for monitor in self.monitors.values():
                 monitor.execute("sudo reboot")
-            logging.info(f"Waiting on Crinkle monitors to finish reboot")
+            logging.info("Waiting on Crinkle monitors to finish reboot")
             self.wait_ssh(progress=True)
             jobs = []
-            logging.info(f"Enabling Crinkle monitor interfaces")
+            logging.info("Enabling Crinkle monitor interfaces")
             for monitor in self.monitors.values():
                 cmd = f"sudo ip link set {monitor.data.cnet_iface.get_device_name()} up; sudo ip link set {monitor.data.cnet_iface.get_device_name()} promisc on; "
                 for _, iface, _, _ in monitor.data.iface_mappings.values():
@@ -1396,15 +1392,15 @@ class CrinkleSlice(Slice):
                 ctr += 1
                 logging.info(f"{ctr}/{len(jobs)} jobs finished")
                 print(f"{ctr}/{len(jobs)} jobs finished")
-            logging.info(f"Crinkle post_boot_config done")
+            logging.info("Crinkle post_boot_config done")
             print("Crinkle post_boot_config done")
 
-    def get_nodes(self, refresh: bool = False) -> List[Node]:
+    def get_nodes(self, refresh: bool = False) -> list[Node]:
         """
         Gets a list of all non-Crinkle nodes in this slice.
 
         :return: a list of fablib nodes
-        :rtype: List[Node]
+        :rtype: list[Node]
         """
         if not self.nodes or not len(self.nodes):
             refresh = True
@@ -1429,7 +1425,7 @@ class CrinkleSlice(Slice):
         Gets a list of all nodes in this slice.
 
         :return: a list of fablib nodes
-        :rtype: List[Node]
+        :rtype: list[Node]
         """
         return super().get_nodes(refresh=refresh)
 
@@ -1449,12 +1445,12 @@ class CrinkleSlice(Slice):
         """
         ret_val = self.get_all_interfaces(refresh=refresh, output="dict").get(name)
         if not ret_val:
-            raise Exception("Interface not found: {}".format(name))
+            raise Exception(f"Interface not found: {name}")
         return ret_val
 
     def get_interfaces(
         self, include_subs: bool = True, refresh: bool = False, output: str = "list"
-    ) -> Union[Dict[str, Interface], List[Interface]]:
+    ) -> dict[str, Interface] | list[Interface]:
         """
         Gets all non-Crinkle interfaces in this slice.
 
@@ -1468,7 +1464,7 @@ class CrinkleSlice(Slice):
         :type output: str
 
         :return: a list of interfaces on this slice
-        :rtype: Union[Dict[str, Interface], List[Interface]]
+        :rtype: dict[str, Interface] | list[Interface]
         """
         return super().get_interfaces(
             include_subs=include_subs, refresh=refresh, output=output
@@ -1476,7 +1472,7 @@ class CrinkleSlice(Slice):
 
     def get_all_interfaces(
         self, include_subs: bool = True, refresh: bool = False, output: str = "list"
-    ) -> Union[Dict[str, Interface], List[Interface]]:
+    ) -> dict[str, Interface] | list[Interface]:
         """
         Gets all interfaces in this slice.
 
@@ -1490,7 +1486,7 @@ class CrinkleSlice(Slice):
         :type output: str
 
         :return: a list of interfaces on this slice
-        :rtype: Union[Dict[str, Interface], List[Interface]]
+        :rtype: dict[str, Interface] | list[Interface]
         """
         if len(self.all_interfaces) == 0 or refresh:
             for node in self.get_all_nodes(refresh=refresh):
@@ -1535,7 +1531,7 @@ class CrinkleSlice(Slice):
         :param mac: IPv6 address
         :type mac: String
         :return: A tuple of the integer values of the front and back halves
-        :rtype: Tuple[int, int]
+        :rtype: tuple[int, int]
         """
         ip6 = IPv6Address(ip6)
         return (int(ip6) // (2**64), int(ip6) % (2**64))
@@ -1629,12 +1625,12 @@ class CrinkleSlice(Slice):
         )
         self.probe_id += 1
 
-    def dump_counters(self) -> Dict[str, Dict[str, Tuple[str, int, int]]]:
+    def dump_counters(self) -> dict[str, dict[str, tuple[str, int, int]]]:
         """
         Runs through each non-crinkle Node, gets the rx_packets and tx_packets count for
-        each interface, then returns a dict of form Dict[node name, Dict[iface name, (dev name, rx, tx)]].
+        each interface, then returns a dict of form dict[node name, dict[iface name, (dev name, rx, tx)]].
         """
-        rdict: Dict[str, Dict[str, Tuple[str, int, int]]] = {}
+        rdict: dict[str, dict[str, tuple[str, int, int]]] = {}
         for node in self.get_nodes():
             if node.get_image() in UBUNTU_IMAGES:
                 nodename = node.get_name()
@@ -1892,7 +1888,7 @@ class CrinkleSlice(Slice):
     ):
         """
         Query the provenance database and return the results as a dict of the form
-        Dict[pkt_id, List[pkt_info]],
+        dict[pkt_id, list[pkt_info]],
         where pkt_info is a dict of the following fields:
             - time
             - tx_host
@@ -1915,10 +1911,10 @@ class CrinkleSlice(Slice):
             download=False,
         )
         self.analyzer.download_file(f"{name}.dot", f"{REMOTEWORKDIR}/{name}.dot")
-        prov_dict: Dict[str, List[Dict[str, str]]] = {}
-        iface_host_map: Dict[str, str] = {}
-        flow_map: Dict[str, Dict[str, str]] = {}
-        flow_tx_map: Dict[str, Dict[str, Dict[str, str]]] = {}
+        prov_dict: dict[str, list[dict[str, str]]] = {}
+        iface_host_map: dict[str, str] = {}
+        flow_map: dict[str, dict[str, str]] = {}
+        flow_tx_map: dict[str, dict[str, dict[str, str]]] = {}
         flow_keys = [
             "eth.type",
             "ip.prot",
@@ -1927,7 +1923,7 @@ class CrinkleSlice(Slice):
             "prot.sport",
             "prot.dport",
         ]
-        with open(f"{name}.dot", "r") as f:
+        with open(f"{name}.dot") as f:
             lines = f.readlines()
             for line in lines:
                 if "->" not in line:
@@ -2138,7 +2134,7 @@ class CrinkleSlice(Slice):
 
     def start_monitor(
         self, monitor: CrinkleMonitor, wait: bool = True, quiet: bool = False
-    ) -> Optional[futures.Future]:
+    ) -> futures.Future | None:
         """
         Start the DPDK script on a monitor.
 
@@ -2168,7 +2164,7 @@ class CrinkleSlice(Slice):
 
     def start_all_monitors(
         self, wait: bool = True, no_return: bool = True
-    ) -> Optional[List[futures.Future]]:
+    ) -> list[futures.Future] | None:
         """
         Start the DPDK script on all monitors.
 
@@ -2177,13 +2173,13 @@ class CrinkleSlice(Slice):
         :param no_return: Whether to return None instead of the list of jobs
         :type no_return: bool
         :return: The futures of all started jobs
-        :rtype: List[concurrent.futures.Future]
+        :rtype: list[concurrent.futures.Future]
         """
-        start_list: List[futures.Future] = []
+        start_list: list[futures.Future] = []
         for monitor in self.monitors.values():
             start_list.append(self.start_monitor(monitor=monitor, wait=False))
         if wait:
-            logging.info(f"Waiting for monitors to finish starting")
+            logging.info("Waiting for monitors to finish starting")
             ctr = 0
             max = len(start_list)
             while ctr < max:

--- a/fabrictestbed_extensions/fablib/crease/spade_reader.py
+++ b/fabrictestbed_extensions/fablib/crease/spade_reader.py
@@ -4,16 +4,15 @@ import getopt
 import queue
 import sys
 import threading
-from concurrent import futures
 from datetime import datetime
 from ipaddress import IPv4Address, IPv6Address
 
 from scapy.all import sniff
 from scapy.fields import IntField, LongField, ShortField, XShortField
 from scapy.layers.inet import IP
-from scapy.layers.inet6 import IPv6, IPv6ExtHdrDestOpt
+from scapy.layers.inet6 import IPv6
 from scapy.layers.l2 import Ether
-from scapy.packet import Packet, Raw, bind_layers
+from scapy.packet import Packet, bind_layers
 
 PROT_CMA = 254
 CMA_ID = b"\x65\x87"

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -88,7 +88,8 @@ from typing import TYPE_CHECKING, Any
 
 import paramiko
 
-from fabrictestbed_extensions.fablib.config.config import Config, ConfigException
+from fabrictestbed_extensions.fablib.config.config import (Config,
+                                                           ConfigException)
 from fabrictestbed_extensions.fablib.constants import Constants
 from fabrictestbed_extensions.fablib.exceptions import SliceNotFoundError
 from fabrictestbed_extensions.utils.utils import Utils

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -84,7 +84,7 @@ warnings.filterwarnings("always", category=DeprecationWarning)
 
 from concurrent.futures import ThreadPoolExecutor
 from ipaddress import IPv4Network, IPv6Network
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any
 
 import paramiko
 
@@ -320,7 +320,7 @@ class FablibManager(Config):
 
     def _get_slice_from_cache(
         self, slice_id: str = None, slice_name: str = None
-    ) -> Optional[Slice]:
+    ) -> Slice | None:
         """
         Retrieves a Slice object from the cache by its ID or name.
 
@@ -706,7 +706,7 @@ Host * !bastion.fabric-testbed.net
         for key in ssh_keys:
             expires_on = key.get(Constants.EXPIRES_ON)
             expires_on_dt = datetime.datetime.fromisoformat(expires_on)
-            now = datetime.datetime.now(tz=datetime.timezone.utc)
+            now = datetime.datetime.now(tz=datetime.UTC)
             if now > expires_on_dt:
                 keys_to_remove.append(key)
                 continue
@@ -944,7 +944,7 @@ Host * !bastion.fabric-testbed.net
 
         return self.manager
 
-    def get_site_names(self) -> List[str]:
+    def get_site_names(self) -> list[str]:
         """
         Gets a list of all available site names.
 
@@ -955,17 +955,17 @@ Host * !bastion.fabric-testbed.net
 
     def list_sites(
         self,
-        output: Optional[str] = None,
-        fields: Optional[str] = None,
-        quiet: Optional[bool] = False,
+        output: str | None = None,
+        fields: str | None = None,
+        quiet: bool | None = False,
         filter_function=None,
-        update: Optional[bool] = False,
-        pretty_names: Optional[bool] = True,
-        force_refresh: Optional[bool] = False,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
-        avoid: Optional[List[str]] = None,
-        includes: Optional[List[str]] = None,
+        update: bool | None = False,
+        pretty_names: bool | None = True,
+        force_refresh: bool | None = False,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        avoid: list[str] | None = None,
+        includes: list[str] | None = None,
     ) -> object:
         """
         Lists all the sites and their attributes.
@@ -988,7 +988,7 @@ Host * !bastion.fabric-testbed.net
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -1029,17 +1029,17 @@ Host * !bastion.fabric-testbed.net
 
     def list_hosts(
         self,
-        output: Optional[str] = None,
-        fields: Optional[str] = None,
-        quiet: Optional[bool] = False,
+        output: str | None = None,
+        fields: str | None = None,
+        quiet: bool | None = False,
         filter_function=None,
-        update: Optional[bool] = False,
-        pretty_names: Optional[bool] = True,
-        force_refresh: Optional[bool] = False,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
-        avoid: Optional[List[str]] = None,
-        includes: Optional[List[str]] = None,
+        update: bool | None = False,
+        pretty_names: bool | None = True,
+        force_refresh: bool | None = False,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        avoid: list[str] | None = None,
+        includes: list[str] | None = None,
     ) -> object:
         """
         Lists all the hosts and their attributes.
@@ -1062,7 +1062,7 @@ Host * !bastion.fabric-testbed.net
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -1101,12 +1101,12 @@ Host * !bastion.fabric-testbed.net
 
     def list_links(
         self,
-        output: Optional[str] = None,
-        fields: Optional[str] = None,
-        quiet: Optional[bool] = False,
+        output: str | None = None,
+        fields: str | None = None,
+        quiet: bool | None = False,
         filter_function=None,
-        update: Optional[bool] = True,
-        pretty_names: Optional[bool] = True,
+        update: bool | None = True,
+        pretty_names: bool | None = True,
     ) -> object:
         """
         Lists all the links and their attributes.
@@ -1129,7 +1129,7 @@ Host * !bastion.fabric-testbed.net
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -1151,14 +1151,14 @@ Host * !bastion.fabric-testbed.net
 
     def list_facility_ports(
         self,
-        output: Optional[str] = None,
-        fields: Optional[str] = None,
-        quiet: Optional[bool] = False,
+        output: str | None = None,
+        fields: str | None = None,
+        quiet: bool | None = False,
         filter_function=None,
-        update: Optional[bool] = False,
-        pretty_names: Optional[bool] = True,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
+        update: bool | None = False,
+        pretty_names: bool | None = True,
+        start: datetime | None = None,
+        end: datetime | None = None,
     ) -> object:
         """
         Lists all the facility ports and their attributes.
@@ -1182,7 +1182,7 @@ Host * !bastion.fabric-testbed.net
         :type output: str
 
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
 
         :param quiet: True to specify printing/display
         :type quiet: bool
@@ -1217,10 +1217,10 @@ Host * !bastion.fabric-testbed.net
 
     def show_config(
         self,
-        output: Optional[str] = None,
+        output: str | None = None,
         fields: list[str] = None,
-        quiet: Optional[bool] = False,
-        pretty_names: Optional[bool] = True,
+        quiet: bool | None = False,
+        pretty_names: bool | None = True,
     ):
         """
         Show a table containing the current FABlib configuration parameters.
@@ -1239,7 +1239,7 @@ Host * !bastion.fabric-testbed.net
         :param output: output format
         :type output: str
         :param fields: list of fields to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param pretty_names:
@@ -1265,10 +1265,10 @@ Host * !bastion.fabric-testbed.net
     def show_site(
         self,
         site_name: str,
-        output: Optional[str] = None,
-        fields: Optional[list[str]] = None,
-        quiet: Optional[bool] = False,
-        pretty_names: Optional[bool] = True,
+        output: str | None = None,
+        fields: list[str] | None = None,
+        quiet: bool | None = False,
+        pretty_names: bool | None = True,
     ):
         """
         Show a table with all the properties of a specific site
@@ -1289,7 +1289,7 @@ Host * !bastion.fabric-testbed.net
         :param output: output format
         :type output: str
         :param fields: list of fields to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param pretty_names:
@@ -1320,9 +1320,9 @@ Host * !bastion.fabric-testbed.net
 
     def get_facility_ports(
         self,
-        update: Optional[bool] = False,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
+        update: bool | None = False,
+        start: datetime | None = None,
+        end: datetime | None = None,
     ) -> ResourcesV2:
         """
         Get the resources object (which includes facility ports).
@@ -1344,12 +1344,12 @@ Host * !bastion.fabric-testbed.net
 
     def get_resources(
         self,
-        update: Optional[bool] = False,
-        force_refresh: Optional[bool] = False,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
-        avoid: Optional[List[str]] = None,
-        includes: Optional[List[str]] = None,
+        update: bool | None = False,
+        force_refresh: bool | None = False,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        avoid: list[str] | None = None,
+        includes: list[str] | None = None,
     ) -> ResourcesV2:
         """
         Get a reference to the resources object. The resources object
@@ -1394,7 +1394,7 @@ Host * !bastion.fabric-testbed.net
         )
 
     @staticmethod
-    def _slice_to_resources(slice_object: "Slice") -> List[Dict[str, Any]]:
+    def _slice_to_resources(slice_object: Slice) -> list[dict[str, Any]]:
         """
         Convert an unsubmitted Slice object into the resource requirement
         list expected by the find-slot API.
@@ -1402,10 +1402,10 @@ Host * !bastion.fabric-testbed.net
         :param slice_object: a fablib Slice built with add_node/add_l2network/etc.
         :return: list of resource dicts
         """
-        resources: List[Dict[str, Any]] = []
+        resources: list[dict[str, Any]] = []
 
         # --- Compute nodes: aggregate by site ---
-        site_compute: Dict[str, Dict[str, Any]] = {}
+        site_compute: dict[str, dict[str, Any]] = {}
         for node in slice_object.get_nodes():
             site = node.get_site()
             if site not in site_compute:
@@ -1468,8 +1468,8 @@ Host * !bastion.fabric-testbed.net
 
     @staticmethod
     def _normalize_component_keys(
-        resources: List[Dict[str, Any]],
-    ) -> List[Dict[str, Any]]:
+        resources: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
         """
         Normalize component keys in resource dicts to match the format used
         by the reports DB: ``"{ComponentType}-{Model}"`` (e.g.
@@ -1484,7 +1484,7 @@ Host * !bastion.fabric-testbed.net
         from fabrictestbed_extensions.fablib.component import Component
 
         # Build fablib-name -> DB-key mapping lazily
-        mapping: Dict[str, str] = {}
+        mapping: dict[str, str] = {}
         for fablib_name, model_type in Component.component_model_map.items():
             catalog_entry = ComponentModelTypeMap.get(model_type)
             if catalog_entry:
@@ -1506,11 +1506,11 @@ Host * !bastion.fabric-testbed.net
         start: datetime.datetime,
         end: datetime.datetime,
         duration: int,
-        slice: Optional["Slice"] = None,
-        resources: Optional[List[Dict[str, Any]]] = None,
+        slice: Slice | None = None,
+        resources: list[dict[str, Any]] | None = None,
         max_results: int = 1,
         use_live_data: bool = False,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Find time windows where requested resources are simultaneously available.
 
@@ -1565,13 +1565,13 @@ Host * !bastion.fabric-testbed.net
         start: datetime.datetime,
         end: datetime.datetime,
         interval: str = "day",
-        site: Optional[List[str]] = None,
-        host: Optional[List[str]] = None,
-        exclude_site: Optional[List[str]] = None,
-        exclude_host: Optional[List[str]] = None,
+        site: list[str] | None = None,
+        host: list[str] | None = None,
+        exclude_site: list[str] | None = None,
+        exclude_host: list[str] | None = None,
         show: str = "all",
-        output: Optional[str] = None,
-        fields: Optional[List[str]] = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
         quiet: bool = False,
         filter_function=None,
     ):
@@ -1652,15 +1652,15 @@ Host * !bastion.fabric-testbed.net
 
     def get_random_site(
         self,
-        avoid: Optional[List[str]] = None,
+        avoid: list[str] | None = None,
         filter_function=None,
-        update: Optional[bool] = True,
+        update: bool | None = True,
     ) -> str:
         """
         Get a random site.
 
         :param avoid: list of site names to avoid choosing
-        :type avoid: List[String]
+        :type avoid: list[String]
         :param filter_function: filter_function
         :type filter_function:
         :param update: flag indicating if fetch latest availability information
@@ -1674,24 +1674,24 @@ Host * !bastion.fabric-testbed.net
 
     def get_random_sites(
         self,
-        count: Optional[int] = 1,
-        avoid: Optional[List[str]] = None,
+        count: int | None = 1,
+        avoid: list[str] | None = None,
         filter_function=None,
-        update: Optional[bool] = True,
-    ) -> List[str]:
+        update: bool | None = True,
+    ) -> list[str]:
         """
         Get a list of random sites names. Each site will be included at most once.
 
         :param count: number of sites to return.
         :type count: int
         :param avoid: list of site names to avoid choosing
-        :type avoid: List[String]
+        :type avoid: list[String]
         :param filter_function: filter_function
         :type filter_function:
         :param update: flag indicating if fetch latest availability information
         :type update: bool
         :return: list of random site names.
-        :rtype: List[String]
+        :rtype: list[String]
         """
         if avoid is None:
             avoid = []
@@ -1747,7 +1747,7 @@ Host * !bastion.fabric-testbed.net
                 rtn_sites.append(None)
         return rtn_sites
 
-    def probe_bastion_host(self) -> Optional[bool]:
+    def probe_bastion_host(self) -> bool | None:
         """
         See if bastion will admit us with our configuration.
 
@@ -1888,12 +1888,12 @@ Host * !bastion.fabric-testbed.net
 
     def get_available_resources(
         self,
-        update: Optional[bool] = False,
-        force_refresh: Optional[bool] = False,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
-        avoid: Optional[List[str]] = None,
-        includes: Optional[List[str]] = None,
+        update: bool | None = False,
+        force_refresh: bool | None = False,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        avoid: list[str] | None = None,
+        includes: list[str] | None = None,
     ) -> ResourcesV2:
         """
         Get the available resources.
@@ -1947,14 +1947,14 @@ Host * !bastion.fabric-testbed.net
 
     def list_slices(
         self,
-        excludes: Optional[list[SliceState]] = None,
-        output: Optional[str] = None,
-        fields: Optional[list[str]] = None,
-        quiet: Optional[bool] = False,
+        excludes: list[SliceState] | None = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
+        quiet: bool | None = False,
         filter_function=None,
-        pretty_names: Optional[bool] = True,
-        user_only: Optional[bool] = True,
-        show_un_submitted: Optional[bool] = False,
+        pretty_names: bool | None = True,
+        user_only: bool | None = True,
+        show_un_submitted: bool | None = False,
     ):
         """
         Lists all the slices created by a user.
@@ -1979,7 +1979,7 @@ Host * !bastion.fabric-testbed.net
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -2016,14 +2016,14 @@ Host * !bastion.fabric-testbed.net
 
     def show_slice(
         self,
-        name: Optional[str] = None,
-        id: Optional[str] = None,
-        output: Optional[str] = None,
-        fields: Optional[list[str]] = None,
-        quiet: Optional[bool] = False,
-        pretty_names: Optional[bool] = True,
-        user_only: Optional[bool] = True,
-        show_un_submitted: Optional[bool] = False,
+        name: str | None = None,
+        id: str | None = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
+        quiet: bool | None = False,
+        pretty_names: bool | None = True,
+        user_only: bool | None = True,
+        show_un_submitted: bool | None = False,
     ):
         """
         Show a table with all the properties of a specific site
@@ -2046,7 +2046,7 @@ Host * !bastion.fabric-testbed.net
         :param output: output format
         :type output: str
         :param fields: list of fields to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param pretty_names: pretty_names
@@ -2072,12 +2072,12 @@ Host * !bastion.fabric-testbed.net
 
     def get_slices(
         self,
-        excludes: Optional[List[SliceState]] = None,
-        slice_name: Optional[str] = None,
-        slice_id: Optional[str] = None,
-        user_only: Optional[bool] = True,
-        show_un_submitted: Optional[bool] = False,
-    ) -> List[Slice]:
+        excludes: list[SliceState] | None = None,
+        slice_name: str | None = None,
+        slice_id: str | None = None,
+        user_only: bool | None = True,
+        show_un_submitted: bool | None = False,
+    ) -> list[Slice]:
         """
         Gets a list of slices from the slice manager.
 
@@ -2087,7 +2087,7 @@ Host * !bastion.fabric-testbed.net
 
         :param excludes: A list of slice states to exclude from the output list.
             Defaults to [SliceState.Dead, SliceState.Closing].
-        :type excludes: List[SliceState]
+        :type excludes: list[SliceState]
         :param slice_name: Filter by slice name
         :type slice_name: str
         :param slice_id: Filter by slice ID
@@ -2098,7 +2098,7 @@ Host * !bastion.fabric-testbed.net
         :type show_un_submitted: bool
 
         :return: a list of slices
-        :rtype: List[Slice]
+        :rtype: list[Slice]
         """
         import time
 
@@ -2205,14 +2205,14 @@ Host * !bastion.fabric-testbed.net
 
     def get_crinkle_slices(
         self,
-        excludes: List[SliceState] = [SliceState.Dead, SliceState.Closing],
+        excludes: list[SliceState] = [SliceState.Dead, SliceState.Closing],
         slice_name: str = None,
         slice_id: str = None,
         user_only: bool = True,
         show_un_submitted: bool = False,
         pcaps_dir: str = ".query_analysis_pcaps",
         name_prefix: str = "C",
-    ) -> List[CrinkleSlice]:
+    ) -> list[CrinkleSlice]:
         """
         Gets a list of Crinkle slices from the slice manager.
 
@@ -2221,7 +2221,7 @@ Host * !bastion.fabric-testbed.net
         an empty list (i.e. excludes=[]) to get a list of all slices.
 
         :param excludes: A list of slice states to exclude from the output list
-        :type excludes: List[SliceState]
+        :type excludes: list[SliceState]
         :param slice_name:
         :param slice_id:
         :param user_only: True indicates return own slices; False indicates return project slices
@@ -2234,7 +2234,7 @@ Host * !bastion.fabric-testbed.net
         :type name_prefix: String
 
         :return: a list of slices
-        :rtype: List[Slice]
+        :rtype: list[Slice]
         """
         import time
 
@@ -2383,11 +2383,11 @@ Host * !bastion.fabric-testbed.net
                 self.remove_slice_from_cache(slice_obj)
                 if progress:
                     print(", Success!")
-            except Exception as e:
+            except Exception:
                 if progress:
                     print(", Failed!")
 
-    def validate_node(self, node: Node, allocated: dict = None) -> Tuple[bool, str]:
+    def validate_node(self, node: Node, allocated: dict = None) -> tuple[bool, str]:
         """
         Validate a node w.r.t available resources on a site before submission.
 
@@ -2396,7 +2396,7 @@ Host * !bastion.fabric-testbed.net
         ``Node.add_component()`` calls ``self.get_fablib_manager().validate_node()``.
 
         :return: Tuple indicating status for validation and error message in case of failure
-        :rtype: Tuple[bool, str]
+        :rtype: tuple[bool, str]
         """
         from fabrictestbed_extensions.fablib.validator import NodeValidator
 
@@ -2409,8 +2409,8 @@ Host * !bastion.fabric-testbed.net
         artifact_title: str,
         description_short: str,
         description_long: str,
-        authors: List[str],
-        tags: List[str],
+        authors: list[str],
+        tags: list[str],
         visibility: Visibility = Visibility.Author,
         update_existing: bool = True,
     ) -> Artifact:
@@ -2443,7 +2443,7 @@ Host * !bastion.fabric-testbed.net
         artifact_title: str = None,
         artifact_id: str = None,
         tag: str = None,
-    ) -> List[Artifact]:
+    ) -> list[Artifact]:
         """
         Gets a list of artifacts either based on artifact id, artifact title or tag.
         :param artifact_title:
@@ -2451,7 +2451,7 @@ Host * !bastion.fabric-testbed.net
         :param tag:
 
         :return: a list of Artifacts
-        :rtype: List[Artifact]
+        :rtype: list[Artifact]
         """
         import time
 
@@ -2612,7 +2612,7 @@ Host * !bastion.fabric-testbed.net
         fetch_func,
         offset: int = 0,
         limit: int = 200,
-    ) -> List:
+    ) -> list:
         """
         Generic paginated fetch helper.
 

--- a/fabrictestbed_extensions/fablib/facility_port.py
+++ b/fabrictestbed_extensions/fablib/facility_port.py
@@ -31,9 +31,8 @@ This module contains methods to work with FABRIC `facility ports`_.
 
 from __future__ import annotations
 
-import json
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING
 
 from fabrictestbed.slice_editor import Capacities, Labels
 from tabulate import tabulate
@@ -71,16 +70,16 @@ class FacilityPort(TemplateMixin):
         super().__init__()
         self.fim_object: FimNode = fim_object
         self.slice: Slice = slice
-        self.interfaces: Dict[str, Interface] = {}
+        self.interfaces: dict[str, Interface] = {}
 
-        self._cached_site: Optional[str] = None
+        self._cached_site: str | None = None
 
         # V2 specific: cached interfaces
-        self._interfaces_cache: Dict[str, Interface] = {}
+        self._interfaces_cache: dict[str, Interface] = {}
 
     def _invalidate_cache(self):
         """Invalidate all cached properties."""
-        super(FacilityPort, self)._invalidate_cache()
+        super()._invalidate_cache()
 
         self._cached_site = None
         self._interfaces_cache = {}
@@ -165,7 +164,7 @@ class FacilityPort(TemplateMixin):
         slice: Slice = None,
         name: str = None,
         site: str = None,
-        vlan: Union[List, str] = None,
+        vlan: list | str = None,
         bandwidth: int = None,
         mtu: int = None,
         labels: Labels = None,
@@ -249,7 +248,7 @@ class FacilityPort(TemplateMixin):
 
     def get_interfaces(
         self, refresh: bool = False, output: str = "list"
-    ) -> Union[Dict[str, Interface], List[Interface]]:
+    ) -> dict[str, Interface] | list[Interface]:
         """
         Gets interfaces associated with this facility port.
 
@@ -260,7 +259,7 @@ class FacilityPort(TemplateMixin):
         :param output: return type - 'list' or 'dict'
         :type output: str
         :return: interfaces
-        :rtype: Union[Dict[str, Interface], List[Interface]]
+        :rtype: dict[str, Interface] | list[Interface]
         """
         from fabrictestbed_extensions.fablib.interface import Interface
 
@@ -285,7 +284,7 @@ class FacilityPort(TemplateMixin):
 
     def get_interface(
         self, name: str = None, refresh: bool = False
-    ) -> Optional[Interface]:
+    ) -> Interface | None:
         """
         Gets a specific interface by name.
 

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -35,7 +35,7 @@ import logging
 import re
 import warnings
 from ipaddress import IPv4Address, IPv6Address
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from fabrictestbed.slice_editor import Flags
 from fim.user import Capacities, InterfaceType, Labels
@@ -43,17 +43,15 @@ from tabulate import tabulate
 
 from fabrictestbed_extensions.fablib.constants import Constants
 from fabrictestbed_extensions.fablib.template_mixin import TemplateMixin
-from fabrictestbed_extensions.utils.utils import Utils
 
 if TYPE_CHECKING:
-    from fabrictestbed_extensions.fablib.slice import Slice
-    from fabrictestbed_extensions.fablib.node import Node
-    from fabrictestbed_extensions.fablib.network_service import NetworkService
     from fabrictestbed_extensions.fablib.component import Component
     from fabrictestbed_extensions.fablib.facility_port import FacilityPort
+    from fabrictestbed_extensions.fablib.network_service import NetworkService
+    from fabrictestbed_extensions.fablib.node import Node
+    from fabrictestbed_extensions.fablib.slice import Slice
     from fabrictestbed_extensions.fablib.switch import Switch
 
-from fabrictestbed.slice_editor import UserData
 from fim.user.interface import Interface as FimInterface
 
 log = logging.getLogger("fablib")
@@ -75,7 +73,7 @@ class Interface(TemplateMixin):
         self,
         component: Component = None,
         fim_interface: FimInterface = None,
-        node: Union[Switch, FacilityPort] = None,
+        node: Switch | FacilityPort = None,
         model: str = None,
         parent: Interface = None,
     ):
@@ -105,25 +103,25 @@ class Interface(TemplateMixin):
         self.parent = parent
 
         # V2 specific: cached FIM properties
-        self._cached_mac: Optional[str] = None
-        self._cached_vlan: Optional[str] = None
-        self._cached_bandwidth: Optional[int] = None
-        self._cached_site: Optional[str] = None
-        self._cached_physical_os_interface: Optional[str] = None
-        self._cached_switch_port: Optional[str] = None
-        self._cached_flag: Optional[bool] = False
-        self._cached_peer_port_name: Optional[str] = None
-        self._cached_fim_type: Optional[str] = None
-        self._cached_peer_account_id: Optional[str] = None
-        self._cached_peer_bgp_key: Optional[str] = None
-        self._cached_peer_asn: Optional[str] = None
-        self._cached_peer_subnet: Optional[str] = None
-        self._cached_subnet: Optional[str] = None
-        self._cached_peer_port_vlan: Optional[str] = None
+        self._cached_mac: str | None = None
+        self._cached_vlan: str | None = None
+        self._cached_bandwidth: int | None = None
+        self._cached_site: str | None = None
+        self._cached_physical_os_interface: str | None = None
+        self._cached_switch_port: str | None = None
+        self._cached_flag: bool | None = False
+        self._cached_peer_port_name: str | None = None
+        self._cached_fim_type: str | None = None
+        self._cached_peer_account_id: str | None = None
+        self._cached_peer_bgp_key: str | None = None
+        self._cached_peer_asn: str | None = None
+        self._cached_peer_subnet: str | None = None
+        self._cached_subnet: str | None = None
+        self._cached_peer_port_vlan: str | None = None
 
     def _invalidate_cache(self):
         """Invalidate all cached properties."""
-        super(Interface, self)._invalidate_cache()
+        super()._invalidate_cache()
 
         self._cached_mac = None
         self._cached_vlan = None
@@ -224,7 +222,7 @@ class Interface(TemplateMixin):
             "switch_port": "Switch Port",
         }
 
-    def toDict(self, skip: Optional[List[str]] = None) -> dict[str, str]:
+    def toDict(self, skip: list[str] | None = None) -> dict[str, str]:
         """
         Returns the interface attributes as a dictionary.
 
@@ -232,7 +230,7 @@ class Interface(TemplateMixin):
         is called.
 
         :param skip: list of keys to exclude
-        :type skip: List[str]
+        :type skip: list[str]
         :return: interface attributes as dictionary
         :rtype: dict
         """
@@ -305,7 +303,7 @@ class Interface(TemplateMixin):
             return dict(self._cached_dict)
         return {k: v for k, v in self._cached_dict.items() if k not in skip}
 
-    def get_switch_port(self) -> Optional[str]:
+    def get_switch_port(self) -> str | None:
         """
         Get the name of the port on the switch corresponding to this interface
 
@@ -324,7 +322,7 @@ class Interface(TemplateMixin):
                     self._cached_switch_port = ifs.labels.local_name
         return self._cached_switch_port
 
-    def get_numa_node(self) -> Optional[str]:
+    def get_numa_node(self) -> str | None:
         """
         Retrieve the NUMA node of the component linked to the interface.
 
@@ -363,7 +361,7 @@ class Interface(TemplateMixin):
         fim_iface.flags = Flags(auto_config=False)
         self._cached_flag = False
 
-    def get_peer_port_name(self) -> Optional[str]:
+    def get_peer_port_name(self) -> str | None:
         """
         If available provide the name of the attached port on the dataplane switch.
         Only possible once the slice has been instantiated.
@@ -379,7 +377,7 @@ class Interface(TemplateMixin):
                 ].labels.local_name
         return self._cached_peer_port_name
 
-    def get_peer_port_vlan(self) -> Optional[str]:
+    def get_peer_port_vlan(self) -> str | None:
         """
         Returns the VLAN associated with the interface.
         For shared NICs extracts it from label_allocations.
@@ -398,7 +396,7 @@ class Interface(TemplateMixin):
 
         return self._cached_peer_port_vlan
 
-    def get_device_name(self) -> Optional[str]:
+    def get_device_name(self) -> str | None:
         """
         Gets a name of the device name on the node
 
@@ -462,7 +460,7 @@ class Interface(TemplateMixin):
         )
         return self.get_device_name()
 
-    def get_os_dev(self) -> Optional[dict[str, str]]:
+    def get_os_dev(self) -> dict[str, str] | None:
         """
         Gets json output of 'ip addr list' for the interface.
 
@@ -497,8 +495,8 @@ class Interface(TemplateMixin):
 
     def ip_addr_add(
         self,
-        addr: Union[IPv4Address, IPv6Address],
-        subnet: Union[ipaddress.IPv4Network, ipaddress.IPv6Network],
+        addr: IPv4Address | IPv6Address,
+        subnet: ipaddress.IPv4Network | ipaddress.IPv6Network,
     ):
         """
         Add an IP address to the interface in the node.
@@ -512,8 +510,8 @@ class Interface(TemplateMixin):
 
     def ip_addr_del(
         self,
-        addr: Union[IPv4Address, IPv6Address],
-        subnet: Union[ipaddress.IPv4Network, ipaddress.IPv6Network],
+        addr: IPv4Address | IPv6Address,
+        subnet: ipaddress.IPv4Network | ipaddress.IPv6Network,
     ):
         """
         Delete an IP address to the interface in the node.
@@ -613,7 +611,7 @@ class Interface(TemplateMixin):
             return self.get_node().get_reservation_id()
         return None
 
-    def get_reservation_state(self) -> Optional[str]:
+    def get_reservation_state(self) -> str | None:
         """
         Gets the reservation state
 
@@ -817,7 +815,7 @@ class Interface(TemplateMixin):
         """
         return self.get_node().get_slice()
 
-    def get_node(self) -> Union[Node, FacilityPort]:
+    def get_node(self) -> Node | FacilityPort:
         """
         Gets the node this interface's component is on.
 
@@ -829,7 +827,7 @@ class Interface(TemplateMixin):
         else:
             return self.get_component().get_node()
 
-    def get_network(self) -> Optional[NetworkService]:
+    def get_network(self) -> NetworkService | None:
         """
         Gets the network this interface is on.
 
@@ -909,7 +907,7 @@ class Interface(TemplateMixin):
             )
 
     # fablib.Interface.get_ip_addr()
-    def get_ip_addr_ssh(self, dev=None) -> Optional[Union[str, list]]:
+    def get_ip_addr_ssh(self, dev=None) -> str | list | None:
         """
         Gets the ip addr info for this interface.
 
@@ -919,7 +917,7 @@ class Interface(TemplateMixin):
         when no output is available or the device is not found.
 
         :return: IP address string, list of addr dicts, or None
-        :rtype: Optional[Union[str, list]]
+        :rtype: str | list | None
         """
         try:
             stdout, stderr = self.get_node().execute("ip -j addr list", quiet=True)
@@ -998,7 +996,7 @@ class Interface(TemplateMixin):
 
         return self
 
-    def set_ip_addr(self, addr: Optional[ipaddress] = None, mode: str = None):
+    def set_ip_addr(self, addr: ipaddress | None = None, mode: str = None):
         """
         Set the IP address for the interface.
 
@@ -1124,7 +1122,6 @@ class Interface(TemplateMixin):
 
         :return: None
         """
-        from fabrictestbed.slice_editor import ServiceType
 
         self.config_vlan_iface()
         network = self.get_network()
@@ -1413,7 +1410,7 @@ class Interface(TemplateMixin):
 
     def get_interfaces(
         self, refresh: bool = False, output: str = "list"
-    ) -> Union[dict[str, Interface], list[Interface]]:
+    ) -> dict[str, Interface] | list[Interface]:
         """
         Gets the interfaces attached to this fablib component's FABRIC component.
 
@@ -1424,7 +1421,7 @@ class Interface(TemplateMixin):
         :type output: str
 
         :return: a list or dict of the interfaces on this component.
-        :rtype: Union[dict[str, Interface], list[Interface]]
+        :rtype: dict[str, Interface] | list[Interface]
         """
 
         if self.interfaces and not refresh and not self._fim_dirty:
@@ -1498,7 +1495,7 @@ class Interface(TemplateMixin):
             return ch_iface
         return None
 
-    def get_type(self) -> Optional[str]:
+    def get_type(self) -> str | None:
         """
         Get Interface type
 

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING
 
 from fabrictestbed.external_api.orchestrator_client import SliverDTO
 from fim.slivers.path_info import Path
@@ -41,19 +41,17 @@ from fim.user import ERO, Gateway
 from tabulate import tabulate
 
 from fabrictestbed_extensions.fablib.exceptions import ResourceNotFoundError
-from fabrictestbed_extensions.utils.utils import Utils
 
 if TYPE_CHECKING:
-    from fabrictestbed_extensions.fablib.slice import Slice
     from fabrictestbed_extensions.fablib.interface import Interface
+    from fabrictestbed_extensions.fablib.slice import Slice
 
 import ipaddress
 import json
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 
-from fabrictestbed.slice_editor import Capacities, Labels
+from fabrictestbed.slice_editor import Capacities, Labels, ServiceType
 from fabrictestbed.slice_editor import NetworkService as FimNetworkService
-from fabrictestbed.slice_editor import ServiceType, UserData
 from fim.slivers.network_service import NetworkServiceSliver, NSLayer, ServiceType
 from fim.user.network_service import MirrorDirection
 
@@ -94,42 +92,42 @@ class NetworkService(TemplateMixin):
     fim_special_service_types = ["PortMirror"]
 
     @staticmethod
-    def __get_fim_l2network_service_types() -> List[str]:
+    def __get_fim_l2network_service_types() -> list[str]:
         """
         Not intended for API use. Returns a list of FIM L2 network service types.
 
         :return: List of FIM L2 network service types.
-        :rtype: List[str]
+        :rtype: list[str]
         """
         return NetworkService.fim_l2network_service_types
 
     @staticmethod
-    def __get_fim_l3network_service_types() -> List[str]:
+    def __get_fim_l3network_service_types() -> list[str]:
         """
         Not intended for API use. Returns a list of FIM L3 network service types.
 
         :return: List of FIM L3 network service types.
-        :rtype: List[str]
+        :rtype: list[str]
         """
         return NetworkService.fim_l3network_service_types
 
     @staticmethod
-    def __get_fim_special_service_types() -> List[str]:
+    def __get_fim_special_service_types() -> list[str]:
         """
         Not intended for API use. Returns a list of FIM special service types.
 
         :return: List of FIM special service types.
-        :rtype: List[str]
+        :rtype: list[str]
         """
         return NetworkService.fim_special_service_types
 
     @staticmethod
-    def get_fim_network_service_types() -> List[str]:
+    def get_fim_network_service_types() -> list[str]:
         """
         Not intended for API use. Returns a list of all FIM network service types.
 
         :return: List of all FIM network service types.
-        :rtype: List[str]
+        :rtype: list[str]
         """
         return (
             NetworkService.__get_fim_l2network_service_types()
@@ -139,7 +137,7 @@ class NetworkService(TemplateMixin):
 
     @staticmethod
     def __calculate_l2_nstype(
-        interfaces: List[Interface] = None, ero_enabled: bool = False
+        interfaces: list[Interface] = None, ero_enabled: bool = False
     ) -> ServiceType:
         """
         Not inteded for API use
@@ -228,7 +226,7 @@ class NetworkService(TemplateMixin):
                 sites.add(interface.get_site())
                 nics.add(interface.get_model())
                 nodes.add(interface.get_node())
-            except Exception as e:
+            except Exception:
                 log.info(
                     f"validate_nstype: skipping interface {interface.get_name()}, likely its a facility port"
                 )
@@ -303,7 +301,7 @@ class NetworkService(TemplateMixin):
         name: str = None,
         mirror_interface_name: str = None,
         mirror_interface_vlan: str = None,
-        receive_interface: Optional[Interface] = None,
+        receive_interface: Interface | None = None,
         mirror_direction: str = "both",
     ) -> NetworkService:
         """
@@ -315,16 +313,16 @@ class NetworkService(TemplateMixin):
         # decode the direction
         if not isinstance(mirror_interface_name, str):
             raise Exception(
-                f"When creating a PortMirror service mirror_interface is specified by name"
+                "When creating a PortMirror service mirror_interface is specified by name"
             )
         if not isinstance(mirror_direction, str):
             raise Exception(
-                f'When creating a PortMirror service mirror_direction is a string "rx", "tx" or "both"'
-                f'defaulting to "both"'
+                'When creating a PortMirror service mirror_direction is a string "rx", "tx" or "both"'
+                'defaulting to "both"'
             )
         if not receive_interface:
             raise Exception(
-                f"For PortMirror service the receiving interface must be specified upfront"
+                "For PortMirror service the receiving interface must be specified upfront"
             )
         direction = MirrorDirection.Both
         # enable below when we are officially off python 3.9 and into 3.10 or higher
@@ -372,11 +370,11 @@ class NetworkService(TemplateMixin):
     def new_l3network(
         slice: Slice = None,
         name: str = None,
-        interfaces: List[Interface] = [],
+        interfaces: list[Interface] = [],
         type: str = None,
         user_data: dict = {},
         technology: str = None,
-        subnet: Optional[ipaddress.ip_network] = None,
+        subnet: ipaddress.ip_network | None = None,
         site: str = None,
     ):
         """
@@ -416,7 +414,7 @@ class NetworkService(TemplateMixin):
     def new_l2network(
         slice: Slice = None,
         name: str = None,
-        interfaces: List[Interface] = [],
+        interfaces: list[Interface] = [],
         type: str = None,
         user_data: dict = {},
     ):
@@ -487,10 +485,10 @@ class NetworkService(TemplateMixin):
         slice: Slice = None,
         name: str = None,
         nstype: ServiceType = None,
-        interfaces: List[Interface] = [],
+        interfaces: list[Interface] = [],
         user_data: dict = {},
         technology: str = None,
-        subnet: Optional[ipaddress.ip_network] = None,
+        subnet: ipaddress.ip_network | None = None,
         site: str = None,
     ):
         """
@@ -574,7 +572,7 @@ class NetworkService(TemplateMixin):
         Gets all L3 networks services in this slice
 
         :return: List of all network services in this slice
-        :rtype: List[NetworkService]
+        :rtype: list[NetworkService]
         """
         topology = slice.get_fim_topology()
 
@@ -747,16 +745,16 @@ class NetworkService(TemplateMixin):
         self.lock = threading.Lock()
 
         # Caching support
-        self._cached_type: Optional[str] = None
-        self._cached_layer: Optional[str] = None
-        self._cached_subnet: Optional[Union[IPv4Network, IPv6Network]] = None
-        self._cached_gateway: Optional[Union[IPv4Address, IPv6Address]] = None
+        self._cached_type: str | None = None
+        self._cached_layer: str | None = None
+        self._cached_subnet: IPv4Network | IPv6Network | None = None
+        self._cached_gateway: IPv4Address | IPv6Address | None = None
 
-        self._interfaces_cache: Dict[str, Interface] = {}
+        self._interfaces_cache: dict[str, Interface] = {}
 
     def _invalidate_cache(self):
         """Invalidate all cached properties."""
-        super(NetworkService, self)._invalidate_cache()
+        super()._invalidate_cache()
 
         self._cached_type = None
         self._cached_layer = None
@@ -820,7 +818,7 @@ class NetworkService(TemplateMixin):
             "error": "Error",
         }
 
-    def toDict(self, skip: List[str] = None):
+    def toDict(self, skip: list[str] = None):
         """
         Returns the network attributes as a dictionary.
 
@@ -828,7 +826,7 @@ class NetworkService(TemplateMixin):
         is called.
 
         :param skip: list of keys to skip
-        :type skip: List[str]
+        :type skip: list[str]
         :return: network attributes as dictionary
         :rtype: dict
         """
@@ -852,7 +850,7 @@ class NetworkService(TemplateMixin):
             return dict(self._cached_dict)
         return {k: v for k, v in self._cached_dict.items() if k not in skip}
 
-    def generate_template_context(self, skip: List[str] = None):
+    def generate_template_context(self, skip: list[str] = None):
         """Build a Jinja2 template context dict for this network service."""
         context = self.toDict(skip=skip)
         context["interfaces"] = []
@@ -871,7 +869,7 @@ class NetworkService(TemplateMixin):
         """
         return self.slice
 
-    def get_site(self) -> Optional[str]:
+    def get_site(self) -> str | None:
         """
         Gets site name on network service.
         """
@@ -885,7 +883,7 @@ class NetworkService(TemplateMixin):
         else:
             return None
 
-    def get_layer(self) -> Optional[str]:
+    def get_layer(self) -> str | None:
         """
         Gets the layer of the network services (L2 or L3).
 
@@ -937,7 +935,7 @@ class NetworkService(TemplateMixin):
             )
         return self.sliver
 
-    def get_gateway(self) -> Optional[Union[IPv4Address, IPv6Address]]:
+    def get_gateway(self) -> IPv4Address | IPv6Address | None:
         """
         Gets the assigned gateway for a FABnetv L3 IPv6 or IPv4 network.
 
@@ -974,7 +972,7 @@ class NetworkService(TemplateMixin):
                     fablib_data = self.get_fablib_data()
                     try:
                         gateway = ipaddress.ip_address(fablib_data["subnet"]["gateway"])
-                    except Exception as e:
+                    except Exception:
                         gateway = None
             else:
                 # Not yet instantiated — check if gateway was explicitly
@@ -997,7 +995,7 @@ class NetworkService(TemplateMixin):
 
     def get_available_ips(
         self, count: int = 256
-    ) -> Optional[List[IPv4Address or IPv6Address]]:
+    ) -> list[IPv4Address or IPv6Address] | None:
         """
         Gets the IPs available for a FABnet L3 network
 
@@ -1008,7 +1006,7 @@ class NetworkService(TemplateMixin):
         :param count: number of addresse to include
         :type slice: Slice
         :return: gateway IP
-        :rtype: List[IPv4Address]
+        :rtype: list[IPv4Address]
         """
         try:
             ip_list = []
@@ -1020,12 +1018,12 @@ class NetworkService(TemplateMixin):
         except Exception as e:
             log.warning(f"Failed to get_available_ips: {e}")
 
-    def get_public_ips(self) -> Optional[Union[List[IPv4Address] or List[IPv6Address]]]:
+    def get_public_ips(self) -> list[IPv4Address] or list[IPv6Address] | None:
         """
         Get list of public IPs assigned to the FabNetv*Ext service
 
         :return: List of Public IPs
-        :rtype: List[IPv4Address] or List[IPv6Address] or None
+        :rtype: list[IPv4Address] or list[IPv6Address] or None
         """
         if self.get_fim().labels is not None:
             if self.get_fim().labels.ipv4 is not None:
@@ -1040,7 +1038,7 @@ class NetworkService(TemplateMixin):
                 return result
         return None
 
-    def get_subnet(self) -> Optional[Union[IPv4Network, IPv6Network]]:
+    def get_subnet(self) -> IPv4Network | IPv6Network | None:
         """
         Gets the assigned subnet for a FABnet L3 IPv6 or IPv4 network.
 
@@ -1106,7 +1104,7 @@ class NetworkService(TemplateMixin):
         except Exception as e:
             log.warning(f"Failed to get subnet: {e}")
 
-    def get_interfaces(self, refresh: bool = False) -> List[Interface]:
+    def get_interfaces(self, refresh: bool = False) -> list[Interface]:
         """
         Gets the interfaces on this network service.
 
@@ -1115,7 +1113,7 @@ class NetworkService(TemplateMixin):
         :param refresh: force refresh from FIM
         :type refresh: bool
         :return: the interfaces on this network service
-        :rtype: List[Interfaces]
+        :rtype: list[Interfaces]
         """
         if self._interfaces_cache and not refresh and not self._fim_dirty:
             return list(self._interfaces_cache.values())
@@ -1137,7 +1135,7 @@ class NetworkService(TemplateMixin):
 
     def get_interface(
         self, name: str = None, refresh: bool = False
-    ) -> Optional[Interface]:
+    ) -> Interface | None:
         """
         Gets a particular interface on this network service.
 
@@ -1331,7 +1329,7 @@ class NetworkService(TemplateMixin):
         # get refreshed on next access
         self.get_slice()._topology_dirty = True
 
-    def set_subnet(self, subnet: Union[IPv4Network, IPv6Network]):
+    def set_subnet(self, subnet: IPv4Network | IPv6Network):
         """
         Add subnet info to the network service.
         """
@@ -1343,7 +1341,7 @@ class NetworkService(TemplateMixin):
         self.set_fablib_data(fablib_data)
         self._cached_subnet = None
 
-    def set_gateway(self, gateway: Union[IPv4Address, IPv6Address]):
+    def set_gateway(self, gateway: IPv4Address | IPv6Address):
         """
         Add gateway info to the network service.
         """
@@ -1364,10 +1362,10 @@ class NetworkService(TemplateMixin):
                 allocated_ips.append(ipaddress.ip_address(addr))
 
             return allocated_ips
-        except Exception as e:
+        except Exception:
             return []
 
-    def set_allocated_ip(self, addr: Optional[Union[IPv4Address, IPv6Address]] = None):
+    def set_allocated_ip(self, addr: IPv4Address | IPv6Address | None = None):
         """
         Add ``addr`` to the list of allocated IPs.
         """
@@ -1378,7 +1376,7 @@ class NetworkService(TemplateMixin):
         allocated_ips.append(str(addr))
         self.set_fablib_data(fablib_data)
 
-    def allocate_ip(self, addr: Optional[Union[IPv4Address, IPv6Address]] = None):
+    def allocate_ip(self, addr: IPv4Address | IPv6Address | None = None):
         """
         Allocate an IP for the network service.
         """
@@ -1405,7 +1403,7 @@ class NetworkService(TemplateMixin):
         finally:
             self.lock.release()
 
-    def set_allocated_ips(self, allocated_ips: list[Union[IPv4Address, IPv6Address]]):
+    def set_allocated_ips(self, allocated_ips: list[IPv4Address | IPv6Address]):
         """
         Set a list of IPs to be "allocated IPs".
         """
@@ -1420,7 +1418,7 @@ class NetworkService(TemplateMixin):
         fablib_data["subnet"]["allocated_ips"] = allocated_ips_strs
         self.set_fablib_data(fablib_data)
 
-    def free_ip(self, addr: Union[IPv4Address, IPv6Address]):
+    def free_ip(self, addr: IPv4Address | IPv6Address):
         """
         Remove an IP from the list of allocated IPs.
         """
@@ -1539,7 +1537,7 @@ class NetworkService(TemplateMixin):
             capacities=capacities,
         )
 
-    def set_l2_route_hops(self, hops: List[str]):
+    def set_l2_route_hops(self, hops: list[str]):
         """
         Define the sequence of sites or hops to be used for a layer 2 connection.
 
@@ -1547,7 +1545,7 @@ class NetworkService(TemplateMixin):
         in the Network Service configuration.
 
         :param hops: A list of site names to be used as hops.
-        :type hops: List[str]
+        :type hops: list[str]
         """
         if not hops:
             return  # Skip if no hops provided

--- a/fabrictestbed_extensions/fablib/network_service.py
+++ b/fabrictestbed_extensions/fablib/network_service.py
@@ -50,9 +50,11 @@ import ipaddress
 import json
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 
-from fabrictestbed.slice_editor import Capacities, Labels, ServiceType
+from fabrictestbed.slice_editor import Capacities, Labels
 from fabrictestbed.slice_editor import NetworkService as FimNetworkService
-from fim.slivers.network_service import NetworkServiceSliver, NSLayer, ServiceType
+from fabrictestbed.slice_editor import ServiceType
+from fim.slivers.network_service import (NetworkServiceSliver, NSLayer,
+                                         ServiceType)
 from fim.user.network_service import MirrorDirection
 
 from fabrictestbed_extensions.fablib.template_mixin import TemplateMixin

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -54,10 +54,9 @@ import select
 import threading
 import time
 import traceback
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING
 
 import paramiko
-from fabric_cf.orchestrator.orchestrator_proxy import Status
 from fabrictestbed.external_api.orchestrator_client import SliverDTO
 from fim.user import ComponentType, NodeType
 from IPython.core.display_functions import display
@@ -79,9 +78,13 @@ if TYPE_CHECKING:
 
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_address
 
-from fabrictestbed.slice_editor import Capacities, CapacityHints, Labels
+from fabrictestbed.slice_editor import (
+    Capacities,
+    CapacityHints,
+    Labels,
+    ServiceType,
+)
 from fabrictestbed.slice_editor import Node as FimNode
-from fabrictestbed.slice_editor import ServiceType, UserData
 from fim.slivers.network_service import NSLayer
 
 from fabrictestbed_extensions.fablib.component import Component
@@ -150,26 +153,26 @@ class Node(TemplateMixin):
 
         # V2 specific: cached FIM properties (None means not yet cached)
         # Must be initialized before set_username() which calls get_image()
-        self._cached_site: Optional[str] = None
-        self._cached_management_ip: Optional[str] = None
-        self._cached_image_type: Optional[str] = None
-        self._cached_image_ref: Optional[str] = None
-        self._cached_requested_disk: Optional[int] = None
-        self._cached_allocated_disk: Optional[int] = None
-        self._cached_requested_ram: Optional[int] = None
-        self._cached_allocated_ram: Optional[int] = None
-        self._cached_requested_cores: Optional[int] = None
-        self._cached_allocated_cores: Optional[int] = None
-        self._cached_instance_name: Optional[str] = None
-        self._cached_type: Optional[NodeType] = None
+        self._cached_site: str | None = None
+        self._cached_management_ip: str | None = None
+        self._cached_image_type: str | None = None
+        self._cached_image_ref: str | None = None
+        self._cached_requested_disk: int | None = None
+        self._cached_allocated_disk: int | None = None
+        self._cached_requested_ram: int | None = None
+        self._cached_allocated_ram: int | None = None
+        self._cached_requested_cores: int | None = None
+        self._cached_allocated_cores: int | None = None
+        self._cached_instance_name: str | None = None
+        self._cached_type: NodeType | None = None
 
         # Persistent network configuration backend: 'nmcli', 'netplan', or 'ip'
-        self._net_config_backend: Optional[str] = None
+        self._net_config_backend: str | None = None
         self._persistent_config: bool = True
 
         # SSH connection cache for reuse across execute/upload/download calls
-        self._ssh_bastion: Optional[paramiko.SSHClient] = None
-        self._ssh_client: Optional[paramiko.SSHClient] = None
+        self._ssh_bastion: paramiko.SSHClient | None = None
+        self._ssh_client: paramiko.SSHClient | None = None
         self._ssh_lock = threading.Lock()
 
         try:
@@ -192,7 +195,7 @@ class Node(TemplateMixin):
 
         Called when the FIM node is updated.
         """
-        super(Node, self)._invalidate_cache()
+        super()._invalidate_cache()
 
         self._cached_site = None
         self._cached_management_ip = None
@@ -250,7 +253,7 @@ class Node(TemplateMixin):
         slice: Slice = None,
         name: str = None,
         site: str = None,
-        avoid: List[str] = None,
+        avoid: list[str] = None,
         validate: bool = False,
         raise_exception: bool = False,
     ) -> Node:
@@ -266,7 +269,7 @@ class Node(TemplateMixin):
         :param site: the name of the site to build the node on
         :type site: str
         :param avoid: a list of site names to avoid
-        :type avoid: List[str]
+        :type avoid: list[str]
         :param validate: Validate node can be allocated w.r.t available resources
         :type validate: bool
         :param raise_exception: Raise exception if validation fails
@@ -341,7 +344,7 @@ class Node(TemplateMixin):
             "private_ssh_key_file": "Private SSH Key File",
         }
 
-    def toDict(self, skip: Optional[List[str]] = None):
+    def toDict(self, skip: list[str] | None = None):
         """
         Returns the node attributes as a dictionary.
 
@@ -349,7 +352,7 @@ class Node(TemplateMixin):
         is called.
 
         :param skip: list of keys to exclude
-        :type skip: List[str]
+        :type skip: list[str]
         :return: node attributes as dictionary
         :rtype: dict
         """
@@ -391,7 +394,7 @@ class Node(TemplateMixin):
             return dict(self._cached_dict)
         return {k: v for k, v in self._cached_dict.items() if k not in skip}
 
-    def generate_template_context(self, skip: List[str] = None):
+    def generate_template_context(self, skip: list[str] = None):
         """Build a Jinja2 template context dict for this node."""
         if skip is None:
             skip = []
@@ -423,7 +426,7 @@ class Node(TemplateMixin):
 
         :param fields: List of fields to show.  JSON output will
             include all available fields.
-        :type fields: List[str]
+        :type fields: list[str]
 
         :param quiet: True to specify printing/display
         :type quiet: bool
@@ -517,7 +520,7 @@ class Node(TemplateMixin):
 
         :param fields: list of fields (table columns) to show.  JSON
             output will include all available fields/columns.
-        :type fields: List[str]
+        :type fields: list[str]
 
         :param quiet: True to specify printing/display
         :type quiet: bool
@@ -601,7 +604,7 @@ class Node(TemplateMixin):
 
         :param fields: List of fields (table columns) to show.  JSON
             output will include all available fields/columns.
-        :type fields: List[str]
+        :type fields: list[str]
 
         :param quiet: True to specify printing/display
         :type quiet: bool
@@ -685,7 +688,7 @@ class Node(TemplateMixin):
 
         :param fields: List of fields (table columns) to show.  JSON
             output will include all available fields/columns.
-        :type fields: List[str]
+        :type fields: list[str]
 
         :param quiet: True to specify printing/display
         :type quiet: bool
@@ -892,7 +895,7 @@ class Node(TemplateMixin):
         """
         return self.slice
 
-    def get_instance_name(self) -> Optional[str]:
+    def get_instance_name(self) -> str | None:
         """
         Gets the instance name of the FABRIC node.
 
@@ -911,7 +914,7 @@ class Node(TemplateMixin):
                 self._cached_instance_name = None
         return self._cached_instance_name
 
-    def get_cores(self) -> Optional[int]:
+    def get_cores(self) -> int | None:
         """
         Gets the number of cores on the FABRIC node.
 
@@ -930,7 +933,7 @@ class Node(TemplateMixin):
                 self._cached_allocated_cores = None
         return self._cached_allocated_cores if self._cached_allocated_cores else 0
 
-    def get_requested_cores(self) -> Optional[int]:
+    def get_requested_cores(self) -> int | None:
         """
         Gets the requested number of cores on the FABRIC node.
 
@@ -947,7 +950,7 @@ class Node(TemplateMixin):
                 self._cached_requested_cores = None
         return self._cached_requested_cores if self._cached_requested_cores else 0
 
-    def get_ram(self) -> Optional[int]:
+    def get_ram(self) -> int | None:
         """
         Gets the amount of RAM on the FABRIC node.
 
@@ -966,7 +969,7 @@ class Node(TemplateMixin):
                 self._cached_allocated_ram = None
         return self._cached_allocated_ram if self._cached_allocated_ram else 0
 
-    def get_requested_ram(self) -> Optional[int]:
+    def get_requested_ram(self) -> int | None:
         """
         Gets the requested amount of RAM on the FABRIC node.
 
@@ -983,7 +986,7 @@ class Node(TemplateMixin):
                 self._cached_requested_ram = None
         return self._cached_requested_ram if self._cached_requested_ram else 0
 
-    def get_disk(self) -> Optional[int]:
+    def get_disk(self) -> int | None:
         """
         Gets the amount of disk space on the FABRIC node.
 
@@ -1002,7 +1005,7 @@ class Node(TemplateMixin):
                 self._cached_allocated_disk = None
         return self._cached_allocated_disk if self._cached_allocated_disk else 0
 
-    def get_requested_disk(self) -> Optional[int]:
+    def get_requested_disk(self) -> int | None:
         """
         Gets the amount of disk space on the FABRIC node.
 
@@ -1019,7 +1022,7 @@ class Node(TemplateMixin):
                 self._cached_requested_disk = None
         return self._cached_requested_disk if self._cached_requested_disk else 0
 
-    def get_image(self) -> Optional[str]:
+    def get_image(self) -> str | None:
         """
         Gets the image reference on the FABRIC node.
 
@@ -1036,7 +1039,7 @@ class Node(TemplateMixin):
                 self._cached_image_ref = None
         return self._cached_image_ref
 
-    def get_image_type(self) -> Optional[str]:
+    def get_image_type(self) -> str | None:
         """
         Gets the image type on the FABRIC node.
 
@@ -1053,7 +1056,7 @@ class Node(TemplateMixin):
                 self._cached_image_type = None
         return self._cached_image_type
 
-    def get_host(self) -> Optional[str]:
+    def get_host(self) -> str | None:
         """
         Gets the hostname on the FABRIC node.
 
@@ -1091,7 +1094,7 @@ class Node(TemplateMixin):
                 self._cached_site = None
         return self._cached_site if self._cached_site is not None else ""
 
-    def get_type(self) -> Optional[NodeType]:
+    def get_type(self) -> NodeType | None:
         """
         Gets the type of the network services.
 
@@ -1271,7 +1274,7 @@ class Node(TemplateMixin):
             self.interfaces.update(component.get_interfaces(output="dict"))
         return component
 
-    def get_components(self, refresh: bool = False) -> List[Component]:
+    def get_components(self, refresh: bool = False) -> list[Component]:
         """
         Gets a list of components associated with this node.
 
@@ -1280,7 +1283,7 @@ class Node(TemplateMixin):
         :param refresh: Refresh the component objects with latest FIM info
         :type refresh: bool
         :return: a list of components on this node
-        :rtype: List[Component]
+        :rtype: list[Component]
         """
         # Skip refresh if cache is valid
         if self.components and not refresh and not self._fim_dirty:
@@ -1350,7 +1353,7 @@ class Node(TemplateMixin):
 
     def get_interfaces(
         self, include_subs: bool = True, refresh: bool = False, output: str = "list"
-    ) -> Union[Dict[str, Interface], List[Interface]]:
+    ) -> dict[str, Interface] | list[Interface]:
         """
         Gets a list of the interfaces associated with the FABRIC node.
 
@@ -1363,7 +1366,7 @@ class Node(TemplateMixin):
         :param output: Return type - 'list' or 'dict'
         :type output: str
         :return: interfaces on the node
-        :rtype: Union[Dict[str, Interface], List[Interface]]
+        :rtype: dict[str, Interface] | list[Interface]
         """
         # Skip refresh if cache is valid
         if self.interfaces and not refresh and not self._fim_dirty:
@@ -1385,7 +1388,7 @@ class Node(TemplateMixin):
 
     def get_interface(
         self, name: str = None, network_name: str = None, refresh: bool = False
-    ) -> Optional[Interface]:
+    ) -> Interface | None:
         """
         Gets a particular interface associated with a FABRIC node.
 
@@ -1508,7 +1511,7 @@ class Node(TemplateMixin):
             except:
                 pass
 
-        raise ValidationError(f"ssh key invalid: FABRIC requires RSA or ECDSA keys")
+        raise ValidationError("ssh key invalid: FABRIC requires RSA or ECDSA keys")
 
     def _get_ssh_connection(
         self,
@@ -1648,7 +1651,7 @@ class Node(TemplateMixin):
         :param private_key_passphrase: pass phrase
         :type private_key_passphrase: str
         :param output_file: path to a file where the stdout/stderr will be written. None for no file output
-        :type output_file: List[str]
+        :type output_file: list[str]
         :return: a thread that called node.execute()
         :raise Exception: if management IP is invalid
         """
@@ -1729,7 +1732,7 @@ class Node(TemplateMixin):
         :type display: bool
 
         :return: A tuple (stdout, stderr).
-        :rtype: Tuple[str, str]
+        :rtype: tuple[str, str]
 
         :raises Exception: If SSH connection fails.
         :raises RuntimeError: If no_ssh mode is enabled.
@@ -1919,7 +1922,7 @@ class Node(TemplateMixin):
         :type output_file: str
 
         :return: A tuple (stdout, stderr).
-        :rtype: Tuple[str, str]
+        :rtype: tuple[str, str]
         """
         with SSHClientInteraction(client, timeout=10, display=display) as interact:
             for cmd, new_prompt, timeout in commands:
@@ -2426,13 +2429,13 @@ class Node(TemplateMixin):
             return False
         return True
 
-    def get_management_os_interface(self) -> Optional[str]:
+    def get_management_os_interface(self) -> str | None:
         """
         Gets the name of the management interface used by the node's
         operating system, based on the default route.
 
         :return: Name of the management interface or None if not found
-        :rtype: Optional[str]
+        :rtype: str | None
         """
         log.debug(f"{self.get_name()}->get_management_os_interface")
 
@@ -2447,7 +2450,7 @@ class Node(TemplateMixin):
         )
         return None
 
-    def _get_default_interface(self, ip_version: str) -> Optional[str]:
+    def _get_default_interface(self, ip_version: str) -> str | None:
         """
         Helper method to get the default interface for a given IP version.
 
@@ -2484,13 +2487,13 @@ class Node(TemplateMixin):
 
         return None
 
-    def get_dataplane_os_interfaces(self) -> List[dict]:
+    def get_dataplane_os_interfaces(self) -> list[dict]:
         """
         Gets a list of all the dataplane interface names used by the
         node's operating system.
 
         :return: interface names
-        :rtype: List[String]
+        :rtype: list[String]
         """
         management_dev = self.get_management_os_interface()
 
@@ -2550,7 +2553,7 @@ class Node(TemplateMixin):
         log.info(f"{self.get_name()}: falling back to ip backend")
         return self._net_config_backend
 
-    def _get_effective_backend(self, persistent: Optional[bool] = None) -> str:
+    def _get_effective_backend(self, persistent: bool | None = None) -> str:
         """
         Return the effective backend considering the persistent flag.
 
@@ -2670,9 +2673,9 @@ class Node(TemplateMixin):
         ip_version: str,
         addresses: str,
         conn_type: str = "ethernet",
-        vlan_id: Optional[str] = None,
-        vlan_parent: Optional[str] = None,
-        mtu: Optional[str] = None,
+        vlan_id: str | None = None,
+        vlan_parent: str | None = None,
+        mtu: str | None = None,
     ):
         """
         Create or modify an nmcli connection.
@@ -2872,13 +2875,13 @@ class Node(TemplateMixin):
     def _netplan_write_config(
         self,
         ifname: str,
-        addresses: List[str],
-        routes: Optional[List[dict]] = None,
-        routing_policy: Optional[List[dict]] = None,
+        addresses: list[str],
+        routes: list[dict] | None = None,
+        routing_policy: list[dict] | None = None,
         is_vlan: bool = False,
-        vlan_id: Optional[str] = None,
-        vlan_link: Optional[str] = None,
-        mtu: Optional[str] = None,
+        vlan_id: str | None = None,
+        vlan_link: str | None = None,
+        mtu: str | None = None,
     ):
         """
         Write a netplan YAML config for a FABRIC interface.
@@ -3031,7 +3034,7 @@ class Node(TemplateMixin):
         for iface in self.get_dataplane_os_interfaces():
             self.flush_os_interface(iface["ifname"])
 
-    def flush_os_interface(self, os_iface: str, persistent: Optional[bool] = None):
+    def flush_os_interface(self, os_iface: str, persistent: bool | None = None):
         """
         Flush the configuration of an interface in the node
 
@@ -3073,11 +3076,11 @@ class Node(TemplateMixin):
                 return self.ip_addr_list_json
             else:
                 if output == "json":
-                    stdout, stderr = self.execute(f"sudo  ip -j addr list", quiet=True)
+                    stdout, stderr = self.execute("sudo  ip -j addr list", quiet=True)
                     self.ip_addr_list_json = json.loads(stdout)
                     return self.ip_addr_list_json
                 else:
-                    stdout, stderr = self.execute(f"sudo ip addr list", quiet=True)
+                    stdout, stderr = self.execute("sudo ip addr list", quiet=True)
                     return stdout
         except Exception as e:
             log.debug(f"Failed to get ip addr list: {e}")
@@ -3085,10 +3088,10 @@ class Node(TemplateMixin):
 
     def ip_route_add(
         self,
-        subnet: Union[IPv4Network, IPv6Network],
-        gateway: Union[IPv4Address, IPv6Address],
+        subnet: IPv4Network | IPv6Network,
+        gateway: IPv4Address | IPv6Address,
         interface: Interface = None,
-        persistent: Optional[bool] = None,
+        persistent: bool | None = None,
     ):
         """
         Add a route on the node.
@@ -3135,8 +3138,8 @@ class Node(TemplateMixin):
 
     def _ip_route_add_legacy(
         self,
-        subnet: Union[IPv4Network, IPv6Network],
-        gateway: Union[IPv4Address, IPv6Address],
+        subnet: IPv4Network | IPv6Network,
+        gateway: IPv4Address | IPv6Address,
     ):
         """Legacy ip route add using raw ip commands."""
         ip_command = ""
@@ -3157,7 +3160,7 @@ class Node(TemplateMixin):
         """
         try:
             stdout, stderr = self.execute(
-                f"sudo systemctl stop NetworkManager", quiet=True
+                "sudo systemctl stop NetworkManager", quiet=True
             )
             log.info(
                 f"Stopped NetworkManager with 'sudo systemctl stop "
@@ -3173,7 +3176,7 @@ class Node(TemplateMixin):
         """
         try:
             stdout, stderr = self.execute(
-                f"sudo systemctl restart NetworkManager", quiet=True
+                "sudo systemctl restart NetworkManager", quiet=True
             )
             log.info(
                 f"Started NetworkManager with 'sudo systemctl start NetworkManager': stdout: {stdout}\nstderr: {stderr}"
@@ -3208,8 +3211,8 @@ class Node(TemplateMixin):
 
     def ip_route_del(
         self,
-        subnet: Union[IPv4Network, IPv6Network],
-        gateway: Union[IPv4Address, IPv6Address],
+        subnet: IPv4Network | IPv6Network,
+        gateway: IPv4Address | IPv6Address,
     ):
         """
         Delete a route on the node.
@@ -3234,10 +3237,10 @@ class Node(TemplateMixin):
 
     def ip_addr_add(
         self,
-        addr: Union[IPv4Address, IPv6Address],
-        subnet: Union[IPv4Network, IPv6Network],
+        addr: IPv4Address | IPv6Address,
+        subnet: IPv4Network | IPv6Network,
         interface: Interface,
-        persistent: Optional[bool] = None,
+        persistent: bool | None = None,
     ):
         """
         Add an IP to an interface on the node.
@@ -3288,8 +3291,8 @@ class Node(TemplateMixin):
 
     def _ip_addr_add_legacy(
         self,
-        addr: Union[IPv4Address, IPv6Address],
-        subnet: Union[IPv4Network, IPv6Network],
+        addr: IPv4Address | IPv6Address,
+        subnet: IPv4Network | IPv6Network,
         interface: Interface,
     ):
         """Legacy ip addr add using raw ip commands."""
@@ -3310,8 +3313,8 @@ class Node(TemplateMixin):
 
     def ip_addr_del(
         self,
-        addr: Union[IPv4Address, IPv6Address],
-        subnet: Union[IPv4Network, IPv6Network],
+        addr: IPv4Address | IPv6Address,
+        subnet: IPv4Network | IPv6Network,
         interface: Interface,
     ):
         """
@@ -3367,7 +3370,7 @@ class Node(TemplateMixin):
         except Exception as e:
             log.warning(f"Failed to mark interface as unmanaged: {e}")
 
-    def ip_link_up(self, subnet: Union[IPv4Network, IPv6Network], interface: Interface):
+    def ip_link_up(self, subnet: IPv4Network | IPv6Network, interface: Interface):
         """
         Bring up a link on an interface on the node.
 
@@ -3402,7 +3405,7 @@ class Node(TemplateMixin):
         self._ip_link_up_legacy(subnet, interface)
 
     def _ip_link_up_legacy(
-        self, subnet: Union[IPv4Network, IPv6Network], interface: Interface
+        self, subnet: IPv4Network | IPv6Network, interface: Interface
     ):
         """Legacy ip link up using raw ip commands."""
         if not interface:
@@ -3449,7 +3452,7 @@ class Node(TemplateMixin):
             raise e
 
     def ip_link_down(
-        self, subnet: Union[IPv4Network, IPv6Network], interface: Interface
+        self, subnet: IPv4Network | IPv6Network, interface: Interface
     ):
         """
         Bring down a link on an interface on the node.
@@ -3475,7 +3478,7 @@ class Node(TemplateMixin):
         self._ip_link_down_legacy(subnet, interface)
 
     def _ip_link_down_legacy(
-        self, subnet: Union[IPv4Network, IPv6Network], interface: Interface
+        self, subnet: IPv4Network | IPv6Network, interface: Interface
     ):
         """Legacy ip link down using raw ip commands."""
         ip_command = None
@@ -3494,7 +3497,7 @@ class Node(TemplateMixin):
                     ip_command = "sudo ip"
             else:
                 ip_command = "sudo ip"
-        except Exception as e:
+        except Exception:
             # log.warning(f"Failed to down link: {e}")
             return
 
@@ -3514,7 +3517,7 @@ class Node(TemplateMixin):
         ip: str = None,
         cidr: str = None,
         mtu: str = None,
-        persistent: Optional[bool] = None,
+        persistent: bool | None = None,
     ):
         """
         Configure IP Address on network interface as seen inside the VM
@@ -3657,7 +3660,7 @@ class Node(TemplateMixin):
                 self.remove_vlan_os_interface(os_iface=i["ifname"])
 
     def remove_vlan_os_interface(
-        self, os_iface: str = None, persistent: Optional[bool] = None
+        self, os_iface: str = None, persistent: bool | None = None
     ):
         """
         Remove one VLAN OS interface
@@ -3699,7 +3702,7 @@ class Node(TemplateMixin):
         cidr: str = None,
         mtu: str = None,
         interface: Interface = None,
-        persistent: Optional[bool] = None,
+        persistent: bool | None = None,
     ):
         """
         Add VLAN tagged interface for a given interface and set IP address on it
@@ -3958,7 +3961,7 @@ class Node(TemplateMixin):
         """
         return bool(self.get_fablib_data().get("storage", False))
 
-    def get_storage_cluster(self) -> Optional[str]:
+    def get_storage_cluster(self) -> str | None:
         """
         Return the Ceph cluster name associated with this node,
         or ``None`` if none was specified.
@@ -3981,8 +3984,8 @@ class Node(TemplateMixin):
 
     def add_route(
         self,
-        subnet: Union[IPv4Network, IPv6Network],
-        next_hop: Union[IPv4Address, IPv6Address, NetworkService],
+        subnet: IPv4Network | IPv6Network,
+        next_hop: IPv4Address | IPv6Address | NetworkService,
     ):
         """
         Add a route.
@@ -4098,10 +4101,10 @@ class Node(TemplateMixin):
         """
         try:
             return self.get_fablib_data()["routes"]
-        except Exception as e:
+        except Exception:
             return []
 
-    def _find_interface_for_gateway(self, gateway) -> Optional[Interface]:
+    def _find_interface_for_gateway(self, gateway) -> Interface | None:
         """
         Find the interface whose network gateway matches the given gateway.
 
@@ -4134,7 +4137,7 @@ class Node(TemplateMixin):
         for route in routes:
             try:
                 next_hop = ipaddress.ip_address(route["next_hop"])
-            except Exception as e:
+            except Exception:
                 net_name = route["next_hop"].split(".")[0]
                 next_hop = (
                     self.get_slice().get_network(name=str(net_name)).get_gateway()
@@ -4142,7 +4145,7 @@ class Node(TemplateMixin):
 
             try:
                 subnet = ipaddress.ip_network(route["subnet"])
-            except Exception as e:
+            except Exception:
                 net_name = route["subnet"].split(".")[0]
                 subnet = self.get_slice().get_network(name=str(net_name)).get_subnet()
 
@@ -4326,7 +4329,7 @@ class Node(TemplateMixin):
         net_type="IPv4",
         nic_type="NIC_Basic",
         routes=None,
-        subnet: Optional[ipaddress.ip_network] = None,
+        subnet: ipaddress.ip_network | None = None,
     ):
         """
         Add a simple layer 3 network to this node.
@@ -4375,11 +4378,11 @@ class Node(TemplateMixin):
     def poa(
         self,
         operation: str,
-        vcpu_cpu_map: List[Dict[str, str]] = None,
-        node_set: List[str] = None,
-        keys: List[Dict[str, str]] = None,
-        bdf: List[str] = None,
-    ) -> Union[Dict, str]:
+        vcpu_cpu_map: list[dict[str, str]] = None,
+        node_set: list[str] = None,
+        keys: list[dict[str, str]] = None,
+        bdf: list[str] = None,
+    ) -> dict | str:
         """
         Perform operation action on a VM; an action which is triggered by CF via the Aggregate
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -3451,9 +3451,7 @@ class Node(TemplateMixin):
             log.warning(f"Failed to up link: {e}")
             raise e
 
-    def ip_link_down(
-        self, subnet: IPv4Network | IPv6Network, interface: Interface
-    ):
+    def ip_link_down(self, subnet: IPv4Network | IPv6Network, interface: Interface):
         """
         Bring down a link on an interface on the node.
 

--- a/fabrictestbed_extensions/fablib/node.py
+++ b/fabrictestbed_extensions/fablib/node.py
@@ -64,27 +64,22 @@ from paramiko_expect import SSHClientInteraction
 from tabulate import tabulate
 
 from fabrictestbed_extensions.fablib.constants import Constants
-from fabrictestbed_extensions.fablib.exceptions import (
-    ResourceNotFoundError,
-    SliceStateError,
-    SSHError,
-    ValidationError,
-)
+from fabrictestbed_extensions.fablib.exceptions import (ResourceNotFoundError,
+                                                        SliceStateError,
+                                                        SSHError,
+                                                        ValidationError)
 from fabrictestbed_extensions.fablib.network_service import NetworkService
 from fabrictestbed_extensions.utils.utils import Utils
 
 if TYPE_CHECKING:
     from fabrictestbed_extensions.fablib.slice import Slice
 
-from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, ip_address
+from ipaddress import (IPv4Address, IPv4Network, IPv6Address, IPv6Network,
+                       ip_address)
 
-from fabrictestbed.slice_editor import (
-    Capacities,
-    CapacityHints,
-    Labels,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import Capacities, CapacityHints, Labels
 from fabrictestbed.slice_editor import Node as FimNode
+from fabrictestbed.slice_editor import ServiceType
 from fim.slivers.network_service import NSLayer
 
 from fabrictestbed_extensions.fablib.component import Component

--- a/fabrictestbed_extensions/fablib/resources_v2.py
+++ b/fabrictestbed_extensions/fablib/resources_v2.py
@@ -38,8 +38,9 @@ required.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any
 
 from fabrictestbed.slice_editor import AdvertisedTopology
 
@@ -54,7 +55,7 @@ log = logging.getLogger("fablib")
 # Pretty-name dictionaries
 # ------------------------------------------------------------------
 
-LINK_PRETTY_NAMES: Dict[str, str] = {
+LINK_PRETTY_NAMES: dict[str, str] = {
     "name": "Link Name",
     "layer": "Layer",
     "bandwidth": "Capacity (Gbps)",
@@ -63,7 +64,7 @@ LINK_PRETTY_NAMES: Dict[str, str] = {
     "sites": "Sites",
 }
 
-FACILITY_PORT_PRETTY_NAMES: Dict[str, str] = {
+FACILITY_PORT_PRETTY_NAMES: dict[str, str] = {
     "name": "Name",
     "site": "Site",
     "port": "Port",
@@ -78,14 +79,14 @@ FACILITY_PORT_PRETTY_NAMES: Dict[str, str] = {
 # ------------------------------------------------------------------
 
 # Reverse map: FIM model name → v1 non_pretty_name used by attribute_name_mappings
-_FIM_MODEL_TO_ATTR: Dict[str, str] = {}
+_FIM_MODEL_TO_ATTR: dict[str, str] = {}
 for _attr, _names in ResourceConstants.attribute_name_mappings.items():
     _FIM_MODEL_TO_ATTR[_attr] = _attr  # exact FIM key (lowered)
     _FIM_MODEL_TO_ATTR[_attr.lower()] = _attr  # lowered duplicate safe
 
 # Also map component model names that appear in the summary JSON
 # to the attribute_name_mappings key they correspond to.
-_SUMMARY_COMP_TO_ATTR: Dict[str, str] = {
+_SUMMARY_COMP_TO_ATTR: dict[str, str] = {
     "GPU-Tesla T4": Constants.GPU_TESLA_T4,
     "GPU-RTX6000": Constants.GPU_RTX6000,
     "GPU-A30": Constants.GPU_A30,
@@ -102,7 +103,7 @@ _SUMMARY_COMP_TO_ATTR: Dict[str, str] = {
 }
 
 
-def _site_summary_to_v1_dict(site_data: Dict[str, Any]) -> Dict[str, Any]:
+def _site_summary_to_v1_dict(site_data: dict[str, Any]) -> dict[str, Any]:
     """Convert a resources_summary site dict to a v1-compatible ordered dict.
 
     The key order and key names match ``Site.to_dict()`` exactly so that
@@ -117,7 +118,7 @@ def _site_summary_to_v1_dict(site_data: Dict[str, Any]) -> Dict[str, Any]:
     else:
         hosts_count = site_data.get("hosts_count", 0)
 
-    d: Dict[str, Any] = {
+    d: dict[str, Any] = {
         "name": site_data.get("name"),
         "state": site_data.get("state"),
         "address": site_data.get("address"),
@@ -131,7 +132,7 @@ def _site_summary_to_v1_dict(site_data: Dict[str, Any]) -> Dict[str, Any]:
     # sourced from the flat summary keys and nested components dict.
     components = site_data.get("components") or {}
 
-    def _get_cap_alloc(attr_key: str) -> Tuple[int, int]:
+    def _get_cap_alloc(attr_key: str) -> tuple[int, int]:
         """Return (capacity, allocated) for a given attribute_name_mappings key."""
         low = attr_key.lower()
         # cores / ram / disk come as flat top-level keys
@@ -171,12 +172,12 @@ def _site_summary_to_v1_dict(site_data: Dict[str, Any]) -> Dict[str, Any]:
     return d
 
 
-def _host_summary_to_v1_dict(host_data: Dict[str, Any]) -> Dict[str, Any]:
+def _host_summary_to_v1_dict(host_data: dict[str, Any]) -> dict[str, Any]:
     """Convert a resources_summary host dict to a v1-compatible ordered dict.
 
     The key order and key names match ``Host.to_dict()`` exactly.
     """
-    d: Dict[str, Any] = {
+    d: dict[str, Any] = {
         "name": host_data.get("name"),
         "state": host_data.get("state"),
         "address": host_data.get("address"),
@@ -186,7 +187,7 @@ def _host_summary_to_v1_dict(host_data: Dict[str, Any]) -> Dict[str, Any]:
 
     components = host_data.get("components") or {}
 
-    def _get_cap_alloc(attr_key: str) -> Tuple[int, int]:
+    def _get_cap_alloc(attr_key: str) -> tuple[int, int]:
         low = attr_key.lower()
         # cores / ram / disk come as flat keys
         cap_key = f"{low}_capacity"
@@ -238,25 +239,25 @@ class ResourcesV2:
         self,
         fablib_manager,
         force_refresh: bool = False,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
-        avoid: Optional[List[str]] = None,
-        includes: Optional[List[str]] = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        avoid: list[str] | None = None,
+        includes: list[str] | None = None,
     ):
         self.fablib_manager = fablib_manager
 
         # Summary-derived caches (lists of plain dicts)
-        self._sites_data: List[Dict[str, Any]] = []
-        self._hosts_data: List[Dict[str, Any]] = []
-        self._links_data: List[Dict[str, Any]] = []
-        self._facility_ports_data: List[Dict[str, Any]] = []
+        self._sites_data: list[dict[str, Any]] = []
+        self._hosts_data: list[dict[str, Any]] = []
+        self._links_data: list[dict[str, Any]] = []
+        self._facility_ports_data: list[dict[str, Any]] = []
 
         # Keyed lookup for sites
-        self._sites_by_name: Dict[str, Dict[str, Any]] = {}
+        self._sites_by_name: dict[str, dict[str, Any]] = {}
 
         # FIM topology — loaded lazily for ERO validation only
-        self._topology: Optional[AdvertisedTopology] = None
-        self._lazy_params: Dict[str, Any] = {}
+        self._topology: AdvertisedTopology | None = None
+        self._lazy_params: dict[str, Any] = {}
 
         self.update(
             force_refresh=force_refresh,
@@ -273,10 +274,10 @@ class ResourcesV2:
     def update(
         self,
         force_refresh: bool = False,
-        start: Optional[datetime] = None,
-        end: Optional[datetime] = None,
-        avoid: Optional[List[str]] = None,
-        includes: Optional[List[str]] = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        avoid: list[str] | None = None,
+        includes: list[str] | None = None,
     ) -> None:
         """Refresh resource data via ``resources_summary``."""
         log.info("ResourcesV2Wrapper: updating resources via resources_summary")
@@ -458,11 +459,11 @@ class ResourcesV2:
     # Site accessors
     # ----------------------------------------------------------
 
-    def get_site_names(self) -> List[str]:
+    def get_site_names(self) -> list[str]:
         """Return a list of all available site names."""
         return list(self._sites_by_name.keys())
 
-    def get_site(self, site_name: str) -> Optional[Dict[str, Any]]:
+    def get_site(self, site_name: str) -> dict[str, Any] | None:
         """Return the site data dict for the given site name, or None."""
         return self._sites_by_name.get(site_name)
 
@@ -544,7 +545,7 @@ class ResourcesV2:
             .get("available", 0)
         )
 
-    def get_location_lat_long(self, site_name: str) -> Tuple[float, float]:
+    def get_location_lat_long(self, site_name: str) -> tuple[float, float]:
         """Return (latitude, longitude) for the given site."""
         loc = self._site_val(site_name, "location", None)
         if isinstance(loc, (list, tuple)) and len(loc) == 2:
@@ -563,7 +564,7 @@ class ResourcesV2:
     # Host accessors
     # ----------------------------------------------------------
 
-    def get_hosts_by_site(self, site_name: str) -> Dict[str, Dict[str, Any]]:
+    def get_hosts_by_site(self, site_name: str) -> dict[str, dict[str, Any]]:
         """Return hosts for a given site as a dict keyed by host name."""
         return {
             h["name"]: h
@@ -571,7 +572,7 @@ class ResourcesV2:
             if h.get("site") == site_name and h.get("name")
         }
 
-    def get_host(self, host_name: str) -> Optional[Dict[str, Any]]:
+    def get_host(self, host_name: str) -> dict[str, Any] | None:
         """Return a single host dict by name, or None."""
         for h in self._hosts_data:
             if h.get("name") == host_name:
@@ -588,10 +589,10 @@ class ResourcesV2:
 
     def list_sites(
         self,
-        output: Optional[str] = None,
-        fields: Optional[List[str]] = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
         quiet: bool = False,
-        filter_function: Optional[Callable] = None,
+        filter_function: Callable | None = None,
         pretty_names: bool = True,
     ) -> object:
         """List all sites as a table."""
@@ -614,8 +615,8 @@ class ResourcesV2:
     def show_site(
         self,
         site_name: str,
-        output: Optional[str] = None,
-        fields: Optional[List[str]] = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
         quiet: bool = False,
         pretty_names: bool = True,
     ) -> object:
@@ -640,10 +641,10 @@ class ResourcesV2:
 
     def list_hosts(
         self,
-        output: Optional[str] = None,
-        fields: Optional[List[str]] = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
         quiet: bool = False,
-        filter_function: Optional[Callable] = None,
+        filter_function: Callable | None = None,
         pretty_names: bool = True,
     ) -> object:
         """List all hosts as a table."""
@@ -664,8 +665,8 @@ class ResourcesV2:
     def show_host(
         self,
         host_name: str,
-        output: Optional[str] = None,
-        fields: Optional[List[str]] = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
         quiet: bool = False,
         pretty_names: bool = True,
     ) -> object:
@@ -691,10 +692,10 @@ class ResourcesV2:
 
     def list_links(
         self,
-        output: Optional[str] = None,
-        fields: Optional[List[str]] = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
         quiet: bool = False,
-        filter_function: Optional[Callable] = None,
+        filter_function: Callable | None = None,
         pretty_names: bool = True,
     ) -> object:
         """List all inter-site links as a table."""
@@ -711,8 +712,8 @@ class ResourcesV2:
     def show_link(
         self,
         link_name: str,
-        output: Optional[str] = None,
-        fields: Optional[List[str]] = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
         quiet: bool = False,
         pretty_names: bool = True,
     ) -> object:
@@ -729,7 +730,7 @@ class ResourcesV2:
                 )
         return f"Link '{link_name}' not found."
 
-    def get_link_list(self) -> List[str]:
+    def get_link_list(self) -> list[str]:
         """Return a list of all link names."""
         return [l.get("name") for l in self._links_data if l.get("name")]
 
@@ -739,10 +740,10 @@ class ResourcesV2:
 
     def list_facility_ports(
         self,
-        output: Optional[str] = None,
-        fields: Optional[List[str]] = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
         quiet: bool = False,
-        filter_function: Optional[Callable] = None,
+        filter_function: Callable | None = None,
         pretty_names: bool = True,
     ) -> object:
         """List all facility ports as a table."""
@@ -759,8 +760,8 @@ class ResourcesV2:
     def show_facility_port(
         self,
         fp_name: str,
-        output: Optional[str] = None,
-        fields: Optional[List[str]] = None,
+        output: str | None = None,
+        fields: list[str] | None = None,
         quiet: bool = False,
         pretty_names: bool = True,
     ) -> object:
@@ -784,7 +785,7 @@ class ResourcesV2:
     # ----------------------------------------------------------
 
     def validate_requested_ero_path(
-        self, source: str, end: str, hops: List[str]
+        self, source: str, end: str, hops: list[str]
     ) -> None:
         """Validate an ERO path between source and end via the given hops."""
         self._ensure_topology_loaded()

--- a/fabrictestbed_extensions/fablib/site.py
+++ b/fabrictestbed_extensions/fablib/site.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 import json
 import logging
 import traceback
-from typing import Dict, List, Tuple
 
 from fabrictestbed.slice_editor import Capacities
 from fim.user import Component, node
@@ -374,7 +373,7 @@ class Host:
                         comp_cap[
                             Constants.ALLOCATED.lower()
                         ] += c.capacity_allocations.unit
-        except Exception as e:
+        except Exception:
             # log.error(f"Failed to get {component_model_name} capacity {site}: {e}")
             pass
 
@@ -387,7 +386,7 @@ class Host:
         """
         try:
             return self.host.components
-        except Exception as e:
+        except Exception:
             pass
 
     def get_component(self, comp_model_type: str) -> Component:
@@ -402,7 +401,7 @@ class Host:
         """
         try:
             return self.host.components.get(comp_model_type)
-        except Exception as e:
+        except Exception:
             pass
 
     def show(
@@ -459,11 +458,11 @@ class Host:
         """
         try:
             return self.host.location.postal
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get postal address for {site}")
             return ""
 
-    def get_location_lat_long(self) -> Tuple[float, float]:
+    def get_location_lat_long(self) -> tuple[float, float]:
         """
         Gets gets location of a site in latitude and longitude
 
@@ -472,7 +471,7 @@ class Host:
         """
         try:
             return self.host.location.to_latlon()
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get latitude and longitude for {site}")
             return 0, 0
 
@@ -486,7 +485,7 @@ class Host:
         """
         try:
             return self.ptp
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get PTP status for {site}")
             return False
 
@@ -498,7 +497,7 @@ class Host:
         """
         try:
             return self.host.name
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get name for {host}")
             return ""
 
@@ -511,7 +510,7 @@ class Host:
         """
         try:
             return self.host.capacities.core
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get core capacity {site}")
             return 0
 
@@ -524,7 +523,7 @@ class Host:
         """
         try:
             return self.host.capacity_allocations.core
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get cores allocated {site}")
             return 0
 
@@ -537,7 +536,7 @@ class Host:
         """
         try:
             return self.get_core_capacity() - self.get_core_allocated()
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get cores available {site}")
             return self.get_core_capacity()
 
@@ -550,7 +549,7 @@ class Host:
         """
         try:
             return self.host.capacities.ram
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get ram capacity {site}")
             return 0
 
@@ -565,7 +564,7 @@ class Host:
         """
         try:
             return self.host.capacity_allocations.ram
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get ram allocated {site}")
             return 0
 
@@ -580,7 +579,7 @@ class Host:
         """
         try:
             return self.get_ram_capacity() - self.get_ram_allocated()
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get ram available {site_name}")
             return self.get_ram_capacity()
 
@@ -593,7 +592,7 @@ class Host:
         """
         try:
             return self.host.capacities.disk
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get disk capacity {site}")
             return 0
 
@@ -606,7 +605,7 @@ class Host:
         """
         try:
             return self.host.capacity_allocations.disk
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get disk allocated {site}")
             return 0
 
@@ -621,7 +620,7 @@ class Host:
         """
         try:
             return self.get_disk_capacity() - self.get_disk_allocated()
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get disk available {site_name}")
             return self.get_disk_capacity()
 
@@ -644,7 +643,7 @@ class Host:
                     component_model_name
                 ].capacities.unit
             return component_capacity
-        except Exception as e:
+        except Exception:
             # log.error(f"Failed to get {component_model_name} capacity {site}: {e}")
             return component_capacity
 
@@ -671,7 +670,7 @@ class Host:
                     component_model_name
                 ].capacity_allocations.unit
             return component_allocated
-        except Exception as e:
+        except Exception:
             # log.error(f"Failed to get {component_model_name} allocated {site}: {e}")
             return component_allocated
 
@@ -692,7 +691,7 @@ class Host:
             return self.get_component_capacity(
                 component_model_name
             ) - self.get_component_allocated(component_model_name)
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get {component_model_name} available {site}")
             return self.get_component_capacity(component_model_name)
 
@@ -720,12 +719,12 @@ class Site:
         self.site_info = {}
         self.__load()
 
-    def get_hosts(self) -> Dict[str, Host]:
+    def get_hosts(self) -> dict[str, Host]:
         """
         Get the hosts associated with the site.
 
         :return: Dictionary of hosts associated with the site.
-        :rtype: Dict[str, Host]
+        :rtype: dict[str, Host]
         """
         return self.hosts
 
@@ -781,12 +780,12 @@ class Site:
         """
         return self.fablib_manager
 
-    def to_row(self) -> Tuple[list, list]:
+    def to_row(self) -> tuple[list, list]:
         """
         Convert the Site object to a row for tabular display.
 
         :return: Tuple containing headers and row for tabular display.
-        :rtype: Tuple[list, list]
+        :rtype: tuple[list, list]
         """
         headers = [
             "Name",
@@ -840,7 +839,7 @@ class Site:
         """
         try:
             return self.site.name
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get name for {site}")
             return ""
 
@@ -858,7 +857,7 @@ class Site:
                     return str(self.site.maintenance_info.get(host).state)
                 else:
                     return "Active"
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get maintenance state for {site}")
             return ""
 
@@ -873,11 +872,11 @@ class Site:
         """
         try:
             return self.site.location.postal
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get postal address for {site}")
             return ""
 
-    def get_location_lat_long(self) -> Tuple[float, float]:
+    def get_location_lat_long(self) -> tuple[float, float]:
         """
         Gets gets location of a site in latitude and longitude
 
@@ -886,7 +885,7 @@ class Site:
         """
         try:
             return self.site.location.to_latlon()
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get latitude and longitude for {site}")
             return 0, 0
 
@@ -901,7 +900,7 @@ class Site:
         """
         try:
             return self.site.flags.ptp
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get PTP status for {site}")
             return False
 
@@ -916,7 +915,7 @@ class Site:
         """
         try:
             return self.site.capacities.unit
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get host count {site}")
             return 0
 
@@ -931,7 +930,7 @@ class Site:
         """
         try:
             return self.site.capacities.cpu
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get cpu capacity {site}")
             return 0
 
@@ -1010,7 +1009,7 @@ class Site:
                     Constants.ALLOCATED.lower(): s.get_allocated(),
                 }
 
-        except Exception as e:
+        except Exception:
             # log.error(f"Failed to get {component_model_name} capacity {site}: {e}")
             pass
 
@@ -1076,7 +1075,7 @@ class Site:
                     component_model_name=component_model_name
                 )
             return component_capacity
-        except Exception as e:
+        except Exception:
             # log.error(f"Failed to get {component_model_name} capacity {site}: {e}")
             return component_capacity
 
@@ -1100,7 +1099,7 @@ class Site:
                     component_model_name=component_model_name
                 )
             return component_allocated
-        except Exception as e:
+        except Exception:
             # log.error(f"Failed to get {component_model_name} allocated {site}: {e}")
             return component_allocated
 
@@ -1121,7 +1120,7 @@ class Site:
             return self.get_component_capacity(
                 component_model_name
             ) - self.get_component_allocated(component_model_name)
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get {component_model_name} available {site}")
             return self.get_component_capacity(component_model_name)
 
@@ -1143,7 +1142,7 @@ class Site:
         """
         try:
             return self.site.capacities.core
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get core capacity {site}")
             return 0
 
@@ -1156,7 +1155,7 @@ class Site:
         """
         try:
             return self.site.capacity_allocations.core
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get cores allocated {site}")
             return 0
 
@@ -1169,7 +1168,7 @@ class Site:
         """
         try:
             return self.get_core_capacity() - self.get_core_allocated()
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get cores available {site}")
             return self.get_core_capacity()
 
@@ -1182,7 +1181,7 @@ class Site:
         """
         try:
             return self.site.capacities.ram
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get ram capacity {site}")
             return 0
 
@@ -1197,7 +1196,7 @@ class Site:
         """
         try:
             return self.site.capacity_allocations.ram
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get ram allocated {site}")
             return 0
 
@@ -1212,7 +1211,7 @@ class Site:
         """
         try:
             return self.get_ram_capacity() - self.get_ram_allocated()
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get ram available {site_name}")
             return self.get_ram_capacity()
 
@@ -1225,7 +1224,7 @@ class Site:
         """
         try:
             return self.site.capacities.disk
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get disk capacity {site}")
             return 0
 
@@ -1238,7 +1237,7 @@ class Site:
         """
         try:
             return self.site.capacity_allocations.disk
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get disk allocated {site}")
             return 0
 
@@ -1253,15 +1252,15 @@ class Site:
         """
         try:
             return self.get_disk_capacity() - self.get_disk_allocated()
-        except Exception as e:
+        except Exception:
             # log.debug(f"Failed to get disk available {site_name}")
             return self.get_disk_capacity()
 
-    def get_host_names(self) -> List[str]:
+    def get_host_names(self) -> list[str]:
         """
         Gets a list of all currently available hosts
 
         :return: list of host names
-        :rtype: List[String]
+        :rtype: list[String]
         """
         return list(self.hosts.keys())

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -65,12 +65,10 @@ from fss_utils.sshkey import FABRICSSHKey
 from IPython.core.display_functions import display
 
 from fabrictestbed_extensions.fablib.constants import Constants
-from fabrictestbed_extensions.fablib.exceptions import (
-    ResourceNotFoundError,
-    SliceStateError,
-    SliceTimeoutError,
-    ValidationError,
-)
+from fabrictestbed_extensions.fablib.exceptions import (ResourceNotFoundError,
+                                                        SliceStateError,
+                                                        SliceTimeoutError,
+                                                        ValidationError)
 from fabrictestbed_extensions.fablib.switch import Switch
 from fabrictestbed_extensions.utils.utils import Utils
 

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -55,8 +55,8 @@ import logging
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Optional, Tuple
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
 
 import pandas as pd
 from fabrictestbed.external_api.orchestrator_client import SliceDTO, SliverDTO
@@ -80,7 +80,6 @@ if TYPE_CHECKING:
 import concurrent.futures
 import os
 from ipaddress import IPv4Address, ip_address
-from typing import Dict, List, Union
 
 from fabrictestbed.slice_editor import ExperimentTopology
 from tabulate import tabulate
@@ -141,7 +140,7 @@ class Slice:
         fablib_manager: FablibManager,
         name: str = None,
         user_only: bool = True,
-        sm_slice: Optional[SliceDTO] = None,
+        sm_slice: SliceDTO | None = None,
     ):
         """
         Create a FABRIC slice, and set its state to be callable.
@@ -153,19 +152,19 @@ class Slice:
 
         self.fablib_manager: FablibManager = fablib_manager
         self.network_iface_map = None
-        self.sm_slice: Optional[SliceDTO] = sm_slice
+        self.sm_slice: SliceDTO | None = sm_slice
         self.slice_name = sm_slice.name if sm_slice else name
-        self.slice_id: Optional[str] = sm_slice.slice_id if sm_slice else None
-        self.topology: Optional[ExperimentTopology] = ExperimentTopology()
+        self.slice_id: str | None = sm_slice.slice_id if sm_slice else None
+        self.topology: ExperimentTopology | None = ExperimentTopology()
         if self.sm_slice and self.sm_slice.model and len(self.sm_slice.model) > 0:
             self.topology.load(graph_string=self.sm_slice.model)
 
-        self.slivers: List[SliverDTO] = []
-        self._sliver_map: Dict[str, SliverDTO] = {}
-        self.nodes: Dict[str, Node] = {}
-        self.facilities: Dict[str, FacilityPort] = {}
-        self.interfaces: Dict[str, Interface] = {}
-        self.network_services: Dict[str, NetworkService] = {}
+        self.slivers: list[SliverDTO] = []
+        self._sliver_map: dict[str, SliverDTO] = {}
+        self.nodes: dict[str, Node] = {}
+        self.facilities: dict[str, FacilityPort] = {}
+        self.interfaces: dict[str, Interface] = {}
+        self.network_services: dict[str, NetworkService] = {}
         self.update_topology_count: int = 0
         self.update_slivers_count: int = 0
         self.update_slice_count: int = 0
@@ -175,7 +174,7 @@ class Slice:
         self._topology_dirty: bool = True
         # CephFS storage defaults applied to every new node via add_node()
         self._storage: bool = False
-        self._storage_cluster: Optional[str] = None
+        self._storage_cluster: str | None = None
 
     def get_fablib_manager(self) -> FablibManager:
         """Return the associated FablibManager instance."""
@@ -248,7 +247,7 @@ class Slice:
         :param output: output format
         :type output: str
         :param fields: list of fields to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param colors: True to specify state colors for pandas output
@@ -316,7 +315,7 @@ class Slice:
     def list_components(
         self,
         output: str = None,
-        fields: List[str] = None,
+        fields: list[str] = None,
         quiet: bool = False,
         filter_function=None,
         pretty_names=True,
@@ -343,7 +342,7 @@ class Slice:
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -380,7 +379,7 @@ class Slice:
     def list_interfaces(
         self,
         output: str = None,
-        fields: List[str] = None,
+        fields: list[str] = None,
         quiet: bool = False,
         filter_function=None,
         pretty_names: bool = True,
@@ -407,7 +406,7 @@ class Slice:
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -792,12 +791,12 @@ class Slice:
             self.get_slivers()
         return self._sliver_map.get(reservation_id)
 
-    def get_slivers(self) -> List[SliverDTO]:
+    def get_slivers(self) -> list[SliverDTO]:
         """
         Returns slivers associated with the slice.
         """
         if not self.slivers:
-            log.debug(f"get_slivers", stack_info=False)
+            log.debug("get_slivers", stack_info=False)
             self.update_slivers()
 
         return self.slivers
@@ -906,7 +905,7 @@ class Slice:
         :return: True if slice is Allocated and starts in future, False otherwise
         :rtype: Bool
         """
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         lease_start = (
             datetime.strptime(self.get_lease_start(), Constants.LEASE_TIME_FORMAT)
             if self.get_lease_start()
@@ -952,7 +951,7 @@ class Slice:
         else:
             return False
 
-    def get_state(self) -> Optional[str]:
+    def get_state(self) -> str | None:
         """
         Gets the slice state.
 
@@ -986,7 +985,7 @@ class Slice:
         """
         return self.slice_id
 
-    def get_lease_end(self) -> Optional[str]:
+    def get_lease_end(self) -> str | None:
         """
         Gets the timestamp at which the slice lease ends.
 
@@ -1002,7 +1001,7 @@ class Slice:
                 f"Exception in get_lease_end from non-None sm_slice. Returning None state: {e}"
             )
 
-    def get_lease_start(self) -> Optional[str]:
+    def get_lease_start(self) -> str | None:
         """
         Gets the timestamp at which the slice lease starts.
 
@@ -1017,7 +1016,7 @@ class Slice:
                 f"Exception in get_lease_end from non-None sm_slice. Returning None state: {e}"
             )
 
-    def get_email(self) -> Optional[str]:
+    def get_email(self) -> str | None:
         """
         Gets the owner's email of the slice.
 
@@ -1028,7 +1027,7 @@ class Slice:
             return self.sm_slice.owner_email
         return None
 
-    def get_user_id(self) -> Optional[str]:
+    def get_user_id(self) -> str | None:
         """
         Gets the owner's user id of the slice.
 
@@ -1039,7 +1038,7 @@ class Slice:
             return self.sm_slice.owner_user_id
         return None
 
-    def get_project_id(self) -> Optional[str]:
+    def get_project_id(self) -> str | None:
         """
         Gets the project id of the slice.
 
@@ -1054,9 +1053,9 @@ class Slice:
         self,
         name: str,
         mirror_interface_name: str,
-        receive_interface: Optional[Interface] = None,
-        mirror_interface_vlan: Optional[str] = None,
-        mirror_direction: Optional[str] = "both",
+        receive_interface: Interface | None = None,
+        mirror_interface_vlan: str | None = None,
+        mirror_direction: str | None = "both",
     ) -> NetworkService:
         """
         Adds a special PortMirror service.
@@ -1089,7 +1088,7 @@ class Slice:
     def add_l2network(
         self,
         name: str = None,
-        interfaces: List[Interface] = [],
+        interfaces: list[Interface] = [],
         type: str = None,
         subnet: ipaddress = None,
         gateway: ipaddress = None,
@@ -1129,7 +1128,7 @@ class Slice:
 
         :param interfaces: a list of interfaces to build the network
             with
-        :type interfaces: List[Interface]
+        :type interfaces: list[Interface]
 
         :param type: optional L2 network type "L2Bridge", "L2STS", or
             "L2PTP"
@@ -1163,7 +1162,7 @@ class Slice:
     def add_l3network(
         self,
         name: str = None,
-        interfaces: List[Interface] = [],
+        interfaces: list[Interface] = [],
         type: str = "IPv4",
         user_data: dict = {},
         technology: str = None,
@@ -1210,7 +1209,7 @@ class Slice:
 
         :param interfaces: a list of interfaces to build the network
             with
-        :type interfaces: List[Interface]
+        :type interfaces: list[Interface]
 
         :param type: L3 network type "IPv4" or "IPv6"
         :type type: String
@@ -1251,7 +1250,7 @@ class Slice:
         self,
         name: str = None,
         site: str = None,
-        vlan: Union[str, list] = None,
+        vlan: str | list = None,
         labels: Labels = None,
         peer_labels: Labels = None,
         bandwidth: int = None,
@@ -1299,7 +1298,7 @@ class Slice:
         instance_type: str = None,
         host: str = None,
         user_data: dict = {},
-        avoid: List[str] = [],
+        avoid: list[str] = [],
         validate: bool = False,
         raise_exception: bool = False,
         storage: bool = False,
@@ -1345,7 +1344,7 @@ class Slice:
 
         :param avoid: (Optional) A list of sites to avoid is allowing
             random site.
-        :type avoid: List[String]
+        :type avoid: list[String]
 
         :param validate: Validate node can be allocated w.r.t available resources
         :type validate: bool
@@ -1418,11 +1417,11 @@ class Slice:
         ram: int = 8,
         disk: int = 50,
         image: str = Attestable_Switch.default_image,
-        ports: List[str] = None,
+        ports: list[str] = None,
         instance_type: str = None,
         host: str = None,
         user_data: dict = {},
-        avoid: List[str] = [],
+        avoid: list[str] = [],
         validate: bool = False,
         raise_exception: bool = False,
         from_raw_image: bool = False,
@@ -1490,7 +1489,7 @@ class Slice:
         name: str,
         site: str = None,
         user_data: dict = None,
-        avoid: List[str] = None,
+        avoid: list[str] = None,
         validate: bool = False,
         raise_exception: bool = False,
     ) -> Switch:
@@ -1509,7 +1508,7 @@ class Slice:
 
         :param avoid: (Optional) A list of sites to avoid is allowing
             random site.
-        :type avoid: List[String]
+        :type avoid: list[String]
 
         :param validate: Validate node can be allocated w.r.t available resources
         :type validate: bool
@@ -1556,7 +1555,7 @@ class Slice:
 
     def get_object_by_reservation(
         self, reservation_id: str
-    ) -> Union[Node, NetworkService, Interface, None]:
+    ) -> Node | NetworkService | Interface | None:
         """
         Gets an object associated with this slice by its reservation ID.
 
@@ -1583,12 +1582,12 @@ class Slice:
 
         return None
 
-    def get_error_messages(self) -> List[dict]:
+    def get_error_messages(self) -> list[dict]:
         """
         Gets the error messages found in the sliver notices.
 
         :return: a list of error messages
-        :rtype: List[Dict[String, String]]
+        :rtype: list[dict[String, String]]
         """
         # strings to ignore
         cascade_notice_string1 = "Closing reservation due to failure in slice"
@@ -1609,7 +1608,7 @@ class Slice:
 
         return origin_notices
 
-    def get_notices(self) -> Dict[str, str]:
+    def get_notices(self) -> dict[str, str]:
         """
         Gets a dictionary all sliver notices keyed by reservation id.
 
@@ -1630,7 +1629,7 @@ class Slice:
 
         return notices
 
-    def get_components(self, refresh: bool = False) -> List[Component]:
+    def get_components(self, refresh: bool = False) -> list[Component]:
         """
         Gets all components in this slice.
 
@@ -1638,7 +1637,7 @@ class Slice:
         :type refresh: bool
 
         :return: List of all components in this slice
-        :rtype: List[Component]
+        :rtype: list[Component]
         """
         return_components = []
 
@@ -1745,7 +1744,7 @@ class Slice:
         refresh: bool = False,
         site: str = None,
         filter_function=None,
-    ) -> List[Node]:
+    ) -> list[Node]:
         """Gets a list of nodes in this slice, optionally filtered.
 
         :param refresh: force refresh from FIM topology
@@ -1756,7 +1755,7 @@ class Slice:
             returning bool (e.g. ``lambda n: n.get_cores() >= 4``)
         :type filter_function: callable
         :return: a list of fablib nodes
-        :rtype: List[Node]
+        :rtype: list[Node]
         """
         if not self.nodes or not len(self.nodes):
             refresh = True
@@ -1814,12 +1813,12 @@ class Slice:
             log.info(e, exc_info=True)
             raise ResourceNotFoundError(f"Facility not found: {name}")
 
-    def get_facilities(self, refresh: bool = False) -> List[FacilityPort]:
+    def get_facilities(self, refresh: bool = False) -> list[FacilityPort]:
         """
         Gets a list of all nodes in this slice.
 
         :return: a list of fablib nodes
-        :rtype: List[FacilityPort]
+        :rtype: list[FacilityPort]
         """
         if not self.facilities or not len(self.facilities):
             refresh = True
@@ -1905,7 +1904,7 @@ class Slice:
             self.facilities.pop(fac_name)
             log.debug(f"Removed extra facility: {fac_name}")
 
-    def get_attestable_switches(self) -> List[Attestable_Switch]:
+    def get_attestable_switches(self) -> list[Attestable_Switch]:
         """
         Get list of attestable switches in the fablib slice.
         """
@@ -1982,7 +1981,7 @@ class Slice:
 
     def get_interfaces(
         self, include_subs: bool = True, refresh: bool = False, output: str = "list"
-    ) -> Union[dict[str, Interface], list[Interface]]:
+    ) -> dict[str, Interface] | list[Interface]:
         """
         Gets all interfaces in this slice.
 
@@ -1996,7 +1995,7 @@ class Slice:
         :type output: str
 
         :return: a list of interfaces on this slice
-        :rtype: Union[dict[str, Interface], list[Interface]]
+        :rtype: dict[str, Interface] | list[Interface]
         """
         if self.interfaces and not refresh and not self._topology_dirty:
             pass
@@ -2046,14 +2045,14 @@ class Slice:
         for interface in self.get_interfaces():
             if name.endswith(interface.get_name()):
                 return interface
-        raise ResourceNotFoundError("Interface not found: {}".format(name))
+        raise ResourceNotFoundError(f"Interface not found: {name}")
 
-    def get_l3networks(self) -> List[NetworkService]:
+    def get_l3networks(self) -> list[NetworkService]:
         """
         Gets all L3 networks services in this slice
 
         :return: List of all network services in this slice
-        :rtype: List[NetworkService]
+        :rtype: list[NetworkService]
         """
         try:
             return NetworkService.get_l3network_services(self)
@@ -2062,7 +2061,7 @@ class Slice:
 
         return []
 
-    def get_l3network(self, name: str = None) -> Union[NetworkService or None]:
+    def get_l3network(self, name: str = None) -> NetworkService or None:
         """
         Gets a particular L3 network service from this slice.
 
@@ -2077,7 +2076,7 @@ class Slice:
         except Exception as e:
             log.info(e, exc_info=True)
 
-    def get_l2networks(self) -> List[NetworkService]:
+    def get_l2networks(self) -> list[NetworkService]:
         """
         Gets a list of the L2 network services on this slice.
 
@@ -2091,7 +2090,7 @@ class Slice:
 
         return []
 
-    def get_l2network(self, name: str = None) -> Optional[NetworkService]:
+    def get_l2network(self, name: str = None) -> NetworkService | None:
         """
         Gets a particular L2 network service from this slice.
 
@@ -2105,7 +2104,7 @@ class Slice:
         except Exception as e:
             log.info(e, exc_info=True)
 
-    def get_network_services(self, force_refresh: bool = False) -> List[NetworkService]:
+    def get_network_services(self, force_refresh: bool = False) -> list[NetworkService]:
         """
         Not intended for API use. See: slice.get_networks()
 
@@ -2115,7 +2114,7 @@ class Slice:
         :param force_refresh: Force refresh from topology even if cached
         :type force_refresh: bool
         :return: List of all network services in this slice
-        :rtype: List[NetworkService]
+        :rtype: list[NetworkService]
         """
         # Return cached results if valid
         if self.network_services and not self._topology_dirty and not force_refresh:
@@ -2159,14 +2158,14 @@ class Slice:
 
     def get_networks(
         self, refresh: bool = True, output: str = "list"
-    ) -> List[NetworkService]:
+    ) -> list[NetworkService]:
         """
         Gets all network services (L2 and L3) in this slice.
 
         Results are cached for performance.
 
         :return: List of all network services in this slice
-        :rtype: List[NetworkService]
+        :rtype: list[NetworkService]
         """
         if not self.network_services or refresh or self._topology_dirty:
             try:
@@ -2256,7 +2255,7 @@ class Slice:
 
         if end_date is not None:
             end = datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S %z")
-            days = (end - datetime.now(timezone.utc)).days
+            days = (end - datetime.now(UTC)).days
 
         # Directly pass the kwargs to submit
         self.submit(lease_in_hours=(days * 24), post_boot_config=False, **kwargs)
@@ -2330,7 +2329,7 @@ class Slice:
                 slice = slices[0]
                 if slice.state in ("StableOK", "ModifyOK"):
                     if progress:
-                        print(" Slice state: {}".format(slice.state))
+                        print(f" Slice state: {slice.state}")
                     break
                 if slice.state in (
                     "Closing",
@@ -2339,10 +2338,10 @@ class Slice:
                     "ModifyError",
                 ):
                     if progress:
-                        print(" Slice state: {}".format(slice.state))
+                        print(f" Slice state: {slice.state}")
                     try:
                         exception_string = self.build_error_exception_string()
-                    except Exception as e:
+                    except Exception:
                         exception_string = "Exception while getting error messages"
 
                     raise SliceStateError(
@@ -2358,9 +2357,7 @@ class Slice:
 
         if time.time() >= timeout_start + timeout:
             raise SliceTimeoutError(
-                " Timeout exceeded ({} sec). Slice: {} ({})".format(
-                    timeout, slice.name, slice.state
-                )
+                f" Timeout exceeded ({timeout} sec). Slice: {slice.name} ({slice.state})"
             )
 
         # Update the fim topology (wait to avoid get topology bug)
@@ -2540,7 +2537,7 @@ class Slice:
                     threads[thread] = node
 
             print(
-                f"Running post boot config threads ..."
+                "Running post boot config threads ..."
             )  # ({time.time() - start:.0f} sec)")
 
             for thread in concurrent.futures.as_completed(threads.keys()):
@@ -2700,10 +2697,8 @@ class Slice:
             if net.get_type() in ["FABNetv4", "FABNetv6", "FABNetv4Ext", "FABNetv6Ext"]:
                 try:
                     if (
-                        not type(net.get_subnet())
-                        in [ipaddress.IPv4Network, ipaddress.IPv6Network]
-                        or not type(net.get_gateway())
-                        in [ipaddress.IPv4Address, ipaddress.IPv6Address]
+                        type(net.get_subnet()) not in [ipaddress.IPv4Network, ipaddress.IPv6Network]
+                        or type(net.get_gateway()) not in [ipaddress.IPv4Address, ipaddress.IPv6Address]
                         or net.get_available_ips() is None
                     ):
                         log.warning(
@@ -2893,7 +2888,7 @@ class Slice:
         wait_jupyter: str = "text",
         post_boot_config: bool = True,
         wait_ssh: bool = True,
-        extra_ssh_keys: List[str] = None,
+        extra_ssh_keys: list[str] = None,
         lease_start_time: datetime = None,
         lease_end_time: datetime = None,
         lease_in_hours: int = None,
@@ -2931,7 +2926,7 @@ class Slice:
         :type wait_ssh: bool
 
         :param extra_ssh_keys: Optional list of additional SSH public keys to be installed in the slivers of this slice
-        :type extra_ssh_keys: List[str]
+        :type extra_ssh_keys: list[str]
 
         :param lease_start_time: Optional lease start time in UTC format: %Y-%m-%d %H:%M:%S %z.
                            Specifies the beginning of the time range to search for available resources valid for `lease_in_hours`.
@@ -2978,7 +2973,7 @@ class Slice:
         # Create slice now or Renew slice
         if lease_in_hours and not lease_start_time and not lease_end_time:
             end_time_str = (
-                datetime.now(timezone.utc) + timedelta(hours=lease_in_hours)
+                datetime.now(UTC) + timedelta(hours=lease_in_hours)
             ).strftime("%Y-%m-%d %H:%M:%S %z")
 
         # Request slice from Orchestrator
@@ -3102,7 +3097,7 @@ class Slice:
         :type output: str
 
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
 
         :param colors: True to add colors to the table when possible
         :type colors: bool
@@ -3123,7 +3118,7 @@ class Slice:
 
         def error_color(val):
             # if 'Failure' in val:
-            if val != "" and not "TicketReviewPolicy" in val:
+            if val != "" and "TicketReviewPolicy" not in val:
                 color = f"{Constants.ERROR_LIGHT_COLOR}"
             else:
                 color = ""
@@ -3219,7 +3214,7 @@ class Slice:
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -3370,7 +3365,7 @@ class Slice:
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -3386,7 +3381,7 @@ class Slice:
 
         def error_color(val):
             # if 'Failure' in val:
-            if val != "" and not "TicketReviewPolicy" in val:
+            if val != "" and "TicketReviewPolicy" not in val:
                 color = f"{Constants.ERROR_LIGHT_COLOR}"
             else:
                 color = ""
@@ -3481,7 +3476,7 @@ class Slice:
         :param output: output format
         :type output: str
         :param fields: list of fields (table columns) to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param filter_function: lambda function
@@ -3497,7 +3492,7 @@ class Slice:
 
         def error_color(val):
             # if 'Failure' in val:
-            if val != "" and not "TicketReviewPolicy" in val:
+            if val != "" and "TicketReviewPolicy" not in val:
                 color = f"{Constants.ERROR_LIGHT_COLOR}"
             else:
                 color = ""
@@ -3691,7 +3686,7 @@ class Slice:
         else:
             return True
 
-    def validate(self, raise_exception: bool = True) -> Tuple[bool, Dict[str, str]]:
+    def validate(self, raise_exception: bool = True) -> tuple[bool, dict[str, str]]:
         """
         Validate the slice w.r.t available resources before submission.
 
@@ -3703,7 +3698,7 @@ class Slice:
 
         :return: Tuple indicating status for validation and dictionary of the errors corresponding to
                  each requested node
-        :rtype: Tuple[bool, Dict[str, str]]
+        :rtype: tuple[bool, dict[str, str]]
         """
         from fabrictestbed_extensions.fablib.validator import NodeValidator
 

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -2697,8 +2697,10 @@ class Slice:
             if net.get_type() in ["FABNetv4", "FABNetv6", "FABNetv4Ext", "FABNetv6Ext"]:
                 try:
                     if (
-                        type(net.get_subnet()) not in [ipaddress.IPv4Network, ipaddress.IPv6Network]
-                        or type(net.get_gateway()) not in [ipaddress.IPv4Address, ipaddress.IPv6Address]
+                        type(net.get_subnet())
+                        not in [ipaddress.IPv4Network, ipaddress.IPv6Network]
+                        or type(net.get_gateway())
+                        not in [ipaddress.IPv4Address, ipaddress.IPv6Address]
                         or net.get_available_ips() is None
                     ):
                         log.warning(

--- a/fabrictestbed_extensions/fablib/switch.py
+++ b/fabrictestbed_extensions/fablib/switch.py
@@ -32,7 +32,7 @@ functionality for programmable data planes.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING
 
 from tabulate import tabulate
 
@@ -86,13 +86,13 @@ class Switch(Node):
         :type raise_exception: bool
 
         """
-        super(Switch, self).__init__(
+        super().__init__(
             slice=slice, node=node, validate=validate, raise_exception=raise_exception
         )
         self.username = Constants.FABRIC_USER
 
         # Cached interfaces
-        self._interfaces_cache: Dict[str, Interface] = {}
+        self._interfaces_cache: dict[str, Interface] = {}
 
     def _invalidate_cache(self):
         """Invalidate all cached properties including interfaces."""
@@ -155,7 +155,7 @@ class Switch(Node):
         slice: Slice = None,
         name: str = None,
         site: str = None,
-        avoid: List[str] = None,
+        avoid: list[str] = None,
         validate: bool = False,
         raise_exception: bool = False,
     ) -> Switch:
@@ -171,7 +171,7 @@ class Switch(Node):
         :param site: the name of the site to build the switch on
         :type site: str
         :param avoid: a list of site names to avoid
-        :type avoid: List[str]
+        :type avoid: list[str]
         :param validate: Validate switch can be allocated w.r.t available resources
         :type validate: bool
         :param raise_exception: Raise exception if validation fails
@@ -315,7 +315,7 @@ class Switch(Node):
 
     def get_interfaces(
         self, include_subs: bool = True, refresh: bool = False, output: str = "list"
-    ) -> Union[Dict[str, Interface], List[Interface]]:
+    ) -> dict[str, Interface] | list[Interface]:
         """
         Gets a list of the interfaces associated with the FABRIC node.
 
@@ -331,7 +331,7 @@ class Switch(Node):
         :type output: str
 
         :return: interfaces on the node
-        :rtype: Union[Dict[str, Interface], List[Interface]]
+        :rtype: dict[str, Interface] | list[Interface]
         """
         if self._interfaces_cache and not refresh and not self._fim_dirty:
             if output == "dict":
@@ -364,7 +364,7 @@ class Switch(Node):
 
     def get_interface(
         self, name: str = None, refresh: bool = False
-    ) -> Optional[Interface]:
+    ) -> Interface | None:
         """
         Gets a specific interface by name.
 

--- a/fabrictestbed_extensions/fablib/template_mixin.py
+++ b/fabrictestbed_extensions/fablib/template_mixin.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from abc import abstractmethod
-from typing import List, Optional
 
 import jinja2
 from fabrictestbed.slice_editor import UserData
@@ -23,18 +22,18 @@ class TemplateMixin:
       customising the :class:`jinja2.Environment` before rendering.
     """
 
-    _default_skip: Optional[List[str]] = None
+    _default_skip: list[str] | None = None
     _show_title: str = ""
 
     def __init__(self, **kwargs):
         # V2 specific: dirty flag for caching
         self._fim_dirty: bool = True
 
-        self._cached_reservation_id: Optional[str] = None
-        self._cached_reservation_state: Optional[str] = None
-        self._cached_error_message: Optional[str] = None
-        self._cached_name: Optional[str] = None
-        self._cached_dict: Optional[dict] = None
+        self._cached_reservation_id: str | None = None
+        self._cached_reservation_state: str | None = None
+        self._cached_error_message: str | None = None
+        self._cached_name: str | None = None
+        self._cached_dict: dict | None = None
 
     def _invalidate_cache(self):
         """
@@ -56,7 +55,7 @@ class TemplateMixin:
         """
 
     @abstractmethod
-    def toDict(self, skip: Optional[List[str]]):
+    def toDict(self, skip: list[str] | None):
         """
         Returns the attributes as a dictionary
 
@@ -64,7 +63,7 @@ class TemplateMixin:
         :rtype: dict
         """
 
-    def generate_template_context(self, skip: Optional[List[str]] = None):
+    def generate_template_context(self, skip: list[str] | None = None):
         """Return a dict representing this object for template rendering.
 
         The default implementation delegates to ``self.toDict()``.
@@ -124,7 +123,7 @@ class TemplateMixin:
                 self._cached_error_message = None
         return self._cached_error_message
 
-    def get_reservation_id(self) -> Optional[str]:
+    def get_reservation_id(self) -> str | None:
         """
         Gets the reservation ID of the node.
 
@@ -142,7 +141,7 @@ class TemplateMixin:
                 self._cached_reservation_id = None
         return self._cached_reservation_id
 
-    def get_reservation_state(self) -> Optional[str]:
+    def get_reservation_state(self) -> str | None:
         """
         Gets the reservation state on the FABRIC node.
 
@@ -220,7 +219,7 @@ class TemplateMixin:
         :param output: output format
         :type output: str
         :param fields: list of fields to show
-        :type fields: List[str]
+        :type fields: list[str]
         :param quiet: True to specify printing/display
         :type quiet: bool
         :param colors: True to specify state colors for pandas output

--- a/fabrictestbed_extensions/fablib/validator.py
+++ b/fabrictestbed_extensions/fablib/validator.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 
 import logging
 import traceback
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from fim.user import ComponentType
 
@@ -57,11 +57,11 @@ class NodeValidator:
 
     @staticmethod
     def can_allocate_node_in_host(
-        host: Dict[str, Any],
+        host: dict[str, Any],
         node: Node,
         allocated: dict,
-        site: Dict[str, Any],
-    ) -> Tuple[bool, str]:
+        site: dict[str, Any],
+    ) -> tuple[bool, str]:
         """Check if a node fits on a specific host given current allocations.
 
         :param host: Host dict from ResourcesV2 (keys: name, state,
@@ -147,8 +147,8 @@ class NodeValidator:
     def validate_node(
         node: Node,
         resources,
-        allocated: Optional[dict] = None,
-    ) -> Tuple[bool, str]:
+        allocated: dict | None = None,
+    ) -> tuple[bool, str]:
         """Validate a single node against available resources.
 
         Unlike the former ``FablibManager.validate_node``, this accepts
@@ -240,9 +240,9 @@ class NodeValidator:
 
     @staticmethod
     def validate_nodes(
-        nodes: List[Node],
+        nodes: list[Node],
         resources,
-    ) -> Tuple[bool, Dict[str, str]]:
+    ) -> tuple[bool, dict[str, str]]:
         """Batch-validate multiple nodes sharing a single allocated dict.
 
         Resources are fetched once by the caller and passed in.
@@ -252,8 +252,8 @@ class NodeValidator:
         :param resources: A ``ResourcesV2`` instance (pre-fetched)
         :return: (all_valid, errors) where errors maps node_name to message
         """
-        allocated: Dict[str, dict] = {}
-        errors: Dict[str, str] = {}
+        allocated: dict[str, dict] = {}
+        errors: dict[str, str] = {}
         for node in nodes:
             status, error = NodeValidator.validate_node(
                 node=node, resources=resources, allocated=allocated

--- a/fabrictestbed_extensions/utils/abc_utils.py
+++ b/fabrictestbed_extensions/utils/abc_utils.py
@@ -29,14 +29,9 @@ from abc import ABC, abstractmethod
 from typing import List
 
 from fabric_cf.orchestrator.orchestrator_proxy import SliceState
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentCatalog,
-    ComponentModelType,
-    ComponentType,
-    ExperimentTopology,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentCatalog,
+                                        ComponentModelType, ComponentType,
+                                        ExperimentTopology, ServiceType)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
 from fabrictestbed.util.constants import Constants
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,8 @@ doc = [
   "furo",
 ]
 test = [
-  "black==24.*",
-  "isort==5.*",
   "tox==4.*",
+  "ruff>=0.4",
   "pytest",
   "pytest-xdist",
   "pytest-timeout",
@@ -66,9 +65,19 @@ test = [
 branch = true
 omit = ["fabrictestbed_extensions/tests/*"]
 
-[tool.isort]
-profile = "black"
-src_paths = ["fabrictestbed_extensions", "docs/source/conf.py", "tests"]
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP"]
+ignore = [
+  "E501",   # line too long — handled by formatter
+  "UP031",  # printf-string-formatting — too many to change at once
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["fabrictestbed_extensions"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -95,6 +104,11 @@ markers = [
   "nvme: Tests requiring NVMe resources",
   "cephfs: Tests requiring CephFS storage",
 ]
+
+[tool.mypy]
+python_version = "3.11"
+warn_unused_configs = true
+ignore_missing_imports = true
 
 [tool.interrogate]
 ignore-init-method = true

--- a/tests/benchmarks/gpu_tesla_t4_benchmark.py
+++ b/tests/benchmarks/gpu_tesla_t4_benchmark.py
@@ -31,15 +31,10 @@ import time
 import traceback
 from typing import List
 
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentCatalog,
-    ComponentModelType,
-    ComponentType,
-    ExperimentTopology,
-    Labels,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentCatalog,
+                                        ComponentModelType, ComponentType,
+                                        ExperimentTopology, Labels,
+                                        ServiceType)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
 
 from fabrictestbed_extensions import images

--- a/tests/benchmarks/link_benchmark.py
+++ b/tests/benchmarks/link_benchmark.py
@@ -32,14 +32,9 @@ import traceback
 from typing import List
 
 import paramiko
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentCatalog,
-    ComponentModelType,
-    ComponentType,
-    ExperimentTopology,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentCatalog,
+                                        ComponentModelType, ComponentType,
+                                        ExperimentTopology, ServiceType)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
 from fabrictestbed.util.constants import Constants
 

--- a/tests/benchmarks/local_network_benchmark.py
+++ b/tests/benchmarks/local_network_benchmark.py
@@ -32,14 +32,9 @@ import traceback
 from typing import List
 
 import paramiko
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentCatalog,
-    ComponentModelType,
-    ComponentType,
-    ExperimentTopology,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentCatalog,
+                                        ComponentModelType, ComponentType,
+                                        ExperimentTopology, ServiceType)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
 from fabrictestbed.util.constants import Constants
 

--- a/tests/benchmarks/network_benchmark_tests.py
+++ b/tests/benchmarks/network_benchmark_tests.py
@@ -6,14 +6,9 @@ import time
 from typing import List
 
 import paramiko
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentModelType,
-    ComponentType,
-    ExperimentTopology,
-    Labels,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentModelType,
+                                        ComponentType, ExperimentTopology,
+                                        Labels, ServiceType)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
 from fabrictestbed.util.constants import Constants
 

--- a/tests/benchmarks/nvme_benchmark.py
+++ b/tests/benchmarks/nvme_benchmark.py
@@ -31,15 +31,10 @@ import time
 import traceback
 from typing import List
 
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentCatalog,
-    ComponentModelType,
-    ComponentType,
-    ExperimentTopology,
-    Labels,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentCatalog,
+                                        ComponentModelType, ComponentType,
+                                        ExperimentTopology, Labels,
+                                        ServiceType)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
 
 from fabrictestbed_extensions import images

--- a/tests/integration/component_tests.py
+++ b/tests/integration/component_tests.py
@@ -32,15 +32,10 @@ import traceback
 from typing import List
 
 from abc_test import AbcTest
-from fabrictestbed.slice_editor import (
-    Capacities,
-    ComponentCatalog,
-    ComponentModelType,
-    ComponentType,
-    ExperimentTopology,
-    Labels,
-    ServiceType,
-)
+from fabrictestbed.slice_editor import (Capacities, ComponentCatalog,
+                                        ComponentModelType, ComponentType,
+                                        ExperimentTopology, Labels,
+                                        ServiceType)
 from fabrictestbed.slice_manager import SliceManager, SliceState, Status
 
 from fabrictestbed_extensions import images
@@ -741,7 +736,8 @@ class ComponentTest(AbcTest):
                             name_prefix + "-" + component_model_name + "-" + str(site)
                         )
                         # print("Running test, slice_name: {}".format(slice_name))
-                        from fabrictestbed_extensions.utils.slice import SliceUtils
+                        from fabrictestbed_extensions.utils.slice import \
+                            SliceUtils
 
                         slice = SliceUtils.get_slice(
                             slice_name=slice_name, slice_manager=self.slice_manager

--- a/tests/unit/test_basic.py
+++ b/tests/unit/test_basic.py
@@ -7,8 +7,10 @@ from fabrictestbed.fabric_manager import FabricManagerException
 from fabrictestbed.token_manager.token_manager import TokenManagerException
 from fabrictestbed.util.constants import Constants
 
-from fabrictestbed_extensions.fablib.config.config import Config, ConfigException
-from fabrictestbed_extensions.fablib.constants import Constants as FablibConstants
+from fabrictestbed_extensions.fablib.config.config import (Config,
+                                                           ConfigException)
+from fabrictestbed_extensions.fablib.constants import \
+    Constants as FablibConstants
 from fabrictestbed_extensions.fablib.fablib import FablibManager
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,7 +9,8 @@ import pathlib
 import tempfile
 import unittest
 
-from fabrictestbed_extensions.fablib.config.config import Config, ConfigException
+from fabrictestbed_extensions.fablib.config.config import (Config,
+                                                           ConfigException)
 from fabrictestbed_extensions.fablib.constants import Constants
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,14 +30,24 @@ deps =
 commands =
     sphinx-build -W -b html {toxinidir}/docs/source/ {toxinidir}/docs/build/html
 
-[testenv:format]
-# An environment for formatting code.
+[testenv:lint]
+# An environment for linting code.
 deps =
-    black==24.*
-    isort==5.*
+    ruff>=0.4
 
 skip_install = True
 
 commands =
-    black fabrictestbed_extensions tests
-    isort fabrictestbed_extensions tests
+    ruff check fabrictestbed_extensions tests
+    ruff format --check fabrictestbed_extensions tests
+
+[testenv:format]
+# An environment for formatting code.
+deps =
+    ruff>=0.4
+
+skip_install = True
+
+commands =
+    ruff check --fix fabrictestbed_extensions tests
+    ruff format fabrictestbed_extensions tests


### PR DESCRIPTION
## Summary
- Replace black + isort with ruff for linting and formatting (closes #73)
- Add `[tool.ruff]` config to `pyproject.toml` with `E`, `F`, `W`, `I`, `UP` rule sets targeting Python 3.11+
- Add `[testenv:lint]` tox environment for `ruff check` + `ruff format --check`
- Update `[testenv:format]` to use `ruff check --fix` + `ruff format`
- Modernize type annotations across all 16 fablib source files: `List[X]` to `list[X]`, `Dict[K,V]` to `dict[K,V]`, `Optional[X]` to `X | None`, `Union[A,B]` to `A | B` (closes #372)
- Add `from __future__ import annotations` to `config/config.py`
- Add gradual mypy configuration in `pyproject.toml`
- Auto-fix 142 ruff lint issues (unused imports, f-string placeholders, etc.)

## Test plan
- [ ] `tox` - unit tests pass (pre-existing failures unaffected)
- [ ] `tox -e lint` - ruff check and format check pass
- [ ] `tox -e format` - ruff format + fix runs cleanly
- [ ] Verify `py_compile` succeeds on all modified files
