### PR TITLE
Fix interface IP address reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix `Interface.get_ips()` to correctly parse `ip -j addr show` output via new `_get_ip_addr_json()` helper (Issue [#296](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/296))
+- Fix bare `except:` in `Interface.get_ip_addr()` — now catches only `ValueError`/`TypeError` and logs to debug (Issue [#296](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/296))
+- Fix `Interface.get_ip_addr_ssh()` crash when `addr_info` is empty (Issue [#296](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/296))
+
+### Added
+- Add `parse_ip_addr_json()` module-level helper for extracting IPs from `ip -j addr show` JSON output (Issue [#296](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/296))
+- Add unit tests for IP address parsing in `tests/unit/test_interface_ip.py` (Issue [#296](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/296))
+
 ## 2.0.4
 
 ### Added

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -59,6 +59,26 @@ from fim.user.interface import Interface as FimInterface
 log = logging.getLogger("fablib")
 
 
+def parse_ip_addr_json(addr_entry: dict, family: str = None) -> list:
+    """
+    Extract IP addresses from a single ``ip -j addr show`` entry.
+
+    :param addr_entry: one element from the JSON output of ``ip -j addr show``
+    :type addr_entry: dict
+    :param family: optional filter — ``"inet"`` for IPv4, ``"inet6"`` for IPv6
+    :type family: str or None
+    :return: list of IP address strings
+    :rtype: list[str]
+    """
+    ips = []
+    for info in addr_entry.get("addr_info", []):
+        if family is None or info.get("family") == family:
+            local = info.get("local")
+            if local:
+                ips.append(local)
+    return ips
+
+
 class Interface(TemplateMixin):
     """Represents a network interface on a FABRIC node."""
 
@@ -935,35 +955,74 @@ class Interface(TemplateMixin):
 
             for addr in addrs:
                 if addr["ifname"] == dev:
-                    return str(ipaddress.ip_address(addr["addr_info"][0]["local"]))
+                    addr_info = addr.get("addr_info", [])
+                    if not addr_info:
+                        return None
+                    return str(ipaddress.ip_address(addr_info[0]["local"]))
 
             return None
         except Exception as e:
-            log.warning(f"{e}")
+            log.warning(
+                f"get_ip_addr_ssh failed for interface {self.get_name()}: {e}"
+            )
+            return None
+
+    def _get_ip_addr_json(self) -> Optional[dict]:
+        """
+        Get the full ``ip -j addr show`` JSON dict for this interface's device.
+
+        Returns the matching entry from ``ip -j addr show <dev>`` as a dict,
+        or ``None`` if the device cannot be resolved or the command fails.
+
+        :return: JSON dict for the device or None
+        :rtype: dict or None
+        """
+        try:
+            dev = self.get_device_name()
+            if not dev:
+                return None
+
+            stdout, stderr = self.get_node().execute(
+                f"ip -j addr show {dev}", quiet=True
+            )
+            if not stdout:
+                return None
+
+            entries = json.loads(stdout)
+            if entries and isinstance(entries, list):
+                return entries[0]
+            return None
+        except Exception as e:
+            log.warning(
+                f"_get_ip_addr_json failed for interface {self.get_name()}: {e}"
+            )
             return None
 
     # fablib.Interface.get_ip_addr()
     def get_ips(self, family=None):
         """
-        Gets a list of ips assigned to this interface.
+        Gets a list of IP addresses assigned to this interface.
 
-        :return: list of ips
+        Queries the node via SSH to retrieve all addresses on the device.
+        Optionally filters by address family (``"inet"`` for IPv4 or
+        ``"inet6"`` for IPv6).
+
+        :param family: address family filter, e.g. ``"inet"`` or ``"inet6"``
+        :type family: str, optional
+        :return: list of IP address strings
         :rtype: list[str]
         """
         return_ips = []
         try:
-            ip_addr = self.get_ip_addr()
+            addr_json = self._get_ip_addr_json()
+            if addr_json is None:
+                return return_ips
 
-            # print(f"{ip_addr}")
-
-            for addr_info in ip_addr["addr_info"]:
-                if family is None:
-                    return_ips.append(addr_info["local"])
-                else:
-                    if addr_info["family"] == family:
-                        return_ips.append(addr_info["local"])
+            return_ips = parse_ip_addr_json(addr_json, family=family)
         except Exception as e:
-            log.warning(f"{e}")
+            log.warning(
+                f"get_ips failed for interface {self.get_name()}: {e}"
+            )
 
         return return_ips
 
@@ -1044,7 +1103,11 @@ class Interface(TemplateMixin):
         if self.ADDR in fablib_data:
             try:
                 addr = ipaddress.ip_address(fablib_data[self.ADDR])
-            except:
+            except (ValueError, TypeError) as e:
+                log.debug(
+                    f"Could not parse IP address '{fablib_data[self.ADDR]}' "
+                    f"for interface {self.get_name()}: {e}"
+                )
                 addr = fablib_data[self.ADDR]
             return addr
         else:

--- a/fabrictestbed_extensions/fablib/interface.py
+++ b/fabrictestbed_extensions/fablib/interface.py
@@ -962,9 +962,7 @@ class Interface(TemplateMixin):
 
             return None
         except Exception as e:
-            log.warning(
-                f"get_ip_addr_ssh failed for interface {self.get_name()}: {e}"
-            )
+            log.warning(f"get_ip_addr_ssh failed for interface {self.get_name()}: {e}")
             return None
 
     def _get_ip_addr_json(self) -> Optional[dict]:
@@ -1020,9 +1018,7 @@ class Interface(TemplateMixin):
 
             return_ips = parse_ip_addr_json(addr_json, family=family)
         except Exception as e:
-            log.warning(
-                f"get_ips failed for interface {self.get_name()}: {e}"
-            )
+            log.warning(f"get_ips failed for interface {self.get_name()}: {e}")
 
         return return_ips
 

--- a/tests/unit/test_interface_ip.py
+++ b/tests/unit/test_interface_ip.py
@@ -4,7 +4,6 @@ import pytest
 
 from fabrictestbed_extensions.fablib.interface import parse_ip_addr_json
 
-
 # Sample data mimicking `ip -j addr show` output
 SAMPLE_ADDR_ENTRY = {
     "ifindex": 3,

--- a/tests/unit/test_interface_ip.py
+++ b/tests/unit/test_interface_ip.py
@@ -1,0 +1,99 @@
+"""Unit tests for interface IP address parsing helpers."""
+
+import pytest
+
+from fabrictestbed_extensions.fablib.interface import parse_ip_addr_json
+
+
+# Sample data mimicking `ip -j addr show` output
+SAMPLE_ADDR_ENTRY = {
+    "ifindex": 3,
+    "ifname": "ens7",
+    "flags": ["BROADCAST", "MULTICAST", "UP", "LOWER_UP"],
+    "mtu": 9000,
+    "qdisc": "mq",
+    "operstate": "UP",
+    "group": "default",
+    "txqlen": 1000,
+    "link_type": "ether",
+    "address": "aa:bb:cc:dd:ee:ff",
+    "broadcast": "ff:ff:ff:ff:ff:ff",
+    "addr_info": [
+        {
+            "family": "inet",
+            "local": "10.20.30.40",
+            "prefixlen": 24,
+            "broadcast": "10.20.30.255",
+            "scope": "global",
+            "label": "ens7",
+            "valid_life_time": 4294967295,
+            "preferred_life_time": 4294967295,
+        },
+        {
+            "family": "inet6",
+            "local": "fe80::a8bb:ccff:fedd:eeff",
+            "prefixlen": 64,
+            "scope": "link",
+            "valid_life_time": 4294967295,
+            "preferred_life_time": 4294967295,
+        },
+    ],
+}
+
+
+class TestParseIpAddrJson:
+    """Tests for parse_ip_addr_json()."""
+
+    def test_all_addresses(self):
+        result = parse_ip_addr_json(SAMPLE_ADDR_ENTRY)
+        assert result == ["10.20.30.40", "fe80::a8bb:ccff:fedd:eeff"]
+
+    def test_filter_inet(self):
+        result = parse_ip_addr_json(SAMPLE_ADDR_ENTRY, family="inet")
+        assert result == ["10.20.30.40"]
+
+    def test_filter_inet6(self):
+        result = parse_ip_addr_json(SAMPLE_ADDR_ENTRY, family="inet6")
+        assert result == ["fe80::a8bb:ccff:fedd:eeff"]
+
+    def test_empty_addr_info(self):
+        entry = {"ifname": "lo", "addr_info": []}
+        result = parse_ip_addr_json(entry)
+        assert result == []
+
+    def test_missing_addr_info_key(self):
+        entry = {"ifname": "lo"}
+        result = parse_ip_addr_json(entry)
+        assert result == []
+
+    def test_no_matching_family(self):
+        entry = {
+            "ifname": "ens7",
+            "addr_info": [
+                {"family": "inet", "local": "192.168.1.1"},
+            ],
+        }
+        result = parse_ip_addr_json(entry, family="inet6")
+        assert result == []
+
+    def test_multiple_ipv4_addresses(self):
+        entry = {
+            "ifname": "ens7",
+            "addr_info": [
+                {"family": "inet", "local": "10.0.0.1"},
+                {"family": "inet", "local": "10.0.0.2"},
+            ],
+        }
+        result = parse_ip_addr_json(entry, family="inet")
+        assert result == ["10.0.0.1", "10.0.0.2"]
+
+    def test_addr_info_with_missing_local(self):
+        entry = {
+            "ifname": "ens7",
+            "addr_info": [
+                {"family": "inet"},
+                {"family": "inet", "local": "10.0.0.1"},
+            ],
+        }
+        result = parse_ip_addr_json(entry)
+        assert result == ["10.0.0.1"]


### PR DESCRIPTION
## Summary
- Fix `Interface.get_ips()` which was broken - it called `get_ip_addr()` then tried to access `["addr_info"]` on the returned string/IP object (closes #296)
- Add `_get_ip_addr_json()` method that properly queries `ip -j addr show <dev>` and returns the full JSON dict
- Add `parse_ip_addr_json()` module-level helper for testable IP address extraction from JSON output
- Fix bare `except:` in `get_ip_addr()` - now catches only `ValueError`/`TypeError` and logs to debug
- Fix `get_ip_addr_ssh()` crash when `addr_info` list is empty
- Add 8 unit tests in `tests/unit/test_interface_ip.py` (all passing)

## Test plan
- [ ] `pytest tests/unit/test_interface_ip.py -v` - all 8 new tests pass
- [ ] `tox` - unit tests pass
- [ ] Manual verification with a live slice that `get_ips()` returns correct addresses
