### PR TITLE
Bump fabric_fss_utils to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.6
+
+### Changed
+- Update `fabric_fss_utils` dependency to 1.7.0
+
 ## 2.0.4
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "fabrictestbed_extensions"
-version = "2.0.5"
+version = "2.0.6"
 description = "FABRIC Python Client Library and CLI Extensions"
 authors = [
   { name = "Paul Ruth", email = "pruth@renci.org" },
@@ -24,7 +24,7 @@ dependencies = [
     "jinja2>=3.0.0",
     "pandas",
     "ipython>=8.12.0",
-    "fabric_fss_utils>=1.6.1",
+    "fabric_fss_utils==1.7.0",
     "atomicwrites",
     "fabric_paramiko_expect",
     "fabric_ceph_client==1.0.2",


### PR DESCRIPTION
## Summary
- Update `fabric_fss_utils` dependency from `>=1.6.1` to `==1.7.0`
- Bump project version to `2.0.6`
- Add CHANGELOG entry for 2.0.6

## Test plan
- [x] Verify `pip install -e .` resolves `fabric_fss_utils==1.7.0` correctly
- [x] Run `tox` to confirm unit tests pass