### PR TITLE
Fix hardcoded crinkle path to point to module install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.7
+
+### Fixed
+- Fix `Crinkle.post_boot_config()` failing to complete a file upload due to an incorrect hardcoded file path.
+
 ## 2.0.6
 
 ### Changed

--- a/fabrictestbed_extensions/fablib/crease/crinkle.py
+++ b/fabrictestbed_extensions/fablib/crease/crinkle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 import ipaddress
 import logging
+import os
 import re
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
@@ -31,7 +32,7 @@ CAPERSTART = "./caper/caper.byte -q -p -e"
 PCAPDIR = "/home/ubuntu/pcaps/"
 LOCALP4DIR = "."
 REMOTEWORKDIR = ".crease"
-CREASEDIR = "fabrictestbed-extensions/fabrictestbed_extensions/fablib/crease"
+CREASEDIR = os.path.dirname(os.path.abspath(__file__))
 MONITORURL = "https://transparnet.cs.iit.edu/~awolosewicz/dpdk-crease_monitor-dev"
 DPDKNAME = "dpdk-crease_monitor-dev"
 MONPROT = 0x6587


### PR DESCRIPTION
This is an artifact from the old method always involving installing a fork locally, so the file was always at this path. Now that this is in upstream, this hardcoded path needs to point to the install location so that the file upload in `post_boot_config` can succeed. Tested and confirmed this solves the issue.