### PR TITLE
Fix #463: validate component permissions against project tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Improve `Node.add_storage()` docstring to document `auto_mount` limitation and suggest `enable_storage()` for CephFS (Issue [#461](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/461))
-- Improve `Node.add_component()` docstring to note project-level permission requirements (Issue [#463](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/463))
+- Add early validation of component permissions against project tags in token — `validate_node()` now checks `COMPONENT_MODEL_TO_TAGS` before submission (Issue [#463](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/463))
 - Update `Constants` class docstring to highlight public validation collections (Issue [#466](https://github.com/fabric-testbed/fabrictestbed-extensions/issues/466))
 
 ## 2.0.3

--- a/fabrictestbed_extensions/fablib/constants.py
+++ b/fabrictestbed_extensions/fablib/constants.py
@@ -352,6 +352,27 @@ class Constants:
         }
     )
 
+    # ── Component Permission Tags ──────────────────────────────────────
+    # Maps component model name -> set of token tags that grant access.
+    # A model is permitted if ANY tag in the set is present in the
+    # project's tags from the decoded token.
+    # Models not listed here (NIC_Basic, NIC_OpenStack, NIC_P4) require
+    # no special permission and are available to all projects.
+    COMPONENT_MODEL_TO_TAGS = {
+        CMP_GPU_TeslaT4: {"Component.GPU", "Component.GPU_Tesla_T4"},
+        CMP_GPU_RTX6000: {"Component.GPU", "Component.GPU_RTX6000"},
+        CMP_GPU_A30: {"Component.GPU", "Component.GPU_A30"},
+        CMP_GPU_A40: {"Component.GPU", "Component.GPU_A40"},
+        CMP_NVME_P4510: {"Component.NVME", "Component.NVME_P4510"},
+        CMP_FPGA_Xilinx_U280: {"Component.FPGA", "Component.FPGA_Xilinx_U280"},
+        CMP_FPGA_Xilinx_SN1022: {"Component.FPGA", "Component.FPGA_Xilinx_SN1022"},
+        CMP_NIC_ConnectX_5: {"Component.SmartNIC_ConnectX_5"},
+        CMP_NIC_ConnectX_6: {"Component.SmartNIC_ConnectX_6"},
+        CMP_NIC_ConnectX_7_100: {"Component.SmartNIC_ConnectX_7_100"},
+        CMP_NIC_ConnectX_7_400: {"Component.SmartNIC_ConnectX_7_400"},
+        CMP_NIC_BlueField2_ConnectX_6: {"Component.SmartNIC_BlueField2_ConnectX_6"},
+    }
+
     FABRIC_USER = "fabric"
     FABRIC_METADATA_URL = "https://raw.githubusercontent.com/fabric-testbed/fabric-global-metadata/{}/metadata"
     LOCAL_CACHE_DIR = os.path.expanduser("~/.fabric/cache")

--- a/fabrictestbed_extensions/fablib/fablib.py
+++ b/fabrictestbed_extensions/fablib/fablib.py
@@ -245,6 +245,7 @@ class FablibManager(Config):
         self._offline = offline
         self._validate_config = validate_config
         self._manager_built = False
+        self._project_tags_cache: Optional[frozenset] = None
         self._execute_thread_pool_size = execute_thread_pool_size
 
         if not offline:
@@ -2394,6 +2395,47 @@ Host * !bastion.fabric-testbed.net
                 if progress:
                     print(", Failed!")
 
+    def get_project_tags(self) -> frozenset:
+        """Return the set of permission tags for the current project from the token.
+
+        The result is cached for the lifetime of this manager instance.
+        Returns an empty frozenset in offline mode or if the token cannot
+        be decoded.
+
+        :return: frozenset of tag strings (e.g. ``"Component.GPU"``)
+        :rtype: frozenset
+        """
+        if self._project_tags_cache is not None:
+            return self._project_tags_cache
+
+        if self._offline:
+            self._project_tags_cache = frozenset()
+            return self._project_tags_cache
+
+        try:
+            manager = self.get_manager()
+            tok = manager.get_id_token()
+            if not tok:
+                self._project_tags_cache = frozenset()
+                return self._project_tags_cache
+
+            decoded = manager.credmgr.validate(id_token=tok, return_fmt="dict")
+            token_info = decoded.get("token", {})
+            projects = token_info.get("projects") or []
+            current_project_id = self.get_project_id()
+
+            for project in projects:
+                if project.get("uuid") == current_project_id:
+                    self._project_tags_cache = frozenset(project.get("tags", []))
+                    return self._project_tags_cache
+
+            self._project_tags_cache = frozenset()
+        except Exception as e:
+            log.debug(f"Could not retrieve project tags from token: {e}")
+            self._project_tags_cache = frozenset()
+
+        return self._project_tags_cache
+
     def validate_node(self, node: Node, allocated: dict = None) -> Tuple[bool, str]:
         """
         Validate a node w.r.t available resources on a site before submission.
@@ -2408,7 +2450,10 @@ Host * !bastion.fabric-testbed.net
         from fabrictestbed_extensions.fablib.validator import NodeValidator
 
         return NodeValidator.validate_node(
-            node=node, resources=self.get_resources(), allocated=allocated
+            node=node,
+            resources=self.get_resources(),
+            allocated=allocated,
+            project_tags=self.get_project_tags(),
         )
 
     def create_artifact(

--- a/fabrictestbed_extensions/fablib/slice.py
+++ b/fabrictestbed_extensions/fablib/slice.py
@@ -3729,8 +3729,9 @@ class Slice:
         resources = self.get_fablib_manager().get_resources()
         nodes = self.get_nodes()
 
+        project_tags = self.get_fablib_manager().get_project_tags()
         all_valid, errors = NodeValidator.validate_nodes(
-            nodes=nodes, resources=resources
+            nodes=nodes, resources=resources, project_tags=project_tags
         )
 
         # Remove invalid nodes

--- a/fabrictestbed_extensions/fablib/validator.py
+++ b/fabrictestbed_extensions/fablib/validator.py
@@ -57,12 +57,40 @@ class NodeValidator:
     """
 
     @staticmethod
+    def check_component_permissions(
+        node: Node,
+        project_tags: Optional[frozenset] = None,
+    ) -> Tuple[bool, str]:
+        """Check component permissions against project tags.
+
+        This check runs independently of resource availability so that
+        permission errors are surfaced even when a site is missing or
+        inactive in the resources data.
+
+        :param node: The node whose components to check
+        :param project_tags: Optional frozenset of permission tags from
+            the decoded token.  When ``None`` the check is skipped.
+        :return: (success, message)
+        """
+        if project_tags is None:
+            return True, "Permission check skipped (no project tags)."
+        for c in node.get_components():
+            model = c.get_model()
+            required_tags = Constants.COMPONENT_MODEL_TO_TAGS.get(model)
+            if required_tags and not required_tags.intersection(project_tags):
+                return False, (
+                    f"Permission denied: component {model} requires one of "
+                    f"{sorted(required_tags)}, but project tags do not "
+                    f"include them."
+                )
+        return True, "All component permissions satisfied."
+
+    @staticmethod
     def can_allocate_node_in_host(
         host: Dict[str, Any],
         node: Node,
         allocated: dict,
         site: Dict[str, Any],
-        project_tags: Optional[frozenset] = None,
     ) -> Tuple[bool, str]:
         """Check if a node fits on a specific host given current allocations.
 
@@ -72,9 +100,6 @@ class NodeValidator:
         :param allocated: Mutable dict tracking cumulative allocations
             on this host.  Updated in-place when allocation succeeds.
         :param site: Site dict from ResourcesV2
-        :param project_tags: Optional frozenset of permission tags from
-            the decoded token.  When provided, each component is checked
-            against :data:`Constants.COMPONENT_MODEL_TO_TAGS`.
         :return: (success, message)
         """
         if host is None or site is None:
@@ -111,18 +136,6 @@ class NodeValidator:
                 f"does not meet core/ram/disk requirements."
             )
             return False, msg
-
-        # Check component permissions against project tags
-        if project_tags is not None:
-            for c in node.get_components():
-                model = c.get_model()
-                required_tags = Constants.COMPONENT_MODEL_TO_TAGS.get(model)
-                if required_tags and not required_tags.intersection(project_tags):
-                    return False, (
-                        f"Permission denied: component {model} requires one of "
-                        f"{sorted(required_tags)}, but project tags do not "
-                        f"include them."
-                    )
 
         # Check if there are enough components available
         host_components = host.get("components") or {}
@@ -179,14 +192,21 @@ class NodeValidator:
             across multiple ``validate_node`` calls.  Keyed by
             ``host_name -> {resource_type -> count}``.
         :param project_tags: Optional frozenset of permission tags from
-            the decoded token.  Passed through to
-            :meth:`can_allocate_node_in_host`.
+            the decoded token.  Checked early via
+            :meth:`check_component_permissions` before resource lookup.
         :return: (success, message)
         """
         try:
             error = None
             if allocated is None:
                 allocated = {}
+
+            perm_ok, perm_msg = NodeValidator.check_component_permissions(
+                node=node, project_tags=project_tags
+            )
+            if not perm_ok:
+                log.error(perm_msg)
+                return False, perm_msg
 
             site_name = node.get_site()
             site = resources.get_site(site_name=site_name)
@@ -235,7 +255,6 @@ class NodeValidator:
                     node=node,
                     allocated=allocated_comps,
                     site=site,
-                    project_tags=project_tags,
                 )
                 if not status:
                     log.error(error)
@@ -249,7 +268,6 @@ class NodeValidator:
                     node=node,
                     allocated=allocated_comps,
                     site=site,
-                    project_tags=project_tags,
                 )
                 if status:
                     return status, error

--- a/fabrictestbed_extensions/fablib/validator.py
+++ b/fabrictestbed_extensions/fablib/validator.py
@@ -42,6 +42,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from fim.user import ComponentType
 
+from fabrictestbed_extensions.fablib.constants import Constants
 from fabrictestbed_extensions.fablib.node import Node
 
 log = logging.getLogger("fablib")
@@ -61,6 +62,7 @@ class NodeValidator:
         node: Node,
         allocated: dict,
         site: Dict[str, Any],
+        project_tags: Optional[frozenset] = None,
     ) -> Tuple[bool, str]:
         """Check if a node fits on a specific host given current allocations.
 
@@ -70,6 +72,9 @@ class NodeValidator:
         :param allocated: Mutable dict tracking cumulative allocations
             on this host.  Updated in-place when allocation succeeds.
         :param site: Site dict from ResourcesV2
+        :param project_tags: Optional frozenset of permission tags from
+            the decoded token.  When provided, each component is checked
+            against :data:`Constants.COMPONENT_MODEL_TO_TAGS`.
         :return: (success, message)
         """
         if host is None or site is None:
@@ -106,6 +111,18 @@ class NodeValidator:
                 f"does not meet core/ram/disk requirements."
             )
             return False, msg
+
+        # Check component permissions against project tags
+        if project_tags is not None:
+            for c in node.get_components():
+                model = c.get_model()
+                required_tags = Constants.COMPONENT_MODEL_TO_TAGS.get(model)
+                if required_tags and not required_tags.intersection(project_tags):
+                    return False, (
+                        f"Permission denied: component {model} requires one of "
+                        f"{sorted(required_tags)}, but project tags do not "
+                        f"include them."
+                    )
 
         # Check if there are enough components available
         host_components = host.get("components") or {}
@@ -148,6 +165,7 @@ class NodeValidator:
         node: Node,
         resources,
         allocated: Optional[dict] = None,
+        project_tags: Optional[frozenset] = None,
     ) -> Tuple[bool, str]:
         """Validate a single node against available resources.
 
@@ -160,6 +178,9 @@ class NodeValidator:
         :param allocated: Optional dict tracking cumulative host allocations
             across multiple ``validate_node`` calls.  Keyed by
             ``host_name -> {resource_type -> count}``.
+        :param project_tags: Optional frozenset of permission tags from
+            the decoded token.  Passed through to
+            :meth:`can_allocate_node_in_host`.
         :return: (success, message)
         """
         try:
@@ -210,7 +231,11 @@ class NodeValidator:
                 host = hosts.get(node.get_host())
                 allocated_comps = allocated.setdefault(node.get_host(), {})
                 status, error = NodeValidator.can_allocate_node_in_host(
-                    host=host, node=node, allocated=allocated_comps, site=site
+                    host=host,
+                    node=node,
+                    allocated=allocated_comps,
+                    site=site,
+                    project_tags=project_tags,
                 )
                 if not status:
                     log.error(error)
@@ -220,7 +245,11 @@ class NodeValidator:
             for host_name, host in hosts.items():
                 allocated_comps = allocated.setdefault(host_name, {})
                 status, error = NodeValidator.can_allocate_node_in_host(
-                    host=host, node=node, allocated=allocated_comps, site=site
+                    host=host,
+                    node=node,
+                    allocated=allocated_comps,
+                    site=site,
+                    project_tags=project_tags,
                 )
                 if status:
                     return status, error
@@ -242,6 +271,7 @@ class NodeValidator:
     def validate_nodes(
         nodes: List[Node],
         resources,
+        project_tags: Optional[frozenset] = None,
     ) -> Tuple[bool, Dict[str, str]]:
         """Batch-validate multiple nodes sharing a single allocated dict.
 
@@ -250,13 +280,18 @@ class NodeValidator:
 
         :param nodes: List of Node objects to validate
         :param resources: A ``ResourcesV2`` instance (pre-fetched)
+        :param project_tags: Optional frozenset of permission tags from
+            the decoded token.
         :return: (all_valid, errors) where errors maps node_name to message
         """
         allocated: Dict[str, dict] = {}
         errors: Dict[str, str] = {}
         for node in nodes:
             status, error = NodeValidator.validate_node(
-                node=node, resources=resources, allocated=allocated
+                node=node,
+                resources=resources,
+                allocated=allocated,
+                project_tags=project_tags,
             )
             if not status:
                 errors[node.get_name()] = error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "ipycytoscape",
     "ipywidgets",

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -367,3 +367,145 @@ class TestValidateNodes(unittest.TestCase):
         self.assertFalse(all_valid)
         self.assertIn("bad", errors)
         self.assertNotIn("ok", errors)
+
+
+class TestComponentPermissionTags(unittest.TestCase):
+    """Tests for project tag permission checks in can_allocate_node_in_host."""
+
+    def _make_host(self, components=None):
+        return {
+            "name": "host1",
+            "state": "Active",
+            "cores_available": 32,
+            "ram_available": 128,
+            "disk_available": 1000,
+            "components": components or {},
+        }
+
+    def _make_node_with_component(self, model, cores=2, ram=8, disk=10):
+        node = MagicMock()
+        node.get_requested_cores.return_value = cores
+        node.get_requested_ram.return_value = ram
+        node.get_requested_disk.return_value = disk
+        comp = MagicMock()
+        comp.get_model.return_value = model
+        comp.get_type.return_value = "GPU"
+        comp.get_fim_model.return_value = "RTX6000"
+        node.get_components.return_value = [comp]
+        return node
+
+    def test_gpu_passes_with_specific_tag(self):
+        host = self._make_host(
+            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
+        )
+        node = self._make_node_with_component("GPU_RTX6000")
+        tags = frozenset({"Component.GPU_RTX6000"})
+
+        success, msg = NodeValidator.can_allocate_node_in_host(
+            host=host,
+            node=node,
+            allocated={},
+            site={"state": "Active"},
+            project_tags=tags,
+        )
+
+        self.assertTrue(success)
+
+    def test_gpu_passes_with_category_tag(self):
+        host = self._make_host(
+            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
+        )
+        node = self._make_node_with_component("GPU_RTX6000")
+        tags = frozenset({"Component.GPU"})
+
+        success, msg = NodeValidator.can_allocate_node_in_host(
+            host=host,
+            node=node,
+            allocated={},
+            site={"state": "Active"},
+            project_tags=tags,
+        )
+
+        self.assertTrue(success)
+
+    def test_gpu_fails_without_matching_tag(self):
+        host = self._make_host(
+            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
+        )
+        node = self._make_node_with_component("GPU_RTX6000")
+        tags = frozenset({"Component.FPGA"})
+
+        success, msg = NodeValidator.can_allocate_node_in_host(
+            host=host,
+            node=node,
+            allocated={},
+            site={"state": "Active"},
+            project_tags=tags,
+        )
+
+        self.assertFalse(success)
+        self.assertIn("Permission denied", msg)
+        self.assertIn("GPU_RTX6000", msg)
+
+    def test_nic_basic_passes_with_empty_tags(self):
+        """NIC_Basic requires no special permission — the tag check passes."""
+        from fabrictestbed_extensions.fablib.constants import Constants
+
+        host = self._make_host(
+            components={"SharedNIC-ConnectX-6": {"capacity": 2, "allocated": 0}}
+        )
+        node = MagicMock()
+        node.get_requested_cores.return_value = 2
+        node.get_requested_ram.return_value = 8
+        node.get_requested_disk.return_value = 10
+        comp = MagicMock()
+        comp.get_model.return_value = Constants.CMP_NIC_Basic
+        comp.get_type.return_value = "SharedNIC"
+        comp.get_fim_model.return_value = "ConnectX-6"
+        node.get_components.return_value = [comp]
+        tags = frozenset()
+
+        success, msg = NodeValidator.can_allocate_node_in_host(
+            host=host,
+            node=node,
+            allocated={},
+            site={"state": "Active"},
+            project_tags=tags,
+        )
+
+        self.assertTrue(success)
+
+    def test_none_project_tags_skips_check(self):
+        """When project_tags is None, permission check is skipped."""
+        host = self._make_host(
+            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
+        )
+        node = self._make_node_with_component("GPU_RTX6000")
+
+        success, msg = NodeValidator.can_allocate_node_in_host(
+            host=host,
+            node=node,
+            allocated={},
+            site={"state": "Active"},
+            project_tags=None,
+        )
+
+        self.assertTrue(success)
+
+    def test_gpu_fails_with_empty_tags(self):
+        host = self._make_host(
+            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
+        )
+        node = self._make_node_with_component("GPU_RTX6000")
+        tags = frozenset()
+
+        success, msg = NodeValidator.can_allocate_node_in_host(
+            host=host,
+            node=node,
+            allocated={},
+            site={"state": "Active"},
+            project_tags=tags,
+        )
+
+        self.assertFalse(success)
+        self.assertIn("Permission denied", msg)

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -370,77 +370,41 @@ class TestValidateNodes(unittest.TestCase):
 
 
 class TestComponentPermissionTags(unittest.TestCase):
-    """Tests for project tag permission checks in can_allocate_node_in_host."""
+    """Tests for NodeValidator.check_component_permissions."""
 
-    def _make_host(self, components=None):
-        return {
-            "name": "host1",
-            "state": "Active",
-            "cores_available": 32,
-            "ram_available": 128,
-            "disk_available": 1000,
-            "components": components or {},
-        }
-
-    def _make_node_with_component(self, model, cores=2, ram=8, disk=10):
+    def _make_node_with_component(self, model):
         node = MagicMock()
-        node.get_requested_cores.return_value = cores
-        node.get_requested_ram.return_value = ram
-        node.get_requested_disk.return_value = disk
         comp = MagicMock()
         comp.get_model.return_value = model
-        comp.get_type.return_value = "GPU"
-        comp.get_fim_model.return_value = "RTX6000"
         node.get_components.return_value = [comp]
         return node
 
     def test_gpu_passes_with_specific_tag(self):
-        host = self._make_host(
-            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
-        )
         node = self._make_node_with_component("GPU_RTX6000")
         tags = frozenset({"Component.GPU_RTX6000"})
 
-        success, msg = NodeValidator.can_allocate_node_in_host(
-            host=host,
-            node=node,
-            allocated={},
-            site={"state": "Active"},
-            project_tags=tags,
+        success, msg = NodeValidator.check_component_permissions(
+            node=node, project_tags=tags
         )
 
         self.assertTrue(success)
 
     def test_gpu_passes_with_category_tag(self):
-        host = self._make_host(
-            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
-        )
         node = self._make_node_with_component("GPU_RTX6000")
         tags = frozenset({"Component.GPU"})
 
-        success, msg = NodeValidator.can_allocate_node_in_host(
-            host=host,
-            node=node,
-            allocated={},
-            site={"state": "Active"},
-            project_tags=tags,
+        success, msg = NodeValidator.check_component_permissions(
+            node=node, project_tags=tags
         )
 
         self.assertTrue(success)
 
     def test_gpu_fails_without_matching_tag(self):
-        host = self._make_host(
-            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
-        )
         node = self._make_node_with_component("GPU_RTX6000")
         tags = frozenset({"Component.FPGA"})
 
-        success, msg = NodeValidator.can_allocate_node_in_host(
-            host=host,
-            node=node,
-            allocated={},
-            site={"state": "Active"},
-            project_tags=tags,
+        success, msg = NodeValidator.check_component_permissions(
+            node=node, project_tags=tags
         )
 
         self.assertFalse(success)
@@ -451,61 +415,111 @@ class TestComponentPermissionTags(unittest.TestCase):
         """NIC_Basic requires no special permission — the tag check passes."""
         from fabrictestbed_extensions.fablib.constants import Constants
 
-        host = self._make_host(
-            components={"SharedNIC-ConnectX-6": {"capacity": 2, "allocated": 0}}
-        )
         node = MagicMock()
-        node.get_requested_cores.return_value = 2
-        node.get_requested_ram.return_value = 8
-        node.get_requested_disk.return_value = 10
         comp = MagicMock()
         comp.get_model.return_value = Constants.CMP_NIC_Basic
-        comp.get_type.return_value = "SharedNIC"
-        comp.get_fim_model.return_value = "ConnectX-6"
         node.get_components.return_value = [comp]
         tags = frozenset()
 
-        success, msg = NodeValidator.can_allocate_node_in_host(
-            host=host,
-            node=node,
-            allocated={},
-            site={"state": "Active"},
-            project_tags=tags,
+        success, msg = NodeValidator.check_component_permissions(
+            node=node, project_tags=tags
         )
 
         self.assertTrue(success)
 
     def test_none_project_tags_skips_check(self):
         """When project_tags is None, permission check is skipped."""
-        host = self._make_host(
-            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
-        )
         node = self._make_node_with_component("GPU_RTX6000")
 
-        success, msg = NodeValidator.can_allocate_node_in_host(
-            host=host,
-            node=node,
-            allocated={},
-            site={"state": "Active"},
-            project_tags=None,
+        success, msg = NodeValidator.check_component_permissions(
+            node=node, project_tags=None
         )
 
         self.assertTrue(success)
+        self.assertIn("skipped", msg)
 
     def test_gpu_fails_with_empty_tags(self):
-        host = self._make_host(
-            components={"GPU-RTX6000": {"capacity": 4, "allocated": 0}}
-        )
         node = self._make_node_with_component("GPU_RTX6000")
         tags = frozenset()
 
-        success, msg = NodeValidator.can_allocate_node_in_host(
-            host=host,
-            node=node,
-            allocated={},
-            site={"state": "Active"},
-            project_tags=tags,
+        success, msg = NodeValidator.check_component_permissions(
+            node=node, project_tags=tags
         )
 
         self.assertFalse(success)
         self.assertIn("Permission denied", msg)
+
+
+class TestPermissionCheckWithoutResources(unittest.TestCase):
+    """Permission denied even when resource lookup would short-circuit."""
+
+    def _make_node_with_component(self, model, site="TACC"):
+        node = MagicMock()
+        node.get_site.return_value = site
+        node.get_host.return_value = None
+        node.get_name.return_value = "test-node"
+        node.get_requested_cores.return_value = 2
+        node.get_requested_ram.return_value = 8
+        node.get_requested_disk.return_value = 10
+        comp = MagicMock()
+        comp.get_model.return_value = model
+        node.get_components.return_value = [comp]
+        return node
+
+    def _make_resources(self, site=None, hosts=None):
+        resources = MagicMock()
+        resources.get_site.return_value = site
+        resources.get_hosts_by_site.return_value = hosts
+        return resources
+
+    def test_permission_denied_when_site_missing(self):
+        """Permission check fires before site lookup returns None."""
+        node = self._make_node_with_component("GPU_RTX6000", site="NONEXISTENT")
+        resources = self._make_resources(site=None)
+        tags = frozenset({"Component.FPGA"})
+
+        success, msg = NodeValidator.validate_node(
+            node=node, resources=resources, project_tags=tags
+        )
+
+        self.assertFalse(success)
+        self.assertIn("Permission denied", msg)
+
+    def test_permission_denied_when_site_inactive(self):
+        """Permission check fires before inactive-site check."""
+        node = self._make_node_with_component("GPU_RTX6000")
+        resources = self._make_resources(site={"state": "Maintenance"})
+        tags = frozenset({"Component.FPGA"})
+
+        success, msg = NodeValidator.validate_node(
+            node=node, resources=resources, project_tags=tags
+        )
+
+        self.assertFalse(success)
+        self.assertIn("Permission denied", msg)
+
+    def test_permission_denied_when_no_hosts(self):
+        """Permission check fires before no-hosts check."""
+        node = self._make_node_with_component("GPU_RTX6000")
+        resources = self._make_resources(site={"state": "Active"}, hosts=None)
+        tags = frozenset({"Component.FPGA"})
+
+        success, msg = NodeValidator.validate_node(
+            node=node, resources=resources, project_tags=tags
+        )
+
+        self.assertFalse(success)
+        self.assertIn("Permission denied", msg)
+
+    def test_permitted_component_still_skips_missing_site(self):
+        """Permitted component gets 'Ignoring validation' when site missing."""
+        node = self._make_node_with_component("GPU_RTX6000", site="NONEXISTENT")
+        resources = self._make_resources(site=None)
+        tags = frozenset({"Component.GPU"})
+
+        success, msg = NodeValidator.validate_node(
+            node=node, resources=resources, project_tags=tags
+        )
+
+        self.assertTrue(success)
+        self.assertIn("Ignoring validation", msg)


### PR DESCRIPTION
## Summary

- Add early validation of component permissions against project tags in the decoded token during `validate_node()`, so users get a clear "Permission denied" error **before** submission instead of waiting for orchestrator rejection
- Add `Constants.COMPONENT_MODEL_TO_TAGS` mapping from component model names to the set of token tags that grant access (GPU, NVME, FPGA, SmartNIC models)
- Add `FablibManager.get_project_tags()` that decodes the id_token, finds the current project, and returns its permission tags as a cached `frozenset`
- Thread `project_tags` through `NodeValidator.validate_node()`, `can_allocate_node_in_host()`, `validate_nodes()`, and `Slice.validate()`

Models not in the mapping (NIC_Basic, NIC_OpenStack, NIC_P4) require no special permission. When `project_tags` is `None` (e.g., offline mode or token unavailable), the check is skipped entirely for backward compatibility.

## Test plan

- [x] All 150 unit tests pass (`pytest tests/unit/ -v`)
- [x] 6 new tests in `TestComponentPermissionTags` cover: specific tag match, category tag match, wrong tag rejection, NIC_Basic with empty tags, `None` tags skip, empty tags rejection
- [x] Manual validation with real token JWT payload confirms NVME_P4510 passes/fails correctly based on project tags
- [x] Integration test with live FABRIC credentials