### PR TITLE
Migrate integration tests to slice_factory fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Migrate integration tests to use `slice_factory` fixture for automatic cleanup: `test_hello_fabric.py`, `test_list_resources.py`, `test_fablib_node.py`, `test_modify.py`, `test_L2_reconfig_post_reboot.py`, `test_fabnetv4_ext.py`, `test_find_resource_slot.py` (Issue [#244](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/244))
+- Convert integration tests from `unittest.TestCase` to pytest-native style with shared fixtures (Issue [#244](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/244))
+
 ## 2.0.4
 
 ### Added

--- a/tests/integration/test_L2_reconfig_post_reboot.py
+++ b/tests/integration/test_L2_reconfig_post_reboot.py
@@ -16,9 +16,7 @@ pytestmark = [pytest.mark.network, pytest.mark.p2, pytest.mark.slow]
 
 
 @pytest.mark.timeout(1200)
-def test_reconfig_post_reboot(
-    fablib, available_site_with_shared_nic, slice_factory
-):
+def test_reconfig_post_reboot(fablib, available_site_with_shared_nic, slice_factory):
     """Create L2 bridge, verify ping, reboot both nodes, reconfigure, verify again."""
     site = available_site_with_shared_nic
     s = slice_factory("l2-reconfig-reboot")
@@ -28,21 +26,15 @@ def test_reconfig_post_reboot(
     node2_name = "Node2"
 
     # Build topology
-    net1 = s.add_l2network(
-        name=network_name, subnet=IPv4Network("192.168.1.0/24")
-    )
+    net1 = s.add_l2network(name=network_name, subnet=IPv4Network("192.168.1.0/24"))
 
     node1 = s.add_node(name=node1_name, site=site, image="default_ubuntu_22")
-    iface1 = node1.add_component(
-        model="NIC_Basic", name="nic1"
-    ).get_interfaces()[0]
+    iface1 = node1.add_component(model="NIC_Basic", name="nic1").get_interfaces()[0]
     iface1.set_mode("auto")
     net1.add_interface(iface1)
 
     node2 = s.add_node(name=node2_name, site=site, image="default_ubuntu_22")
-    iface2 = node2.add_component(
-        model="NIC_Basic", name="nic1"
-    ).get_interfaces()[0]
+    iface2 = node2.add_component(model="NIC_Basic", name="nic1").get_interfaces()[0]
     iface2.set_mode("auto")
     net1.add_interface(iface2)
 

--- a/tests/integration/test_L2_reconfig_post_reboot.py
+++ b/tests/integration/test_L2_reconfig_post_reboot.py
@@ -1,149 +1,78 @@
-#!/usr/bin/env python3
-# # Create a Local Ethernet (Layer 2) Network: Automatic Configuration
-#
-# This notebook shows how to create an isolated local Ethernet and connect compute nodes to it and
-# use FABlib's automatic configuration functionality.
-#
-import unittest
+"""Integration test for L2 network reconfiguration after node reboot.
+
+Verifies that automatic L2Bridge configuration survives a reboot when
+nodes are reconfigured afterward.
+
+Run with::
+
+    pytest tests/integration/test_L2_reconfig_post_reboot.py -v
+"""
+
 from ipaddress import IPv4Network
 
-from fabrictestbed_extensions.fablib.fablib import FablibManager
+import pytest
+
+pytestmark = [pytest.mark.network, pytest.mark.p2, pytest.mark.slow]
 
 
-class L2ReconfigPostRebootTests(unittest.TestCase):
-    def test_reconfig_post_reboot(self):
-        # Import the FABlib Library
-        fablib = FablibManager()
+@pytest.mark.timeout(1200)
+def test_reconfig_post_reboot(
+    fablib, available_site_with_shared_nic, slice_factory
+):
+    """Create L2 bridge, verify ping, reboot both nodes, reconfigure, verify again."""
+    site = available_site_with_shared_nic
+    s = slice_factory("l2-reconfig-reboot")
 
-        fablib.show_config()
+    network_name = "net1"
+    node1_name = "Node1"
+    node2_name = "Node2"
 
-        # Create the Experiment Slice
-        #
-        # The following creates two nodes with basic NICs connected to an isolated local Ethernet.
-        #
-        # Two nodes are created and one NIC component is added to each node.
-        # This example uses components of model `NIC_Basic` which are SR-IOV Virtual Function on a 100 Gpbs
-        # Mellanox ConnectX-6 PCI device. The VF is accessed by the node via PCI passthrough.
-        # Other NIC models are listed below. When using dedicated PCI devices the whole physical device is
-        # allocated to one node and the device is accessed by the node using PCI passthrough.
-        # Calling the `get_interfaces()` method on a component will return a list of interfaces.
-        # Many dedicated NIC components may have more than one port.  Either port can be connected to the network.
-        #
-        # Automatic configuration requires specify a subnet for the network and setting the
-        # interface's mode to `auto` using the `iface1.set_mode('auto')` function before submitting the request.
-        # With automatic configuration, FABlib will allocate an IP from the network's subnet and configure the
-        # device during the post boot configuration stage.  Optionally, you can add routes to the node before
-        # submitting the request.
-        #
-        #
-        # NIC component models options:
-        # - NIC_Basic: 100 Gbps Mellanox ConnectX-6 SR-IOV VF (1 Port)
-        # - NIC_ConnectX_5: 25 Gbps Dedicated Mellanox ConnectX-5 PCI Device (2 Ports)
-        # - NIC_ConnectX_6: 100 Gbps Dedicated Mellanox ConnectX-6 PCI Device (2 Ports)
+    # Build topology
+    net1 = s.add_l2network(
+        name=network_name, subnet=IPv4Network("192.168.1.0/24")
+    )
 
-        slice_name = "MySlice"
-        site = fablib.get_random_site()
-        site = "GATECH"
-        print(f"Site: {site}")
+    node1 = s.add_node(name=node1_name, site=site, image="default_ubuntu_22")
+    iface1 = node1.add_component(
+        model="NIC_Basic", name="nic1"
+    ).get_interfaces()[0]
+    iface1.set_mode("auto")
+    net1.add_interface(iface1)
 
-        node1_name = "Node1"
-        node2_name = "Node2"
+    node2 = s.add_node(name=node2_name, site=site, image="default_ubuntu_22")
+    iface2 = node2.add_component(
+        model="NIC_Basic", name="nic1"
+    ).get_interfaces()[0]
+    iface2.set_mode("auto")
+    net1.add_interface(iface2)
 
-        network_name = "net1"
+    s.submit()
 
-        # Create Slice
-        slice = fablib.new_slice(name=slice_name)
+    # Verify initial connectivity
+    s = fablib.get_slice(s.get_name())
+    node1 = s.get_node(name=node1_name)
+    node2 = s.get_node(name=node2_name)
+    node2_addr = node2.get_interface(network_name=network_name).get_ip_addr()
 
-        try:
-            print(f"Building topology for the slice: {slice_name}")
-            # Network
-            net1 = slice.add_l2network(
-                name=network_name, subnet=IPv4Network("192.168.1.0/24")
-            )
+    stdout, stderr = node1.execute(f"ping -c 5 {node2_addr}")
+    assert "5 packets transmitted, 5 received, 0% packet loss" in stdout
 
-            # Node1
-            node1 = slice.add_node(
-                name=node1_name, site=site, image="default_ubuntu_22"
-            )
-            iface1 = node1.add_component(
-                model="NIC_Basic", name="nic1"
-            ).get_interfaces()[0]
-            iface1.set_mode("auto")
-            net1.add_interface(iface1)
+    # Reboot both nodes
+    node1.execute("sudo reboot")
+    node2.execute("sudo reboot")
 
-            # Node2
-            node2 = slice.add_node(
-                name=node2_name, site=site, image="default_ubuntu_22"
-            )
-            iface2 = node2.add_component(
-                model="NIC_Basic", name="nic1"
-            ).get_interfaces()[0]
-            iface2.set_mode("auto")
-            net1.add_interface(iface2)
+    # Wait and reconfigure
+    s.wait_ssh()
+    node1 = s.get_node(name=node1_name)
+    node1.config()
+    node2 = s.get_node(name=node2_name)
+    node2.config()
 
-            print(f"Submitting slice {slice_name}")
-            # Submit Slice Request
-            slice.submit()
+    # Verify connectivity after reboot
+    s = fablib.get_slice(s.get_name())
+    node1 = s.get_node(name=node1_name)
+    node2 = s.get_node(name=node2_name)
+    node2_addr = node2.get_interface(network_name=network_name).get_ip_addr()
 
-            # Run the Experiment
-            #
-            # With automatic configuration the slice is ready for experimentation after it becomes active.
-            # Note that automatic configuration works well when saving slices to a file and reinstantiating the slice.
-            # Configuration tasks can be stored in the saved slice, reducing the complexity of notebooks and
-            # other runtime steps.
-            #
-            # We will find the ping round trip time for this pair of sites.  Your experiment should be more interesting!
-            #
-            print(f"Verifying connectivity between the nodes connected via L2Bridge")
-            slice = fablib.get_slice(slice_name)
-            node1 = slice.get_node(name=node1_name)
-            node2 = slice.get_node(name=node2_name)
-            node2_addr = node2.get_interface(network_name=network_name).get_ip_addr()
-
-            stdout, stderr = node1.execute(f"ping -c 5 {node2_addr}")
-            self.assertTrue(
-                "5 packets transmitted, 5 received, 0% packet loss" in stdout
-            )
-            self.assertEqual(stderr, "")
-
-            # Reboot Nodes
-            slice = fablib.get_slice(slice_name)
-
-            print(f"Rebooting Node {node1_name}")
-            node1 = slice.get_node(name=node1_name)
-            node1.execute("sudo reboot")
-
-            print(f"Rebooting Node {node2_name}")
-            node2 = slice.get_node(name=node2_name)
-            node2.execute("sudo reboot")
-
-            # Wait for the Nodes to come back up and re-configure them
-            print(f"Waiting for Nodes to come up")
-            slice.wait_ssh()
-            print(f"Reconfiguring {node1_name}")
-            node1.config()
-            print(f"Reconfiguring {node2_name}")
-            node2.config()
-
-            # Verify that the traffic can still be passed between the VMs
-            print(f"Verifying connectivity between the nodes connected via L2Bridge")
-            slice = fablib.get_slice(slice_name)
-
-            node1 = slice.get_node(name=node1_name)
-            node2 = slice.get_node(name=node2_name)
-
-            node2_addr = node2.get_interface(network_name=network_name).get_ip_addr()
-
-            stdout, stderr = node1.execute(f"ping -c 5 {node2_addr}")
-            self.assertTrue(
-                "5 packets transmitted, 5 received, 0% packet loss" in stdout
-            )
-            self.assertEqual(stderr, "")
-
-        finally:
-            # Delete the slice
-            slice.delete()
-
-
-if __name__ == "__main__":
-    unittest.main()
+    stdout, stderr = node1.execute(f"ping -c 5 {node2_addr}")
+    assert "5 packets transmitted, 5 received, 0% packet loss" in stdout

--- a/tests/integration/test_fablib_node.py
+++ b/tests/integration/test_fablib_node.py
@@ -1,66 +1,21 @@
-#!/usr/bin/env python3
-# MIT License
-#
-# Copyright (c) 2020 FABRIC Testbed
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
+"""Integration tests for fabrictestbed_extensions.fablib.node.Node.
 
-import socket
-import time
-import unittest
+Run with::
 
-from fabrictestbed_extensions.fablib.fablib import FablibManager
-from fabrictestbed_extensions.fablib.node import Node
-from fabrictestbed_extensions.fablib.slice import Slice
+    pytest tests/integration/test_fablib_node.py -v
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.compute, pytest.mark.p1]
 
 
-class FablibNodeTests(unittest.TestCase):
-    """
-    Tests for fabrictestbed_extensions.fablib.node.Node.
-    """
+@pytest.mark.timeout(600)
+def test_node_list_networks(fablib, available_site, slice_factory):
+    """A node with no networks should have an empty network list."""
+    s = slice_factory("node-networks")
+    s.add_node(name="node-1", site=available_site, cores=1, ram=2, disk=10)
+    s.submit()
 
-    def setUp(self):
-        self.fablib = FablibManager()
-
-        time_stamp = time.strftime("%Y-%m-%d %H:%M:%S")
-        host = socket.gethostname()
-        slice_name = f"integration test @ {time_stamp} on {host}"
-
-        self.slice = self.fablib.new_slice(name=slice_name)
-        self.node = self.slice.add_node(name="node-1")
-
-        self.assertIsInstance(self.fablib.get_config(), dict)
-        self.assertIsInstance(self.slice, Slice)
-        self.assertIsInstance(self.node, Node)
-
-        self.slice.submit()
-
-    def tearDown(self):
-        self.slice.delete()
-
-    def test_list_networks(self):
-        # A node with no networks should have an empty network list.
-        # list_networks() returns a table string (with headers even when empty),
-        # so check the underlying data instead.
-        self.assertEqual(len(self.node.get_networks()), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()
+    node = s.get_node(name="node-1")
+    assert len(node.get_networks()) == 0

--- a/tests/integration/test_fabnetv4_ext.py
+++ b/tests/integration/test_fabnetv4_ext.py
@@ -1,141 +1,81 @@
-import unittest
+"""Integration tests for FABNetv4Ext (external IPv4) connectivity.
 
-from fabrictestbed_extensions.fablib.fablib import FablibManager
+Run with::
+
+    pytest tests/integration/test_fabnetv4_ext.py -v
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.network, pytest.mark.p1]
 
 
-class FabNet4ExtTest(unittest.TestCase):
-    """
-    Run some basic tests against the testbed.
-    """
+@pytest.mark.timeout(1200)
+def test_fabnetv4_ext_lifecycle(fablib, available_sites_pair, slice_factory):
+    """Create a slice with FABNetv4Ext, make IPs routable, verify connectivity."""
+    site1, site2 = available_sites_pair
 
-    fablib = None
-    slice_name = "MySlice-fabnet-v4ext"
     node1_name = "Node1"
     node2_name = "Node2"
-
     network1_name = "net1"
     network2_name = "net2"
 
-    node1_nic_name = "nic1"
-    node2_nic_name = "nic2"
+    # Step 1: Create slice with two nodes and external networks
+    s = slice_factory("fabnetv4-ext")
 
-    def setUp(self) -> None:
-        self.fablib = FablibManager()
-        self.fablib.show_config()
+    node1 = s.add_node(name=node1_name, site=site1)
+    iface1 = node1.add_component(
+        model="NIC_Basic", name="nic1"
+    ).get_interfaces()[0]
 
-    def test_1_fabnetv4_ext_create_slice(self):
-        """
-        Create a slice with a single node, and echo a message from the node.
-        """
-        [site1, site2] = self.fablib.get_random_sites(count=2)
-        print(f"Sites: {site1}, {site2}")
+    node2 = s.add_node(name=node2_name, site=site2)
+    iface2 = node2.add_component(
+        model="NIC_Basic", name="nic2"
+    ).get_interfaces()[0]
 
-        # Create Slice
-        slice = self.fablib.new_slice(name=self.slice_name)
+    s.add_l3network(name=network1_name, interfaces=[iface1], type="IPv4Ext")
+    s.add_l3network(name=network2_name, interfaces=[iface2], type="IPv4Ext")
 
-        # Node1
-        node1 = slice.add_node(name=self.node1_name, site=site1)
-        iface1 = node1.add_component(
-            model="NIC_Basic", name=self.node1_nic_name
-        ).get_interfaces()[0]
+    s.submit()
 
-        # Node2
-        node2 = slice.add_node(name=self.node2_name, site=site2)
-        iface2 = node2.add_component(
-            model="NIC_Basic", name=self.node2_nic_name
-        ).get_interfaces()[0]
+    # Step 2: Make IPs publicly routable
+    s = fablib.get_slice(name=s.get_name())
+    network1 = s.get_network(name=network1_name)
+    network1_available_ips = network1.get_available_ips()
 
-        # NetworkS
-        net1 = slice.add_l3network(
-            name=self.network1_name, interfaces=[iface1], type="IPv4Ext"
-        )
-        net2 = slice.add_l3network(
-            name=self.network2_name, interfaces=[iface2], type="IPv4Ext"
-        )
+    network2 = s.get_network(name=network2_name)
+    network2_available_ips = network2.get_available_ips()
 
-        # Submit Slice Request
-        slice.submit()
+    network1.make_ip_publicly_routable(ipv4=[str(network1_available_ips[0])])
+    network2.make_ip_publicly_routable(ipv4=[str(network2_available_ips[0])])
+    s.submit()
 
-    def test_2_fabnetv4_ext_make_ip_routable(self):
-        slice = self.fablib.get_slice(name=self.slice_name)
-        network1 = slice.get_network(name=self.network1_name)
-        network1_available_ips = network1.get_available_ips()
-        network1.show()
+    # Step 3: Configure IPs and verify connectivity
+    s = fablib.get_slice(name=s.get_name())
+    network1 = s.get_network(name=network1_name)
+    network2 = s.get_network(name=network2_name)
 
-        network2 = slice.get_network(name=self.network2_name)
-        network2_available_ips = network2.get_available_ips()
-        network2.show()
+    node1 = s.get_node(name=node1_name)
+    node1_iface = node1.get_interface(network_name=network1_name)
+    node1_addr = network1.get_public_ips()[0]
+    node1_iface.ip_addr_add(addr=node1_addr, subnet=network1.get_subnet())
+    node1.ip_route_add(subnet=network2.get_subnet(), gateway=network1.get_gateway())
 
-        try:
-            # Enable Public IPv6 make_ip_publicly_routable
-            network1.make_ip_publicly_routable(ipv4=[str(network1_available_ips[0])])
+    node1.execute(
+        f"sudo ip route add 0.0.0.0/1 via {network1.get_gateway()}"
+    )
 
-            # Enable Public IPv6 make_ip_publicly_routable
-            network2.make_ip_publicly_routable(ipv4=[str(network2_available_ips[0])])
+    node2 = s.get_node(name=node2_name)
+    node2_iface = node2.get_interface(network_name=network2_name)
+    node2_addr = network2.get_public_ips()[0]
+    node2_iface.ip_addr_add(addr=node2_addr, subnet=network2.get_subnet())
+    node2.ip_route_add(subnet=network1.get_subnet(), gateway=network2.get_gateway())
 
-            slice.submit()
+    node2.execute(
+        f"sudo ip route add 0.0.0.0/1 via {network2.get_gateway()}"
+    )
 
-        except Exception as e:
-            print(f"Exception: {e}")
-            import traceback
-
-            traceback.print_exc()
-
-    def test_3_fabnetv4_ext_connectivity(self):
-        slice = self.fablib.get_slice(name=self.slice_name)
-        network1 = slice.get_network(name=self.network1_name)
-        network2 = slice.get_network(name=self.network2_name)
-
-        node1 = slice.get_node(name=self.node1_name)
-        node1_iface = node1.get_interface(network_name=self.network1_name)
-        node1_addr = network1.get_public_ips()[0]
-        node1_iface.ip_addr_add(addr=node1_addr, subnet=network1.get_subnet())
-
-        node1.ip_route_add(subnet=network2.get_subnet(), gateway=network1.get_gateway())
-
-        # Add route to external network
-        stdout, stderr = node1.execute(
-            f"sudo ip route add 0.0.0.0/1 via {network1.get_gateway()}"
-        )
-
-        stdout, stderr = node1.execute(f"ip addr show {node1_iface.get_device_name()}")
-        stdout, stderr = node1.execute(f"ip route list")
-
-        node2 = slice.get_node(name=self.node2_name)
-        node2_iface = node2.get_interface(network_name=self.network2_name)
-        node2_addr = network2.get_public_ips()[0]
-        node2_iface.ip_addr_add(addr=node2_addr, subnet=network2.get_subnet())
-
-        node2.ip_route_add(subnet=network1.get_subnet(), gateway=network2.get_gateway())
-
-        # Add route to external network
-        stdout, stderr = node2.execute(
-            f"sudo ip route add 0.0.0.0/1 via {network2.get_gateway()}"
-        )
-
-        stdout, stderr = node2.execute(f"ip addr show {node2_iface.get_device_name()}")
-        stdout, stderr = node2.execute(f"ip route list")
-
-        node1 = slice.get_node(name=self.node1_name)
-        node2 = slice.get_node(name=self.node2_name)
-
-        node2_addr = node2.get_interface(network_name=self.network2_name).get_ip_addr()
-
-        stdout, stderr = node1.execute(f"ping -c 5 {node2_addr}")
-
-        # Verify external connectivity
-        stdout, stderr = node1.execute(
-            f"sudo ping -c 5 -I {node1_iface.get_device_name()} bing.com"
-        )
-
-        stdout, stderr = node1.execute(
-            f"sudo ping -c 5 -I {node2_iface.get_device_name()} bing.com"
-        )
-
-    def test_3_fabnetv4_ext_delete(self):
-        slice = self.fablib.get_slice(name=self.slice_name)
-        slice.delete()
-
-
-if __name__ == "__main__":
-    unittest.main()
+    # Verify inter-node connectivity
+    node2_addr = node2.get_interface(network_name=network2_name).get_ip_addr()
+    stdout, stderr = node1.execute(f"ping -c 5 {node2_addr}")
+    assert "0% packet loss" in stdout or "5 received" in stdout

--- a/tests/integration/test_fabnetv4_ext.py
+++ b/tests/integration/test_fabnetv4_ext.py
@@ -24,14 +24,10 @@ def test_fabnetv4_ext_lifecycle(fablib, available_sites_pair, slice_factory):
     s = slice_factory("fabnetv4-ext")
 
     node1 = s.add_node(name=node1_name, site=site1)
-    iface1 = node1.add_component(
-        model="NIC_Basic", name="nic1"
-    ).get_interfaces()[0]
+    iface1 = node1.add_component(model="NIC_Basic", name="nic1").get_interfaces()[0]
 
     node2 = s.add_node(name=node2_name, site=site2)
-    iface2 = node2.add_component(
-        model="NIC_Basic", name="nic2"
-    ).get_interfaces()[0]
+    iface2 = node2.add_component(model="NIC_Basic", name="nic2").get_interfaces()[0]
 
     s.add_l3network(name=network1_name, interfaces=[iface1], type="IPv4Ext")
     s.add_l3network(name=network2_name, interfaces=[iface2], type="IPv4Ext")
@@ -61,9 +57,7 @@ def test_fabnetv4_ext_lifecycle(fablib, available_sites_pair, slice_factory):
     node1_iface.ip_addr_add(addr=node1_addr, subnet=network1.get_subnet())
     node1.ip_route_add(subnet=network2.get_subnet(), gateway=network1.get_gateway())
 
-    node1.execute(
-        f"sudo ip route add 0.0.0.0/1 via {network1.get_gateway()}"
-    )
+    node1.execute(f"sudo ip route add 0.0.0.0/1 via {network1.get_gateway()}")
 
     node2 = s.get_node(name=node2_name)
     node2_iface = node2.get_interface(network_name=network2_name)
@@ -71,9 +65,7 @@ def test_fabnetv4_ext_lifecycle(fablib, available_sites_pair, slice_factory):
     node2_iface.ip_addr_add(addr=node2_addr, subnet=network2.get_subnet())
     node2.ip_route_add(subnet=network1.get_subnet(), gateway=network2.get_gateway())
 
-    node2.execute(
-        f"sudo ip route add 0.0.0.0/1 via {network2.get_gateway()}"
-    )
+    node2.execute(f"sudo ip route add 0.0.0.0/1 via {network2.get_gateway()}")
 
     # Verify inter-node connectivity
     node2_addr = node2.get_interface(network_name=network2_name).get_ip_addr()

--- a/tests/integration/test_find_resource_slot.py
+++ b/tests/integration/test_find_resource_slot.py
@@ -1,498 +1,280 @@
-#!/usr/bin/env python3
-# MIT License
-#
-# Copyright (c) 2020 FABRIC Testbed
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# Author Komal Thareja (kthare10@renci.org)
-"""
-Integration tests for FablibManager.find_resource_slot().
+"""Integration tests for FablibManager.find_resource_slot().
 
 Requires valid FABRIC credentials (token, project_id, etc.) to be
 configured via environment variables or fabric_rc.
+
+Run with::
+
+    pytest tests/integration/test_find_resource_slot.py -v
 """
 
 import datetime
-import os
-import socket
-import time
-import unittest
 
-from fabrictestbed_extensions.fablib.fablib import FablibManager
+import pytest
+
+pytestmark = [pytest.mark.compute, pytest.mark.p1]
 
 
-class FindResourceSlotIntegrationTests(unittest.TestCase):
-    """
-    Integration tests that call find_resource_slot() against the live
-    FABRIC testbed API.
-    """
+def _search_window(days=7):
+    """Return a (start, end) tuple covering the next *days* days."""
+    start = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
+        hours=1
+    )
+    end = start + datetime.timedelta(days=days)
+    return start, end
 
-    @classmethod
-    def setUpClass(cls):
-        cls.fablib = FablibManager()
-        cls.fablib.show_config()
 
-        # Pick two random sites for all tests to use
-        sites = cls.fablib.get_random_sites(count=2)
-        cls.site1 = sites[0]
-        cls.site2 = sites[1]
-        print(f"\nUsing sites: site1={cls.site1}, site2={cls.site2}")
+@pytest.fixture(scope="module")
+def two_sites(fablib):
+    """Pick two random sites for all tests in this module."""
+    sites = fablib.get_random_sites(count=2)
+    if None in sites or len(sites) < 2:
+        pytest.skip("Could not find two available sites")
+    return sites[0], sites[1]
 
-    @staticmethod
-    def _search_window(days=7):
-        """Return a (start, end) tuple covering the next *days* days."""
-        start = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(
-            hours=1
-        )
-        end = start + datetime.timedelta(days=days)
-        return start, end
 
-    # ------------------------------------------------------------------
-    # Tests using raw resource dicts
-    # ------------------------------------------------------------------
+# ------------------------------------------------------------------
+# Tests using raw resource dicts
+# ------------------------------------------------------------------
 
-    def test_find_slot_basic_compute(self):
-        """Search for a small compute slot using raw resource dicts."""
-        start, end = self._search_window()
-        resources = [
-            {
-                "type": "compute",
-                "site": self.site1,
-                "cores": 2,
-                "ram": 8,
-                "disk": 10,
-            }
-        ]
 
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            resources=resources,
+class TestFindSlotRawResources:
+    """Test find_resource_slot() with raw resource dicts."""
+
+    def test_basic_compute(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, _ = two_sites
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1,
+            resources=[{"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10}],
             max_results=3,
         )
+        assert isinstance(result, dict)
 
-        print(f"\nBasic compute result: {result}")
-        self.assertIsInstance(result, dict)
-
-    def test_find_slot_compute_with_component_db_format(self):
-        """Search using the DB-format component key (e.g. GPU-Tesla T4)."""
-        start, end = self._search_window()
-        resources = [
-            {
-                "type": "compute",
-                "site": self.site1,
-                "cores": 4,
-                "ram": 16,
-                "disk": 50,
+    def test_compute_with_gpu_db_format(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, _ = two_sites
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1,
+            resources=[{
+                "type": "compute", "site": site1, "cores": 4, "ram": 16, "disk": 50,
                 "components": {"GPU-Tesla T4": 1},
-            }
-        ]
-
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            resources=resources,
+            }],
         )
+        assert isinstance(result, dict)
 
-        print(f"\nGPU (DB format) result: {result}")
-        self.assertIsInstance(result, dict)
-
-    def test_find_slot_compute_with_component_fablib_format(self):
-        """Search using the fablib-format component key (e.g. GPU_TeslaT4)."""
-        start, end = self._search_window()
-        resources = [
-            {
-                "type": "compute",
-                "site": self.site1,
-                "cores": 4,
-                "ram": 16,
-                "disk": 50,
+    def test_compute_with_gpu_fablib_format(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, _ = two_sites
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1,
+            resources=[{
+                "type": "compute", "site": site1, "cores": 4, "ram": 16, "disk": 50,
                 "components": {"GPU_TeslaT4": 1},
-            }
-        ]
-
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            resources=resources,
+            }],
         )
+        assert isinstance(result, dict)
 
-        print(f"\nGPU (fablib format) result: {result}")
-        self.assertIsInstance(result, dict)
-
-    def test_find_slot_with_smartnic(self):
-        """Search for a node with a SmartNIC using fablib name."""
-        start, end = self._search_window()
-        resources = [
-            {
-                "type": "compute",
-                "site": self.site1,
-                "cores": 4,
-                "ram": 16,
-                "disk": 10,
+    def test_with_smartnic(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, _ = two_sites
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1,
+            resources=[{
+                "type": "compute", "site": site1, "cores": 4, "ram": 16, "disk": 10,
                 "components": {"NIC_ConnectX_6": 1},
-            }
-        ]
-
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            resources=resources,
+            }],
         )
+        assert isinstance(result, dict)
 
-        print(f"\nSmartNIC result: {result}")
-        self.assertIsInstance(result, dict)
-
-    def test_find_slot_multi_site(self):
-        """Search for compute resources on two different sites."""
-        start, end = self._search_window()
-        resources = [
-            {
-                "type": "compute",
-                "site": self.site1,
-                "cores": 2,
-                "ram": 8,
-                "disk": 10,
-            },
-            {
-                "type": "compute",
-                "site": self.site2,
-                "cores": 2,
-                "ram": 8,
-                "disk": 10,
-            },
-        ]
-
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            resources=resources,
+    def test_multi_site(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, site2 = two_sites
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1,
+            resources=[
+                {"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10},
+                {"type": "compute", "site": site2, "cores": 2, "ram": 8, "disk": 10},
+            ],
         )
+        assert isinstance(result, dict)
 
-        print(f"\nMulti-site result: {result}")
-        self.assertIsInstance(result, dict)
-
-    def test_find_slot_with_link(self):
-        """Search for compute on two sites plus an inter-site link."""
-        start, end = self._search_window()
-        resources = [
-            {
-                "type": "compute",
-                "site": self.site1,
-                "cores": 2,
-                "ram": 8,
-                "disk": 10,
-            },
-            {
-                "type": "compute",
-                "site": self.site2,
-                "cores": 2,
-                "ram": 8,
-                "disk": 10,
-            },
-            {
-                "type": "link",
-                "site_a": self.site1,
-                "site_b": self.site2,
-                "bandwidth": 10,
-            },
-        ]
-
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            resources=resources,
+    def test_with_link(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, site2 = two_sites
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1,
+            resources=[
+                {"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10},
+                {"type": "compute", "site": site2, "cores": 2, "ram": 8, "disk": 10},
+                {"type": "link", "site_a": site1, "site_b": site2, "bandwidth": 10},
+            ],
         )
+        assert isinstance(result, dict)
 
-        print(f"\nCompute + link result: {result}")
-        self.assertIsInstance(result, dict)
-
-    def test_find_slot_max_results(self):
-        """Verify max_results parameter is respected."""
-        start, end = self._search_window()
-        resources = [
-            {
-                "type": "compute",
-                "site": self.site1,
-                "cores": 2,
-                "ram": 8,
-                "disk": 10,
-            }
-        ]
-
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            resources=resources,
+    def test_max_results(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, _ = two_sites
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1,
+            resources=[{"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10}],
             max_results=5,
         )
+        assert isinstance(result, dict)
 
-        print(f"\nmax_results=5 result: {result}")
-        self.assertIsInstance(result, dict)
-
-    def test_find_slot_longer_duration(self):
-        """Search for a longer slot (24 hours)."""
-        start, end = self._search_window(days=14)
-        resources = [
-            {
-                "type": "compute",
-                "site": self.site1,
-                "cores": 2,
-                "ram": 8,
-                "disk": 10,
-            }
-        ]
-
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=24,
-            resources=resources,
+    def test_longer_duration(self, fablib, two_sites):
+        start, end = _search_window(days=14)
+        site1, _ = two_sites
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=24,
+            resources=[{"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10}],
         )
+        assert isinstance(result, dict)
 
-        print(f"\n24-hour duration result: {result}")
-        self.assertIsInstance(result, dict)
 
-    # ------------------------------------------------------------------
-    # Tests using Slice objects
-    # ------------------------------------------------------------------
+# ------------------------------------------------------------------
+# Tests using Slice objects
+# ------------------------------------------------------------------
 
-    def test_find_slot_with_slice_object(self):
-        """Build an unsubmitted Slice and use it to find a slot."""
-        start, end = self._search_window()
 
-        slice_obj = self.fablib.new_slice(name="test-find-slot-slice")
-        slice_obj.add_node(name="node1", site=self.site1, cores=2, ram=8, disk=10)
+class TestFindSlotWithSlice:
+    """Test find_resource_slot() with Slice objects."""
 
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            slice=slice_obj,
+    def test_with_slice_object(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, _ = two_sites
+
+        slice_obj = fablib.new_slice(name="test-find-slot-slice")
+        slice_obj.add_node(name="node1", site=site1, cores=2, ram=8, disk=10)
+
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1, slice=slice_obj,
         )
+        assert isinstance(result, dict)
 
-        print(f"\nSlice object result: {result}")
-        self.assertIsInstance(result, dict)
+    def test_with_gpu_node(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, _ = two_sites
 
-    def test_find_slot_with_slice_gpu_node(self):
-        """Slice with a GPU node."""
-        start, end = self._search_window()
-
-        slice_obj = self.fablib.new_slice(name="test-find-slot-gpu")
+        slice_obj = fablib.new_slice(name="test-find-slot-gpu")
         node = slice_obj.add_node(
-            name="gpu-node", site=self.site1, cores=8, ram=32, disk=100
+            name="gpu-node", site=site1, cores=8, ram=32, disk=100
         )
         node.add_component(model="GPU_TeslaT4", name="gpu1")
 
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            slice=slice_obj,
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1, slice=slice_obj,
         )
+        assert isinstance(result, dict)
 
-        print(f"\nSlice GPU node result: {result}")
-        self.assertIsInstance(result, dict)
+    def test_with_two_sites_and_l2network(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, site2 = two_sites
 
-    def test_find_slot_with_slice_two_sites_and_l2network(self):
-        """Slice with two nodes on different sites connected by L2PTP."""
-        start, end = self._search_window()
-
-        slice_obj = self.fablib.new_slice(name="test-find-slot-l2")
-        node1 = slice_obj.add_node(
-            name="node1", site=self.site1, cores=2, ram=8, disk=10
-        )
+        slice_obj = fablib.new_slice(name="test-find-slot-l2")
+        node1 = slice_obj.add_node(name="node1", site=site1, cores=2, ram=8, disk=10)
         iface1 = node1.add_component(model="NIC_Basic", name="nic1").get_interfaces()[0]
 
-        node2 = slice_obj.add_node(
-            name="node2", site=self.site2, cores=2, ram=8, disk=10
-        )
+        node2 = slice_obj.add_node(name="node2", site=site2, cores=2, ram=8, disk=10)
         iface2 = node2.add_component(model="NIC_Basic", name="nic2").get_interfaces()[0]
 
         slice_obj.add_l2network(name="net1", interfaces=[iface1, iface2])
 
-        result = self.fablib.find_resource_slot(
-            start=start,
-            end=end,
-            duration=1,
-            slice=slice_obj,
+        result = fablib.find_resource_slot(
+            start=start, end=end, duration=1, slice=slice_obj,
         )
+        assert isinstance(result, dict)
 
-        print(f"\nSlice L2PTP result: {result}")
-        self.assertIsInstance(result, dict)
 
-    # ------------------------------------------------------------------
-    # End-to-end test: submit a slice then check availability
-    # ------------------------------------------------------------------
+# ------------------------------------------------------------------
+# End-to-end test: submit a slice then check availability
+# ------------------------------------------------------------------
 
-    def test_find_slot_after_submitting_smartnic_slice(self):
-        """
-        Submit a real slice with SmartNIC-connected nodes, then use
-        find_resource_slot() with an equivalent Slice object to verify
-        the API returns availability results while resources are in use.
-        """
-        time_stamp = time.strftime("%Y-%m-%d %H:%M:%S")
-        host = socket.gethostname()
-        slice_name = f"test-find-slot-smartnic @ {time_stamp} on {host}"
 
-        print(f"\nCreating slice '{slice_name}' on {self.site1} and {self.site2}...")
-        live_slice = self.fablib.new_slice(name=slice_name)
+@pytest.mark.timeout(900)
+def test_find_slot_after_submitting_smartnic_slice(
+    fablib, two_sites, slice_factory
+):
+    """Submit a real SmartNIC slice, then search for equivalent availability."""
+    site1, site2 = two_sites
+    s = slice_factory("find-slot-smartnic")
 
-        node1 = live_slice.add_node(
-            name="smartnic-node1", site=self.site1, cores=2, ram=8, disk=10
-        )
-        nic1 = node1.add_component(model="NIC_ConnectX_6", name="nic1")
-        iface1 = nic1.get_interfaces()[0]
+    node1 = s.add_node(name="smartnic-node1", site=site1, cores=2, ram=8, disk=10)
+    nic1 = node1.add_component(model="NIC_ConnectX_6", name="nic1")
+    iface1 = nic1.get_interfaces()[0]
 
-        node2 = live_slice.add_node(
-            name="smartnic-node2", site=self.site2, cores=2, ram=8, disk=10
-        )
-        nic2 = node2.add_component(model="NIC_ConnectX_6", name="nic2")
-        iface2 = nic2.get_interfaces()[0]
+    node2 = s.add_node(name="smartnic-node2", site=site2, cores=2, ram=8, disk=10)
+    nic2 = node2.add_component(model="NIC_ConnectX_6", name="nic2")
+    iface2 = nic2.get_interfaces()[0]
 
-        live_slice.add_l2network(name="smartnic-net", interfaces=[iface1, iface2])
+    s.add_l2network(name="smartnic-net", interfaces=[iface1, iface2])
+    s.submit(wait=True)
 
-        try:
-            # Submit and wait for the slice to become active
-            print(f"Submitting slice '{slice_name}'...")
-            live_slice.submit(wait=True)
+    # Now search for equivalent resources
+    start, end = _search_window()
 
-            print(f"Slice '{slice_name}' status:")
-            live_slice.show()
+    query_slice = fablib.new_slice(name="query-smartnic-slot")
+    qn1 = query_slice.add_node(name="node1", site=site1, cores=2, ram=8, disk=10)
+    qi1 = qn1.add_component(model="NIC_ConnectX_6", name="nic1").get_interfaces()[0]
 
-            # Now build an equivalent unsubmitted slice and search for a slot
-            start, end = self._search_window()
+    qn2 = query_slice.add_node(name="node2", site=site2, cores=2, ram=8, disk=10)
+    qi2 = qn2.add_component(model="NIC_ConnectX_6", name="nic2").get_interfaces()[0]
 
-            query_slice = self.fablib.new_slice(name="query-smartnic-slot")
-            qn1 = query_slice.add_node(
-                name="node1", site=self.site1, cores=2, ram=8, disk=10
-            )
-            qnic1 = qn1.add_component(model="NIC_ConnectX_6", name="nic1")
-            qi1 = qnic1.get_interfaces()[0]
+    query_slice.add_l2network(name="net1", interfaces=[qi1, qi2])
 
-            qn2 = query_slice.add_node(
-                name="node2", site=self.site2, cores=2, ram=8, disk=10
-            )
-            qnic2 = qn2.add_component(model="NIC_ConnectX_6", name="nic2")
-            qi2 = qnic2.get_interfaces()[0]
+    result = fablib.find_resource_slot(
+        start=start, end=end, duration=1, slice=query_slice,
+    )
+    assert isinstance(result, dict)
 
-            query_slice.add_l2network(name="net1", interfaces=[qi1, qi2])
+    # Also test with raw resource dicts
+    result_raw = fablib.find_resource_slot(
+        start=start, end=end, duration=1,
+        resources=[
+            {"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10,
+             "components": {"NIC_ConnectX_6": 1}},
+            {"type": "compute", "site": site2, "cores": 2, "ram": 8, "disk": 10,
+             "components": {"NIC_ConnectX_6": 1}},
+            {"type": "link", "site_a": site1, "site_b": site2, "bandwidth": 10},
+        ],
+        max_results=3,
+    )
+    assert isinstance(result_raw, dict)
 
-            print("\nSearching for available slot with equivalent SmartNIC topology...")
-            result = self.fablib.find_resource_slot(
-                start=start,
-                end=end,
-                duration=1,
-                slice=query_slice,
-            )
 
-            print(f"SmartNIC slot result: {result}")
-            self.assertIsInstance(result, dict)
+# ------------------------------------------------------------------
+# Validation tests
+# ------------------------------------------------------------------
 
-            # Also test with raw resource dicts using fablib component names
-            print("\nSearching with raw resource dicts (fablib format)...")
-            result_raw = self.fablib.find_resource_slot(
-                start=start,
-                end=end,
-                duration=1,
-                resources=[
-                    {
-                        "type": "compute",
-                        "site": self.site1,
-                        "cores": 2,
-                        "ram": 8,
-                        "disk": 10,
-                        "components": {"NIC_ConnectX_6": 1},
-                    },
-                    {
-                        "type": "compute",
-                        "site": self.site2,
-                        "cores": 2,
-                        "ram": 8,
-                        "disk": 10,
-                        "components": {"NIC_ConnectX_6": 1},
-                    },
-                    {
-                        "type": "link",
-                        "site_a": self.site1,
-                        "site_b": self.site2,
-                        "bandwidth": 10,
-                    },
-                ],
-                max_results=3,
-            )
 
-            print(f"SmartNIC raw resource result: {result_raw}")
-            self.assertIsInstance(result_raw, dict)
+class TestFindSlotValidation:
+    """Validation tests — these run against live fablib but don't create slices."""
 
-        finally:
-            print(f"\nDeleting slice '{slice_name}'...")
-            live_slice.delete()
+    def test_raises_on_both_slice_and_resources(self, fablib, two_sites):
+        start, end = _search_window()
+        site1, _ = two_sites
+        slice_obj = fablib.new_slice(name="test-both")
+        slice_obj.add_node(name="node1", site=site1)
 
-    # ------------------------------------------------------------------
-    # Validation tests (no credentials needed but run against live fablib)
-    # ------------------------------------------------------------------
-
-    def test_find_slot_raises_on_both_slice_and_resources(self):
-        """Passing both slice and resources should raise ValueError."""
-        start, end = self._search_window()
-        slice_obj = self.fablib.new_slice(name="test-both")
-        slice_obj.add_node(name="node1", site=self.site1)
-
-        with self.assertRaises(ValueError):
-            self.fablib.find_resource_slot(
-                start=start,
-                end=end,
-                duration=1,
+        with pytest.raises(ValueError):
+            fablib.find_resource_slot(
+                start=start, end=end, duration=1,
                 slice=slice_obj,
-                resources=[{"type": "compute", "site": self.site1, "cores": 2}],
+                resources=[{"type": "compute", "site": site1, "cores": 2}],
             )
 
-    def test_find_slot_raises_on_neither_slice_nor_resources(self):
-        """Passing neither slice nor resources should raise ValueError."""
-        start, end = self._search_window()
+    def test_raises_on_neither_slice_nor_resources(self, fablib):
+        start, end = _search_window()
+        with pytest.raises(ValueError):
+            fablib.find_resource_slot(start=start, end=end, duration=1)
 
-        with self.assertRaises(ValueError):
-            self.fablib.find_resource_slot(start=start, end=end, duration=1)
-
-    def test_find_slot_raises_on_short_time_range(self):
-        """Time range shorter than 60 minutes should raise."""
+    def test_raises_on_short_time_range(self, fablib, two_sites):
+        site1, _ = two_sites
         start = datetime.datetime.now(tz=datetime.timezone.utc)
         end = start + datetime.timedelta(minutes=30)
 
-        with self.assertRaises(Exception) as ctx:
-            self.fablib.find_resource_slot(
-                start=start,
-                end=end,
-                duration=1,
-                resources=[{"type": "compute", "site": self.site1, "cores": 2}],
+        with pytest.raises(Exception, match="at least 60 minutes"):
+            fablib.find_resource_slot(
+                start=start, end=end, duration=1,
+                resources=[{"type": "compute", "site": site1, "cores": 2}],
             )
-        self.assertIn("at least 60 minutes", str(ctx.exception))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/integration/test_find_resource_slot.py
+++ b/tests/integration/test_find_resource_slot.py
@@ -45,8 +45,12 @@ class TestFindSlotRawResources:
         start, end = _search_window()
         site1, _ = two_sites
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1,
-            resources=[{"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10}],
+            start=start,
+            end=end,
+            duration=1,
+            resources=[
+                {"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10}
+            ],
             max_results=3,
         )
         assert isinstance(result, dict)
@@ -55,11 +59,19 @@ class TestFindSlotRawResources:
         start, end = _search_window()
         site1, _ = two_sites
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1,
-            resources=[{
-                "type": "compute", "site": site1, "cores": 4, "ram": 16, "disk": 50,
-                "components": {"GPU-Tesla T4": 1},
-            }],
+            start=start,
+            end=end,
+            duration=1,
+            resources=[
+                {
+                    "type": "compute",
+                    "site": site1,
+                    "cores": 4,
+                    "ram": 16,
+                    "disk": 50,
+                    "components": {"GPU-Tesla T4": 1},
+                }
+            ],
         )
         assert isinstance(result, dict)
 
@@ -67,11 +79,19 @@ class TestFindSlotRawResources:
         start, end = _search_window()
         site1, _ = two_sites
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1,
-            resources=[{
-                "type": "compute", "site": site1, "cores": 4, "ram": 16, "disk": 50,
-                "components": {"GPU_TeslaT4": 1},
-            }],
+            start=start,
+            end=end,
+            duration=1,
+            resources=[
+                {
+                    "type": "compute",
+                    "site": site1,
+                    "cores": 4,
+                    "ram": 16,
+                    "disk": 50,
+                    "components": {"GPU_TeslaT4": 1},
+                }
+            ],
         )
         assert isinstance(result, dict)
 
@@ -79,11 +99,19 @@ class TestFindSlotRawResources:
         start, end = _search_window()
         site1, _ = two_sites
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1,
-            resources=[{
-                "type": "compute", "site": site1, "cores": 4, "ram": 16, "disk": 10,
-                "components": {"NIC_ConnectX_6": 1},
-            }],
+            start=start,
+            end=end,
+            duration=1,
+            resources=[
+                {
+                    "type": "compute",
+                    "site": site1,
+                    "cores": 4,
+                    "ram": 16,
+                    "disk": 10,
+                    "components": {"NIC_ConnectX_6": 1},
+                }
+            ],
         )
         assert isinstance(result, dict)
 
@@ -91,7 +119,9 @@ class TestFindSlotRawResources:
         start, end = _search_window()
         site1, site2 = two_sites
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1,
+            start=start,
+            end=end,
+            duration=1,
             resources=[
                 {"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10},
                 {"type": "compute", "site": site2, "cores": 2, "ram": 8, "disk": 10},
@@ -103,7 +133,9 @@ class TestFindSlotRawResources:
         start, end = _search_window()
         site1, site2 = two_sites
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1,
+            start=start,
+            end=end,
+            duration=1,
             resources=[
                 {"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10},
                 {"type": "compute", "site": site2, "cores": 2, "ram": 8, "disk": 10},
@@ -116,8 +148,12 @@ class TestFindSlotRawResources:
         start, end = _search_window()
         site1, _ = two_sites
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1,
-            resources=[{"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10}],
+            start=start,
+            end=end,
+            duration=1,
+            resources=[
+                {"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10}
+            ],
             max_results=5,
         )
         assert isinstance(result, dict)
@@ -126,8 +162,12 @@ class TestFindSlotRawResources:
         start, end = _search_window(days=14)
         site1, _ = two_sites
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=24,
-            resources=[{"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10}],
+            start=start,
+            end=end,
+            duration=24,
+            resources=[
+                {"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10}
+            ],
         )
         assert isinstance(result, dict)
 
@@ -148,7 +188,10 @@ class TestFindSlotWithSlice:
         slice_obj.add_node(name="node1", site=site1, cores=2, ram=8, disk=10)
 
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1, slice=slice_obj,
+            start=start,
+            end=end,
+            duration=1,
+            slice=slice_obj,
         )
         assert isinstance(result, dict)
 
@@ -163,7 +206,10 @@ class TestFindSlotWithSlice:
         node.add_component(model="GPU_TeslaT4", name="gpu1")
 
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1, slice=slice_obj,
+            start=start,
+            end=end,
+            duration=1,
+            slice=slice_obj,
         )
         assert isinstance(result, dict)
 
@@ -181,7 +227,10 @@ class TestFindSlotWithSlice:
         slice_obj.add_l2network(name="net1", interfaces=[iface1, iface2])
 
         result = fablib.find_resource_slot(
-            start=start, end=end, duration=1, slice=slice_obj,
+            start=start,
+            end=end,
+            duration=1,
+            slice=slice_obj,
         )
         assert isinstance(result, dict)
 
@@ -192,9 +241,7 @@ class TestFindSlotWithSlice:
 
 
 @pytest.mark.timeout(900)
-def test_find_slot_after_submitting_smartnic_slice(
-    fablib, two_sites, slice_factory
-):
+def test_find_slot_after_submitting_smartnic_slice(fablib, two_sites, slice_factory):
     """Submit a real SmartNIC slice, then search for equivalent availability."""
     site1, site2 = two_sites
     s = slice_factory("find-slot-smartnic")
@@ -223,18 +270,35 @@ def test_find_slot_after_submitting_smartnic_slice(
     query_slice.add_l2network(name="net1", interfaces=[qi1, qi2])
 
     result = fablib.find_resource_slot(
-        start=start, end=end, duration=1, slice=query_slice,
+        start=start,
+        end=end,
+        duration=1,
+        slice=query_slice,
     )
     assert isinstance(result, dict)
 
     # Also test with raw resource dicts
     result_raw = fablib.find_resource_slot(
-        start=start, end=end, duration=1,
+        start=start,
+        end=end,
+        duration=1,
         resources=[
-            {"type": "compute", "site": site1, "cores": 2, "ram": 8, "disk": 10,
-             "components": {"NIC_ConnectX_6": 1}},
-            {"type": "compute", "site": site2, "cores": 2, "ram": 8, "disk": 10,
-             "components": {"NIC_ConnectX_6": 1}},
+            {
+                "type": "compute",
+                "site": site1,
+                "cores": 2,
+                "ram": 8,
+                "disk": 10,
+                "components": {"NIC_ConnectX_6": 1},
+            },
+            {
+                "type": "compute",
+                "site": site2,
+                "cores": 2,
+                "ram": 8,
+                "disk": 10,
+                "components": {"NIC_ConnectX_6": 1},
+            },
             {"type": "link", "site_a": site1, "site_b": site2, "bandwidth": 10},
         ],
         max_results=3,
@@ -258,7 +322,9 @@ class TestFindSlotValidation:
 
         with pytest.raises(ValueError):
             fablib.find_resource_slot(
-                start=start, end=end, duration=1,
+                start=start,
+                end=end,
+                duration=1,
                 slice=slice_obj,
                 resources=[{"type": "compute", "site": site1, "cores": 2}],
             )
@@ -275,6 +341,8 @@ class TestFindSlotValidation:
 
         with pytest.raises(Exception, match="at least 60 minutes"):
             fablib.find_resource_slot(
-                start=start, end=end, duration=1,
+                start=start,
+                end=end,
+                duration=1,
                 resources=[{"type": "compute", "site": site1, "cores": 2}],
             )

--- a/tests/integration/test_hello_fabric.py
+++ b/tests/integration/test_hello_fabric.py
@@ -20,8 +20,6 @@ def test_fablib_hello(fablib, available_site, slice_factory):
     s.submit()
 
     for node in s.get_nodes():
-        stdout, stderr = node.execute(
-            "echo Hello, FABRIC from node `hostname -s`"
-        )
+        stdout, stderr = node.execute("echo Hello, FABRIC from node `hostname -s`")
         assert stdout == f"Hello, FABRIC from node {node_name}\n"
         assert stderr == ""

--- a/tests/integration/test_hello_fabric.py
+++ b/tests/integration/test_hello_fabric.py
@@ -1,70 +1,27 @@
-import socket
-import time
-import unittest
+"""Basic integration test — create a single node and execute a command.
 
-from fabrictestbed_extensions.fablib.fablib import FablibManager
-from fabrictestbed_extensions.fablib.node import Node
-from fabrictestbed_extensions.fablib.slice import Slice
+Run with::
 
+    pytest tests/integration/test_hello_fabric.py -v
+"""
 
-class HelloFabricTests(unittest.TestCase):
-    """
-    Run some basic tests against the testbed.
-    """
+import pytest
 
-    def test_fablib_hello(self):
-        """
-        Create a slice with a single node, and echo a message from the node.
-        """
-        fablib = FablibManager()
-
-        fablib.show_config()
-
-        # fablib.list_sites()
-
-        # Give the slice a unique name so that slice creation will not
-        # fail (because there is an existing slice with the same name) and
-        # we will have some hints about the test that created the slice.
-        time_stamp = time.strftime("%Y-%m-%d %H:%M:%S")
-        host = socket.gethostname()
-        slice_name = f"integration test @ {time_stamp} on {host}"
-
-        print(f"Creating slice '{slice_name}'..")
-        slice = fablib.new_slice(name=slice_name)
-
-        self.assertIsInstance(slice, Slice)
-
-        try:
-            # Add a node.
-            node_name = "node-1"
-            site_name = fablib.get_random_site()
-
-            print(
-                f"Adding node '{node_name}' at site '{site_name}' to slice '{slice_name}'.."
-            )
-            node = slice.add_node(name=node_name, site=site_name)
-
-            self.assertIsInstance(node, Node)
-
-            # Submit the slice.
-            print(f"Submitting slice '{slice_name}'..")
-            slice.submit()
-
-            print(f"Slice '{slice_name}' status:")
-            slice.show()
-
-            print(f"Testing node '{node_name}' on slice '{slice_name}'...")
-            for node in slice.get_nodes():
-                stdout, stderr = node.execute(
-                    "echo Hello, FABRIC from node `hostname -s`"
-                )
-
-                self.assertEqual(stdout, f"Hello, FABRIC from node {node_name}\n")
-                self.assertEqual(stderr, "")
-
-        finally:
-            slice.delete()
+pytestmark = [pytest.mark.smoke, pytest.mark.p0]
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.timeout(600)
+def test_fablib_hello(fablib, available_site, slice_factory):
+    """Create a slice with a single node, and echo a message from the node."""
+    s = slice_factory("hello-fabric")
+    node_name = "node-1"
+
+    node = s.add_node(name=node_name, site=available_site)
+    s.submit()
+
+    for node in s.get_nodes():
+        stdout, stderr = node.execute(
+            "echo Hello, FABRIC from node `hostname -s`"
+        )
+        assert stdout == f"Hello, FABRIC from node {node_name}\n"
+        assert stderr == ""

--- a/tests/integration/test_list_resources.py
+++ b/tests/integration/test_list_resources.py
@@ -1,47 +1,22 @@
-#!/usr/bin/env python3
-# MIT License
-#
-# Copyright (c) 2020 FABRIC Testbed
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-#
-# Author Komal Thareja (kthare10@renci.org)
-import unittest
+"""Integration tests for resource listing.
 
-from fabrictestbed_extensions.fablib.fablib import FablibManager
+Run with::
+
+    pytest tests/integration/test_list_resources.py -v
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.smoke, pytest.mark.p0]
 
 
-class ListResourcesTests(unittest.TestCase):
-    def test_list_resources(self):
-        # Import the FABlib Library
-        fablib = FablibManager()
-
-        fablib.show_config()
-
-        print("List Sites")
-        sites = fablib.list_sites(output="json")
-        self.assertIsNotNone(sites)
-
-        print("List Facilities")
-        facilities = fablib.list_facility_ports(output="json")
-        self.assertIsNotNone(facilities)
+def test_list_sites(fablib):
+    """Verify site listing returns data."""
+    sites = fablib.list_sites(output="json")
+    assert sites is not None
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_list_facility_ports(fablib):
+    """Verify facility port listing returns data."""
+    facilities = fablib.list_facility_ports(output="json")
+    assert facilities is not None

--- a/tests/integration/test_modify.py
+++ b/tests/integration/test_modify.py
@@ -8,9 +8,9 @@ Run with::
 """
 
 import logging
+from ipaddress import IPv4Network
 
 import pytest
-from ipaddress import IPv4Network
 
 pytestmark = [pytest.mark.lifecycle, pytest.mark.p1]
 

--- a/tests/integration/test_modify.py
+++ b/tests/integration/test_modify.py
@@ -1,178 +1,104 @@
-#!/usr/bin/env python3
-#
-# MIT License
-#
-# Copyright (c) 2023 FABRIC Testbed
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+"""Integration tests for slice modify operations.
+
+Tests L2 + L3 network configuration with and without modify.
+
+Run with::
+
+    pytest tests/integration/test_modify.py -v
+"""
 
 import logging
-import socket
-import time
-import unittest
+
+import pytest
 from ipaddress import IPv4Network
 
-from fabrictestbed_extensions.fablib.fablib import FablibManager
+pytestmark = [pytest.mark.lifecycle, pytest.mark.p1]
 
 
-class ModifyTests(unittest.TestCase):
-    # Parts of this is extracted from the notebook
-    # create_l2network_wide_area_auto.ipynb, while investigating
-    # https://github.com/fabric-testbed/fabrictestbed-extensions/issues/261
+class TestModifySlice:
+    """Tests for slice modification with L2/L3 networks."""
 
-    def setUp(self):
-        self.fablib = FablibManager()
-        # Create a slice
-        time_stamp = time.strftime("%Y-%m-%d %H:%M:%S")
-        host = socket.gethostname()
-        slice_name = f"integration test @ {time_stamp} on {host}"
-        self._slice = self.fablib.new_slice(name=slice_name)
+    @pytest.mark.timeout(1200)
+    def test_modify_add_l2_l3_nodes(
+        self, fablib, available_sites_trio, slice_factory
+    ):
+        """Add nodes with L2 network, submit, add a third node with L3, resubmit."""
+        site1, site2, site3 = available_sites_trio
+        s = slice_factory("modify-l2-l3")
 
-    def tearDown(self):
-        self._slice.delete()
+        self._add_l2(s, site1, site2)
+        s.submit()
 
-    def test_modify_add_l2_l3_nodes(self):
-        # Add nodes with L2 network, submit, add a third node with L3
-        # network, add L3 network to the first two nodes, submit again.
-
-        [site1, site2, site3] = self.fablib.get_random_sites(count=3)
-        print(f"Sites: {site1}, {site2}, {site3}")
-
-        print(f"Adding nodes to slice at {site1} and {site2}")
-        self._add_l2(site1, site2)
-        print(f"Submitting '{self._slice.get_name()}'")
-        self._slice.submit()
-
-        # Add a "marker" log line for ease of searching/spotting.
         logging.info("@@@@@@@@@@@@@@@ BEGIN MODIFY @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@")
 
-        print(f"Adding a third node at {site3}")
-        self._add_l3(site1, site2, site3)
-        print(f"Re-submitting '{self._slice.get_name()}'")
-        self._slice.submit()
+        self._add_l3(s, site1, site2, site3)
+        s.submit()
 
         logging.info("############### END MODIFY #################################")
 
-        self._check_interfaces()
+        self._check_interfaces(s)
 
-    def test_no_modify_l2_l3_nodes(self):
-        # Add nodes with L2 network, add a third node, and L3 network,
-        # then submit.
+    @pytest.mark.timeout(900)
+    def test_no_modify_l2_l3_nodes(
+        self, fablib, available_sites_trio, slice_factory
+    ):
+        """Add nodes with L2 and L3 networks, then submit once."""
+        site1, site2, site3 = available_sites_trio
+        s = slice_factory("no-modify-l2-l3")
 
-        print("Adding nodes, no modify")
-        [site1, site2, site3] = self.fablib.get_random_sites(count=3)
-        print(f"Sites: {site1}, {site2}, {site3}")
+        self._add_l2(s, site1, site2)
+        self._add_l3(s, site1, site2, site3)
+        s.submit()
 
-        print(f"Adding nodes and L2 network to slice at {site1} and {site2}")
-        self._add_l2(site1, site2)
+        self._check_interfaces(s)
 
-        print(f"Adding a node at {site3} and L3 network to slice at {site1}, {site2}")
-        self._add_l3(site1, site2, site3)
+    # ── Helpers ───────────────────────────────────────────────────────
 
-        print("Submitting slice")
-        self._slice.submit()
-
-        self._check_interfaces()
-
-    def _add_l2(self, site1, site2):
-        """
-        Make a slice with an L2 network and two nodes.
-        """
-        # Add an L2 network.
-        network_name = "net-L2"
-        l2_net = self._slice.add_l2network(
-            name=network_name, subnet=IPv4Network("192.168.1.0/24")
+    @staticmethod
+    def _add_l2(s, site1, site2):
+        """Add an L2 network with two nodes."""
+        l2_net = s.add_l2network(
+            name="net-L2", subnet=IPv4Network("192.168.1.0/24")
         )
 
-        # Add some nodes with L2 networking.
-        self.__add_node_l2(site1, l2_net)
-        self.__add_node_l2(site2, l2_net)
+        for site in [site1, site2]:
+            node = s.add_node(name=f"node-{site}", site=site)
+            iface = node.add_component(
+                model="NIC_Basic", name=f"nic-L2-{site}"
+            ).get_interfaces()[0]
+            iface.set_mode("auto")
+            l2_net.add_interface(iface)
 
-    def __add_node_l2(self, site, net):
-        # Set up a node with a NIC.
-        node_name = f"node-{site}"
-        print(f"Adding node {node_name}")
-        node = self._slice.add_node(name=node_name, site=site)
+    @staticmethod
+    def _add_l3(s, site1, site2, site3):
+        """Add L3 networking to existing nodes and a new node."""
+        for site in [site1, site2]:
+            node = s.get_node(name=f"node-{site}")
+            iface = node.add_component(
+                model="NIC_Basic", name=f"nic-L3-{site}"
+            ).get_interfaces()[0]
+            iface.set_mode("auto")
 
-        ifname = f"nic-L2-{site}"
-        print(f"Adding {ifname} to {node_name}")
+            l3_net = s.add_l3network(name=f"net-L3-{site}", type="IPv4")
+            l3_net.add_interface(iface)
 
-        iface = node.add_component(model="NIC_Basic", name=ifname).get_interfaces()[0]
-        iface.set_mode("auto")
+        # New node at site3
+        node3 = s.add_node(name=f"node-L3-{site3}", site=site3)
+        iface3 = node3.add_component(
+            model="NIC_Basic", name=f"nic-L3-{site3}"
+        ).get_interfaces()[0]
+        iface3.set_mode("auto")
 
-        net.add_interface(iface)
+        l3_net3 = s.add_l3network(name=f"net-L3-{site3}", type="IPv4")
+        l3_net3.add_interface(iface3)
 
-    def _add_l3(self, site1, site2, site3):
-        """
-        Add an L3 network to the slice.
-        """
-        # Add L3 networking to existing nodes.
-        self.__add_l3_to_node(site1)
-        self.__add_l3_to_node(site2)
-
-        # Add another L3 network tied to a new node.
-        self.__add_l3_node(site3)
-
-    def __add_l3_to_node(self, site):
-        node_name = f"node-{site}"
-        node = self._slice.get_node(name=node_name)
-        self.__add_l3_iface(site, node)
-
-    def __add_l3_node(self, site):
-        node_name = f"node-L3-{site}"
-        print(f"Adding node {node_name}")
-        node = self._slice.add_node(name=node_name, site=site)
-
-        self.__add_l3_iface(site, node)
-
-    def __add_l3_iface(self, site, node):
-        if_name = f"nic-L3-{site}"
-        print(f"Adding {if_name} to {node.get_name()}")
-
-        iface = node.add_component(model="NIC_Basic", name=if_name).get_interfaces()[0]
-        iface.set_mode("auto")
-
-        l3_net_name = f"net-L3-{site}"
-        print(f"Adding L3 network {l3_net_name}, with {if_name}")
-        l3_net = self._slice.add_l3network(name=l3_net_name, type="IPv4")
-
-        l3_net.add_interface(iface)
-
-    def _check_interfaces(self):
-        print("============ interfaces ====================================")
-
-        ifaces = self._slice.get_interfaces()
-        for iface in ifaces:
-            print(f"{iface}")
-
-        print("============ networks ======================================")
-
-        networks = self._slice.get_networks()
-        for network in networks:
-            print(f"{network}")
-
-        print("============================================================")
-
-        errors = []
-
-        for iface in ifaces:
-            if iface.get_ip_addr() is None:
-                errors.append(f"iface {iface.get_name()} has no IP address")
-
-        self.assertEqual(errors, [])
+    @staticmethod
+    def _check_interfaces(s):
+        """Verify all interfaces have IP addresses."""
+        ifaces = s.get_interfaces()
+        errors = [
+            f"iface {iface.get_name()} has no IP address"
+            for iface in ifaces
+            if iface.get_ip_addr() is None
+        ]
+        assert errors == [], f"Interfaces missing IPs: {errors}"

--- a/tests/integration/test_modify.py
+++ b/tests/integration/test_modify.py
@@ -19,9 +19,7 @@ class TestModifySlice:
     """Tests for slice modification with L2/L3 networks."""
 
     @pytest.mark.timeout(1200)
-    def test_modify_add_l2_l3_nodes(
-        self, fablib, available_sites_trio, slice_factory
-    ):
+    def test_modify_add_l2_l3_nodes(self, fablib, available_sites_trio, slice_factory):
         """Add nodes with L2 network, submit, add a third node with L3, resubmit."""
         site1, site2, site3 = available_sites_trio
         s = slice_factory("modify-l2-l3")
@@ -39,9 +37,7 @@ class TestModifySlice:
         self._check_interfaces(s)
 
     @pytest.mark.timeout(900)
-    def test_no_modify_l2_l3_nodes(
-        self, fablib, available_sites_trio, slice_factory
-    ):
+    def test_no_modify_l2_l3_nodes(self, fablib, available_sites_trio, slice_factory):
         """Add nodes with L2 and L3 networks, then submit once."""
         site1, site2, site3 = available_sites_trio
         s = slice_factory("no-modify-l2-l3")
@@ -57,9 +53,7 @@ class TestModifySlice:
     @staticmethod
     def _add_l2(s, site1, site2):
         """Add an L2 network with two nodes."""
-        l2_net = s.add_l2network(
-            name="net-L2", subnet=IPv4Network("192.168.1.0/24")
-        )
+        l2_net = s.add_l2network(name="net-L2", subnet=IPv4Network("192.168.1.0/24"))
 
         for site in [site1, site2]:
             node = s.add_node(name=f"node-{site}", site=site)


### PR DESCRIPTION
## Summary
- Migrate 7 integration test files from `unittest.TestCase` with manual `FablibManager()` setup to pytest-native functions using shared fixtures (`fablib`, `slice_factory`, `available_site`, etc.) (closes #244)
- Tests now use `slice_factory` fixture which auto-deletes slices at teardown, preventing slice leaks
- Migrated files: `test_hello_fabric.py`, `test_list_resources.py`, `test_fablib_node.py`, `test_modify.py`, `test_L2_reconfig_post_reboot.py`, `test_fabnetv4_ext.py`, `test_find_resource_slot.py`

## Test plan
- [ ] `tox -e integration` - integration tests pass (requires FABRIC credentials)
- [ ] Manual verification that slice cleanup occurs on test failure
