### PR TITLE
Fix multi-VLAN facility port interface index bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.7
+
+### Fixed
+- Fix `FacilityPort.new_facility_port()` multi-VLAN interface index bug — `index` was never incremented, causing all interfaces to be named `iface-1` when multiple VLANs were passed
+
 ## 2.0.6
 
 ### Changed

--- a/fabrictestbed_extensions/fablib/facility_port.py
+++ b/fabrictestbed_extensions/fablib/facility_port.py
@@ -208,6 +208,7 @@ class FacilityPort(TemplateMixin):
                     capacities,
                 )
                 interfaces.append(iface_tuple)
+                index += 1
 
         fim_facility_port = slice.get_fim_topology().add_facility(
             name=name,

--- a/tests/unit/test_facility_port.py
+++ b/tests/unit/test_facility_port.py
@@ -1,0 +1,100 @@
+"""Unit tests for FacilityPort, focusing on multi-VLAN interface creation."""
+
+import unittest
+from unittest.mock import MagicMock
+
+from fim.user.topology import ExperimentTopology
+
+from fabrictestbed_extensions.fablib.facility_port import FacilityPort
+
+
+class TestFacilityPortMultiVlan(unittest.TestCase):
+    """Test that add_facility_port with multiple VLANs creates distinct interfaces."""
+
+    def _make_mock_slice(self):
+        """Create a mock Slice backed by a real FIM ExperimentTopology."""
+        topology = ExperimentTopology()
+        mock_slice = MagicMock()
+        mock_slice.get_fim_topology.return_value = topology
+        return mock_slice, topology
+
+    def test_single_vlan_creates_one_interface(self):
+        mock_slice, topology = self._make_mock_slice()
+
+        fp = FacilityPort.new_facility_port(
+            slice=mock_slice,
+            name="TestFP-LOSA",
+            site="LOSA",
+            vlan="3520",
+        )
+
+        interfaces = list(fp.get_fim().interfaces.values())
+        self.assertEqual(len(interfaces), 1)
+        self.assertEqual(interfaces[0].labels.vlan, "3520")
+
+    def test_single_vlan_as_list_creates_one_interface(self):
+        mock_slice, topology = self._make_mock_slice()
+
+        fp = FacilityPort.new_facility_port(
+            slice=mock_slice,
+            name="TestFP-LOSA",
+            site="LOSA",
+            vlan=["3520"],
+        )
+
+        interfaces = list(fp.get_fim().interfaces.values())
+        self.assertEqual(len(interfaces), 1)
+        self.assertEqual(interfaces[0].labels.vlan, "3520")
+
+    def test_multiple_vlans_create_distinct_interfaces(self):
+        mock_slice, topology = self._make_mock_slice()
+
+        fp = FacilityPort.new_facility_port(
+            slice=mock_slice,
+            name="TestFP-LOSA",
+            site="LOSA",
+            vlan=["3520", "3521", "3522"],
+        )
+
+        interfaces = list(fp.get_fim().interfaces.values())
+        self.assertEqual(len(interfaces), 3)
+
+        # Each interface should have a unique name
+        names = [iface.name for iface in interfaces]
+        self.assertEqual(len(set(names)), 3, f"Interface names are not unique: {names}")
+
+        # Each interface should have the correct VLAN
+        vlans = sorted(iface.labels.vlan for iface in interfaces)
+        self.assertEqual(vlans, ["3520", "3521", "3522"])
+
+    def test_multiple_vlans_interface_naming(self):
+        mock_slice, topology = self._make_mock_slice()
+
+        fp = FacilityPort.new_facility_port(
+            slice=mock_slice,
+            name="TestFP-LOSA",
+            site="LOSA",
+            vlan=["100", "200"],
+        )
+
+        interfaces = list(fp.get_fim().interfaces.values())
+        names = sorted(iface.name for iface in interfaces)
+        self.assertEqual(names, ["iface-1", "iface-2"])
+
+    def test_no_vlan_creates_default_interface(self):
+        mock_slice, topology = self._make_mock_slice()
+
+        fp = FacilityPort.new_facility_port(
+            slice=mock_slice,
+            name="TestFP-LOSA",
+            site="LOSA",
+        )
+
+        interfaces = list(fp.get_fim().interfaces.values())
+        self.assertEqual(len(interfaces), 1)
+        # Default interface uses name-int naming from FIM
+        self.assertEqual(interfaces[0].name, "TestFP-LOSA-int")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix `FacilityPort.new_facility_port()` where the `index` variable was never incremented when iterating over multiple VLANs, causing all interfaces to be named `iface-1`
- Add unit tests for single and multi-VLAN facility port creation (5 tests)
- Add CHANGELOG entry under 2.0.7

## Test plan
- [x] `pytest tests/unit/test_facility_port.py` — all 5 new tests pass
- [x] Full unit test suite (159 tests) passes